### PR TITLE
convert area listed by antares to lowercase for link candidate search

### DIFF
--- a/src/src_cpp/exe/exe_lpnamer/main.cpp
+++ b/src/src_cpp/exe/exe_lpnamer/main.cpp
@@ -56,6 +56,14 @@ std::string get_name(std::string const & path) {
 }
 
 
+std::string toLowercase(std::string const& inputString_p)
+{
+	std::string result;
+	std::transform(inputString_p.cbegin(), inputString_p.cend(), std::back_inserter(result), [](char const& c) {
+		return std::tolower(c);
+		});
+	return result;
+}
 
 
 /**
@@ -125,7 +133,7 @@ void initializedCandidates(std::string rootPath, Candidates & candidates) {
 	}
 	while (std::getline(area_filestream, line)) {
 		if (!line.empty() && line.front() != '#') {
-			Candidates::area_names.push_back(line);
+			Candidates::area_names.push_back(toLowercase(line));
 		}
 	}
 	for (auto const & kvp : Candidates::intercos_map) {


### PR DESCRIPTION
Closes #32 

In antares-solver, area from study are listed in a area txt file. This file contains the name as displayed on the GUI : with or without uppercase.

Candidates defined in _user\expansion\candidates.ini_ are read with uppercase to lowercase transformation.
Now we convert also area defined in area txt file to lowercase so we can compare with area defined in candidates.ini file