### PR TITLE
Fix/python set GitHub actions

### DIFF
--- a/.github/workflows/linux-system.yml
+++ b/.github/workflows/linux-system.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
           

--- a/.github/workflows/releases-linux.yml
+++ b/.github/workflows/releases-linux.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2 
     
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
           

--- a/.github/workflows/releases-windows.yml
+++ b/.github/workflows/releases-windows.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9.1
           
     - name: Install dependencies
       run: |

--- a/.github/workflows/releases-windows.yml
+++ b/.github/workflows/releases-windows.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2 
     
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
           

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
           

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9.1
           
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Use of `actions/setup-python@v2`

Force 3.9.1 python setup in windows to have same version as default github action windows runners.

closes #70 

