### PR TITLE
Fix mps coin

### DIFF
--- a/src/src_cpp/src_helpers/ortools_utils.cc
+++ b/src/src_cpp/src_helpers/ortools_utils.cc
@@ -107,7 +107,7 @@ void ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p,
     To send the data to CBC, the model has to be solved
     We set a Time limit of 1ms so that the solve, which is only required to send the data
     is not time consuming */
-    solver_p.set_time_limit(1);
+    solver_p.SetTimeLimit( absl::Milliseconds(1) );
     solver_p.Solve();
 
     // We take the underlying solver present in CBC
@@ -164,8 +164,8 @@ int ORTwriteMps_CBC_with_names(OsiClpSolverInterface* solver,
     const int numcols = solver->getNumCols();
     std::shared_ptr<char[]> shared_integrality(new char[numcols]);
     char* integrality = shared_integrality.get();
-    integrality = CoinCopyOfArray(solver->getColType(false), numcols);
-
+    CoinCopyN(solver->getColType(false), numcols, integrality);
+    
     bool hasInteger = false;
     for (int i = 0; i < numcols; ++i) {
         if (solver->isInteger(i)) {
@@ -177,7 +177,7 @@ int ORTwriteMps_CBC_with_names(OsiClpSolverInterface* solver,
     // Get multiplier for objective function - default 1.0
     std::shared_ptr<double[]> shared_objective(new double[numcols]);
     double* objective = shared_objective.get();
-    objective = CoinCopyOfArray(solver->getObjCoefficients(), numcols);
+    CoinCopyN(solver->getObjCoefficients(), numcols, objective);
 
     double locObjSense = (objSense == 0 ? 1 : objSense);
     if (solver->getObjSense() * locObjSense < 0.0) {

--- a/src/src_cpp/src_helpers/ortools_utils.cc
+++ b/src/src_cpp/src_helpers/ortools_utils.cc
@@ -99,7 +99,7 @@ bool ORTwritemps(operations_research::MPSolver const & solver_p, std::string con
 	return true;
 }
 
-bool ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p, 
+void ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p, 
     std::string const& filename_p) {
     
     /*The MPS writer of inner CBC solver will be used
@@ -140,7 +140,7 @@ bool ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p,
     const CoinSet* setInfo = NULL;
     ORTwriteMps_CBC_with_names(
         underlying_CBC_solver,
-        "master_cbcWritten.mps",
+        filename_p.c_str(),
         formatType,
         numberAcross,
         objSense,
@@ -149,7 +149,6 @@ bool ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p,
         columnNamesVector,
         rowNamesVector
     );
-    
 }
 
 int ORTwriteMps_CBC_with_names(OsiClpSolverInterface* solver,

--- a/src/src_cpp/src_helpers/ortools_utils.h
+++ b/src/src_cpp/src_helpers/ortools_utils.h
@@ -3,7 +3,10 @@
 #include <sstream>
 
 #include "ortools/linear_solver/linear_solver.h"
-
+#include "OsiClpSolverInterface.hpp"
+#include "OsiSolverInterface.hpp"
+#include "CoinMpsIO.hpp"
+#include "CoinHelperFunctions.hpp"
 
 #if ( (!defined(ORTOOLS_LP_SOLVER_TYPE)) || (!defined(ORTOOLS_MIP_SOLVER_TYPE)) )
 #if defined(CPLEX_SOLVER)
@@ -37,6 +40,43 @@ operations_research::MPSolverResponseStatus ORTreadmps(operations_research::MPSo
  * @param filename_p  : path to the mps file to produce
  */
 bool ORTwritemps(operations_research::MPSolver const & solver_p, std::string const & filename_p);
+
+/**
+ * @brief writes a problem into an mps format with high precision on number, 
+ *              only available if COIN-OR CBC is used as solver
+ *
+ * @param solver_p  : solver containing the model to export, cannot be const as the model 
+ *              to be written is sent to the inner solver in this method
+ * @param filename_p  : path to the mps file to produce
+ */
+bool ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p, 
+    std::string const& filename_p);
+
+
+/**
+ * @brief writes a problem into an mps format
+ *
+ * @param solver : Solver containing the problem data
+ * @param filename : path to the mps file to produce
+ * @param formatType : 0 for default CBC accuracy, 1 for ExtraAccuracy
+ * @param numberAcross : Not described in CBC documentation
+ * @param objSense : Not described in CBC documentation,
+ *              1.0 for minimization, -1.0 for maximization
+ * @param numberSOS : Not described in CBC documentation
+ * @param setInfo : Not described in CBC documentation, may bu NULL
+ * @param colNamesVec : Vector of column (variables) names, needs an artificial variable named
+ *              "dummy" at index 0
+ * @param rowNamesVec : Vector of row names (contraints)
+ */
+int ORTwriteMps_CBC_with_names(OsiClpSolverInterface* solver,
+    const char* filename,
+    int formatType,
+    int numberAcross,
+    double objSense,
+    int numberSOS,
+    const CoinSet* setInfo,
+    std::vector<std::string> const& colNamesVec,
+    std::vector<std::string> const& rowNamesVec);
 
 /**
  * @brief writes a problem into an lp format

--- a/src/src_cpp/src_helpers/ortools_utils.h
+++ b/src/src_cpp/src_helpers/ortools_utils.h
@@ -49,7 +49,7 @@ bool ORTwritemps(operations_research::MPSolver const & solver_p, std::string con
  *              to be written is sent to the inner solver in this method
  * @param filename_p  : path to the mps file to produce
  */
-bool ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p, 
+void ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p, 
     std::string const& filename_p);
 
 

--- a/src/src_cpp/src_helpers/ortools_utils.h
+++ b/src/src_cpp/src_helpers/ortools_utils.h
@@ -69,7 +69,7 @@ void ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p,
  * @param rowNamesVec : Vector of row names (contraints)
  */
 int ORTwriteMps_CBC_with_names(OsiClpSolverInterface* solver,
-    const char* filename,
+    std::string const& filename,
     int formatType,
     int numberAcross,
     double objSense,


### PR DESCRIPTION
Add two functions in "helpers/ortools_utils.cc" to write an MPS file with an ORTools CBC interface : 
operations_research::MPSolver::CBC_MIXED_INTEGER_PROGRAMMING

The function ORTwritempsPreciseWithCoin(operations_research::MPSolver & solver_p, std::string const& filename_p) takes the same arguments as ORTwritemps, and should do the work. I didn't change the calls in lp_namer code as I don't know which one needs to be modified.