### PR TITLE
split read_prob / write_prob in 2 functions for MPS and LP

### DIFF
--- a/src/cpp/benders_sequential/Worker.cpp
+++ b/src/cpp/benders_sequential/Worker.cpp
@@ -70,7 +70,7 @@ void Worker::init(Str2Int const & variable_map, std::string const & path_to_mps,
 		_solver->init();
 	}
 	_solver->set_threads(1);
-	_solver->read_prob(path_to_mps.c_str(), "MPS");
+	_solver->read_prob_mps(path_to_mps);
 	
 	int var_index;
 	for(auto const & kvp : variable_map) {

--- a/src/cpp/exe/lpnamer/main.cpp
+++ b/src/cpp/exe/lpnamer/main.cpp
@@ -159,7 +159,7 @@ void masterGeneration(std::string rootPath,
 	std::string const lp_name = "master";
 	// writelp is useless no ?
 	//ORTwritelp(master_l, rootPath + PATH_SEPARATOR + "lp" + PATH_SEPARATOR + lp_name + ".lp");
-	master_l->write_prob((rootPath + PATH_SEPARATOR + "lp" + PATH_SEPARATOR + lp_name + ".mps").c_str(), "MPS");
+	master_l->write_prob_mps((rootPath + PATH_SEPARATOR + "lp" + PATH_SEPARATOR + lp_name + ".mps"));
 
 	std::map<std::string, std::map<std::string, int> > output;
 	for (auto const & coupling : couplings) {

--- a/src/cpp/exe/merge/merge_mps.cpp
+++ b/src/cpp/exe/merge/merge_mps.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv)
 				std::cerr << "missing variable " << x.first << " in " << kvp.first << " supposedly renamed to " << varPrefix_l+x.first << ".";
 				ORTwritelp(mergedSolver_l, options.OUTPUTROOT + PATH_SEPARATOR + "mergeError.lp");
 				std::string mpsName = options.OUTPUTROOT + PATH_SEPARATOR + "mergeError.mps";
-				mergedSolver_l->write_prob(mpsName.c_str(), "MPS");
+				mergedSolver_l->write_prob_mps(mpsName);
 				std::exit(1);
 			}
 			else{

--- a/src/cpp/helpers/ortools_utils.cc
+++ b/src/cpp/helpers/ortools_utils.cc
@@ -3,17 +3,17 @@
 void ORTreadmps(SolverAbstract::Ptr solver_p, 
     std::string const & filename_p)
 {
-    solver_p->read_prob(filename_p.c_str(), "MPS");
+    solver_p->read_prob_mps(filename_p);
 }
 
 void ORTwritemps(SolverAbstract::Ptr const solver_p, std::string const & filename_p)
 {
-    solver_p->write_prob(filename_p.c_str(), "MPS");
+    solver_p->write_prob_mps(filename_p);
 }
 
 void ORTwritelp(SolverAbstract::Ptr const solver_p, std::string const & filename_p)
 {
-    solver_p->write_prob(filename_p.c_str(), "LP");
+    solver_p->write_prob_lp(filename_p);
 }
 
 

--- a/src/cpp/lpnamer/IntercoDataMps.cpp
+++ b/src/cpp/lpnamer/IntercoDataMps.cpp
@@ -293,7 +293,7 @@ void Candidates::createMpsFileAndFillCouplings(std::string const & mps_name,
 	SolverFactory factory;
 	SolverAbstract::Ptr in_prblm;
 	in_prblm = factory.create_solver(solver_name);
-	in_prblm->read_prob(mps_name.c_str(), "MPS");
+	in_prblm->read_prob_mps(mps_name);
 
 	int ncols = in_prblm->get_ncols();
 	int nrows = in_prblm->get_nrows();
@@ -412,7 +412,7 @@ void Candidates::createMpsFileAndFillCouplings(std::string const & mps_name,
 
 	ORTaddrows(out_prblm, rowtype, rhs, {}, rstart, colind, dmatval);
 
-	out_prblm->write_prob(lp_mps_name.c_str(), "MPS");
+	out_prblm->write_prob_mps(lp_mps_name);
 	std::cout << "mps_name : " << lp_mps_name << " done" << std::endl;
 }
 

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -65,101 +65,100 @@ void SolverCbc::free() {
 /*************************************************************************************************
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
-void SolverCbc::write_prob(const char* name, const char* flags) {
+void SolverCbc::write_prob_mps(const std::string& filename) {
 
-	if (std::string(flags) == "LP") {
-		_clp_inner_solver.writeLpNative(name, NULL, NULL);
-	}
-	else if (std::string(flags) == "MPS") {
+    const int numcols = get_ncols();
+    std::shared_ptr<char[]> shared_integrality(new char[numcols]);
+    char* integrality = shared_integrality.get();
+    CoinCopyN(_clp_inner_solver.getColType(false), numcols, integrality);
 
-		const int numcols = get_ncols();
-		std::shared_ptr<char[]> shared_integrality(new char[numcols]);
-		char* integrality = shared_integrality.get();
-		CoinCopyN(_clp_inner_solver.getColType(false), numcols, integrality);
+    bool hasInteger = false;
+    for (int i = 0; i < numcols; ++i) {
+        if (_clp_inner_solver.isInteger(i)) {
+            hasInteger = true;
+            break;
+        }
+    }
 
-		bool hasInteger = false;
-		for (int i = 0; i < numcols; ++i) {
-			if (_clp_inner_solver.isInteger(i)) {
-				hasInteger = true;
-				break;
-			}
-		}
+    CoinMpsIO writer;
+    writer.setInfinity(_clp_inner_solver.getInfinity());
+    writer.passInMessageHandler(_clp_inner_solver.messageHandler());
 
-		CoinMpsIO writer;
-		writer.setInfinity(_clp_inner_solver.getInfinity());
-		writer.passInMessageHandler(_clp_inner_solver.messageHandler());
-		
-		// If the user added cuts or rows but did not added names to them
-		// the number of names returned by solver might be different from the
-		// actual number of names, resulting in a crash
-		std::vector<std::string> rowNames(get_nrows());
-		for (int i = 0; i < get_nrows(); ++i) {
-			std::string const& name(_clp_inner_solver.getRowName(i));
-			if (name == "") {
-				std::stringstream buffer;
-				buffer << "R" << i;
-				rowNames[i] = buffer.str();
-			}else{
-				rowNames[i] = name;
-			}
-		}
-		
-		std::vector<std::string> colNames(get_ncols());
-		for (int i = 0; i < get_ncols(); ++i) {
-			std::string const& name(_clp_inner_solver.getColName(i));
-			if (name == "") {
-				std::stringstream buffer;
-				buffer << "C" << i;
-				colNames[i] = buffer.str();
-			}
-			else {
-				colNames[i] = name;
-			}
-		}
-		
-		writer.setMpsData(
-			*(_clp_inner_solver.getMatrixByCol()),
-			_clp_inner_solver.getInfinity(),
-			_clp_inner_solver.getColLower(),
-			_clp_inner_solver.getColUpper(),
-			_clp_inner_solver.getObjCoefficients(),
-			hasInteger ? integrality : NULL,
-			_clp_inner_solver.getRowLower(),
-			_clp_inner_solver.getRowUpper(),
-			colNames,
-			rowNames
-		);
+    // If the user added cuts or rows but did not added names to them
+    // the number of names returned by solver might be different from the
+    // actual number of names, resulting in a crash
+    std::vector<std::string> rowNames(get_nrows());
+    for (int i = 0; i < get_nrows(); ++i) {
+        std::string const& name(_clp_inner_solver.getRowName(i));
+        if (name == "") {
+            std::stringstream buffer;
+            buffer << "R" << i;
+            rowNames[i] = buffer.str();
+        }else{
+            rowNames[i] = name;
+        }
+    }
 
-		std::string probName = "";
-		_clp_inner_solver.getStrParam(OsiProbName, probName);
-		writer.setProblemName(probName.c_str());
+    std::vector<std::string> colNames(get_ncols());
+    for (int i = 0; i < get_ncols(); ++i) {
+        std::string const& name(_clp_inner_solver.getColName(i));
+        if (name == "") {
+            std::stringstream buffer;
+            buffer << "C" << i;
+            colNames[i] = buffer.str();
+        }
+        else {
+            colNames[i] = name;
+        }
+    }
 
-		double objOffset = 0.0;
-		_clp_inner_solver.getDblParam(OsiObjOffset, objOffset);
-		writer.setObjectiveOffset(objOffset);
+    writer.setMpsData(
+        *(_clp_inner_solver.getMatrixByCol()),
+        _clp_inner_solver.getInfinity(),
+        _clp_inner_solver.getColLower(),
+        _clp_inner_solver.getColUpper(),
+        _clp_inner_solver.getObjCoefficients(),
+        hasInteger ? integrality : NULL,
+        _clp_inner_solver.getRowLower(),
+        _clp_inner_solver.getRowUpper(),
+        colNames,
+        rowNames
+    );
 
-		writer.writeMps(name, 0 /*gzip it*/, 1, 1,
-			NULL, 0, NULL);
-	}
-	else {
-		std::cout << "ERROR : Write prob - unknown format type " << flags << std::endl;
-		std::exit(1);
-	}
+    std::string probName = "";
+    _clp_inner_solver.getStrParam(OsiProbName, probName);
+    writer.setProblemName(probName.c_str());
+
+    double objOffset = 0.0;
+    _clp_inner_solver.getDblParam(OsiObjOffset, objOffset);
+    writer.setObjectiveOffset(objOffset);
+
+    writer.writeMps(filename.c_str(), 0 /*gzip it*/, 1, 1,
+        NULL, 0, NULL);
+
 }
 
-void SolverCbc::read_prob(const char* prob_name, const char* flags){
+void SolverCbc::write_prob_lp(const std::string& name) {
+    _clp_inner_solver.writeLpNative(name.c_str(), NULL, NULL);
+}
+void SolverCbc::read_prob(const char* prob_name, const char* flags)
+{
+    int status = _clp_inner_solver.readMps(prob_name, flags);
+    zero_status_check(status, "read problem");
+
+    // Affectation of new Clp interface to Cbc
+    // As CbcModel _cbc is modified, need to set log level to 0 again
+    _cbc = CbcModel(_clp_inner_solver);
+    set_output_log_level(_current_log_level);
+}
+void SolverCbc::read_prob_mps(const std::string& prob_name){
 	std::string clp_flags = "mps";
-	if (std::string(flags) == "LP") {
-		clp_flags = "lp";
-	}
+    read_prob(prob_name.c_str(), clp_flags.c_str());
+}
 
-	int status = _clp_inner_solver.readMps(prob_name, clp_flags.c_str());
-	zero_status_check(status, "read problem");
-
-	// Affectation of new Clp interface to Cbc
-	// As CbcModel _cbc is modified, need to set log level to 0 again
-	_cbc = CbcModel(_clp_inner_solver);	
-	set_output_log_level(_current_log_level);
+void SolverCbc::read_prob_lp(const std::string& prob_name){
+    std::string clp_flags = "lp";
+    read_prob(prob_name.c_str(), clp_flags.c_str());
 }
 
 void SolverCbc::copy_prob(const SolverAbstract::Ptr fictif_solv){

--- a/src/cpp/multisolver_interface/SolverCbc.h
+++ b/src/cpp/multisolver_interface/SolverCbc.h
@@ -43,6 +43,9 @@ public:
 	virtual ~SolverCbc();
 	virtual int get_number_of_instances();
 
+private:
+    void defineCbcModelFromInnerSolver();
+
 /*************************************************************************************************
 ---------------------------------    Output and stream management    -----------------------------
 *************************************************************************************************/
@@ -66,16 +69,6 @@ public:
     virtual void read_prob_lp(const std::string& filename);
 
     virtual void copy_prob(const SolverAbstract::Ptr fictif_solv);
-
-private:
-    /**
-	* @brief Reads a problem from a file, CBC WARNING : resets the solver log level to 0
-	*
-	* @param prob_name 	: Name of file containing the problem
-	* @param flags : flags to chose the file type
-	*/
-    virtual void read_prob(const char* prob_name, const char* flags);
-
 
 /*************************************************************************************************
 -----------------------    Get general informations about problem    ----------------------------

--- a/src/cpp/multisolver_interface/SolverCbc.h
+++ b/src/cpp/multisolver_interface/SolverCbc.h
@@ -59,16 +59,22 @@ public:
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
 public:
-	virtual void write_prob(const char* name, const char* flags);
+    virtual void write_prob_mps(const std::string& filename);
+    virtual void write_prob_lp(const std::string& filename);
 
-	/**
+    virtual void read_prob_mps(const std::string& filename);
+    virtual void read_prob_lp(const std::string& filename);
+
+    virtual void copy_prob(const SolverAbstract::Ptr fictif_solv);
+
+private:
+    /**
 	* @brief Reads a problem from a file, CBC WARNING : resets the solver log level to 0
 	*
 	* @param prob_name 	: Name of file containing the problem
 	* @param flags : flags to chose the file type
 	*/
     virtual void read_prob(const char* prob_name, const char* flags);
-    virtual void copy_prob(const SolverAbstract::Ptr fictif_solv);
 
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -63,22 +63,24 @@ void SolverClp::free() {
 /*************************************************************************************************
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
-void SolverClp::write_prob(const char* name, const char* flags){
+void SolverClp::write_prob_mps(const std::string& filename){
 	std::string nFlags = "";
-	if (std::string(flags) == "LP") {
-		nFlags = "-l";
-	}
-	_clp.writeMps(name, 1);
+	_clp.writeMps(filename.c_str(), 1);
 }
 
-void SolverClp::read_prob(const char* prob_name, const char* flags){
+void SolverClp::write_prob_lp(const std::string& filename){
+    std::string nFlags = "-l";
+    _clp.writeMps(filename.c_str(), 1);
+}
+
+void SolverClp::read_prob_mps(const std::string& filename){
 	set_output_log_level(0);
-	if (std::string(flags) == "LP") {
-		_clp.readLp(prob_name);
-	}
-	else {
-		_clp.readMps(prob_name, true, false);
-	}
+	_clp.readMps(filename.c_str(), true, false);
+}
+
+void SolverClp::read_prob_lp(const std::string& filename){
+    set_output_log_level(0);
+    _clp.readLp(filename.c_str());
 }
 
 void SolverClp::copy_prob(const SolverAbstract::Ptr fictif_solv){

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -64,13 +64,11 @@ void SolverClp::free() {
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
 void SolverClp::write_prob_mps(const std::string& filename){
-	std::string nFlags = "";
 	_clp.writeMps(filename.c_str(), 1);
 }
 
 void SolverClp::write_prob_lp(const std::string& filename){
-    std::string nFlags = "-l";
-    _clp.writeMps(filename.c_str(), 1);
+    _clp.writeLp(filename.c_str());
 }
 
 void SolverClp::read_prob_mps(const std::string& filename){

--- a/src/cpp/multisolver_interface/SolverClp.h
+++ b/src/cpp/multisolver_interface/SolverClp.h
@@ -64,10 +64,13 @@ public:
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
 public:
-	virtual void write_prob(const char* name, const char* flags);
-    virtual void read_prob(const char* prob_name, const char* flags);
-    virtual void copy_prob(const SolverAbstract::Ptr fictif_solv);
+    virtual void write_prob_mps(const std::string& filename);
+    virtual void write_prob_lp(const std::string& filename);
 
+    virtual void read_prob_mps(const std::string& filename);
+    virtual void read_prob_lp(const std::string& filename);
+
+    virtual void copy_prob(const SolverAbstract::Ptr fictif_solv);
 
 /*************************************************************************************************
 -----------------------    Get general informations about problem    ----------------------------

--- a/src/cpp/multisolver_interface/SolverCplex.cpp
+++ b/src/cpp/multisolver_interface/SolverCplex.cpp
@@ -96,12 +96,25 @@ void SolverCplex::free() {
 /*************************************************************************************************
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
-void SolverCplex::write_prob(const char* name, const char* flags){
-    CPXwriteprob(_env, _prb, name, flags);
+void SolverCplex::write_prob_mps(const std::string& filename){
+    std::string cplexFlags = "MPS";
+    CPXwriteprob(_env, _prb, filename.c_str(), cplexFlags.c_str());
 }
 
-void SolverCplex::read_prob(const char* prob_name, const char* flags){
-	int status = CPXreadcopyprob(_env, _prb, prob_name, flags);
+void SolverCplex::write_prob_lp(const std::string& filename){
+    std::string cplexFlags = "LP";
+    CPXwriteprob(_env, _prb, filename.c_str(), cplexFlags.c_str());
+}
+
+void SolverCplex::read_prob_mps(const std::string& filename){
+    std::string cplexFlags = "MPS";
+    int status = CPXreadcopyprob(_env, _prb, filename.c_str(), cplexFlags.c_str());
+    zero_status_check(status, "read problem");
+}
+
+void SolverCplex::read_prob_lp(const std::string& filename){
+    std::string cplexFlags = "LP";
+    int status = CPXreadcopyprob(_env, _prb, filename.c_str(), cplexFlags.c_str());
     zero_status_check(status, "read problem");
 }
 

--- a/src/cpp/multisolver_interface/SolverCplex.h
+++ b/src/cpp/multisolver_interface/SolverCplex.h
@@ -60,6 +60,11 @@ public:
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
 public:
+    virtual void write_prob_mps(const std::string& filename);
+    virtual void write_prob_lp(const std::string& filename);
+
+    virtual void read_prob_mps(const std::string& filename);
+    virtual void read_prob_lp(const std::string& filename);
 	virtual void write_prob(const char* name, const char* flags);
     virtual void read_prob(const char* prob_name, const char* flags);
     virtual void copy_prob(const SolverAbstract::Ptr fictif_solv);

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -84,7 +84,7 @@ void SolverXpress::write_prob_mps(const std::string& filename){
 }
 
 void SolverXpress::write_prob_lp(const std::string& filename){
-    std::string nFlags = "LP";
+    std::string nFlags = "l";
     int status = XPRSwriteprob(_xprs, filename.c_str(), nFlags.c_str());
     zero_status_check(status, "write problem");
 }

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -77,22 +77,28 @@ void SolverXpress::free() {
 /*************************************************************************************************
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
-void SolverXpress::write_prob(const char* name, const char* flags){
-	std::string nFlags = "";
-	if (std::string(flags) == "LP") {
-		nFlags = "-l";
-	}
+void SolverXpress::write_prob_mps(const std::string& filename){
+    std::string nFlags = "";
+    int status = XPRSwriteprob(_xprs, filename.c_str(), nFlags.c_str());
+    zero_status_check(status, "write problem");
+}
 
-	int status = XPRSwriteprob(_xprs, name, nFlags.c_str());
-	zero_status_check(status, "write problem");
+void SolverXpress::write_prob_lp(const std::string& filename){
+    std::string nFlags = "LP";
+    int status = XPRSwriteprob(_xprs, filename.c_str(), nFlags.c_str());
+    zero_status_check(status, "write problem");
+}
+
+void SolverXpress::read_prob_mps(const std::string& filename){
+    std::string nFlags = "";
+    read_prob(filename.c_str(), nFlags.c_str());
+}
+void SolverXpress::read_prob_lp(const std::string& filename){
+    std::string nFlags = "l";
+    read_prob(filename.c_str(), nFlags.c_str());
 }
 
 void SolverXpress::read_prob(const char* prob_name, const char* flags){
-	std::string xprs_flags = "";
-	if (std::string(flags) == "LP") {
-		xprs_flags = "l";
-	}
-	
 	// To delete obj from rows when reading prob
 	int keeprows(0);
 	int status = XPRSgetintcontrol(_xprs, XPRS_KEEPNROWS, &keeprows);
@@ -115,7 +121,7 @@ void SolverXpress::read_prob(const char* prob_name, const char* flags){
 	}
 	*/
 	
-	status = XPRSreadprob(_xprs, prob_name, xprs_flags.c_str());
+	status = XPRSreadprob(_xprs, prob_name, flags);
 	zero_status_check(status, "read problem");
 
 	//If param KEEPNROWS not -1 remove first row which is the objective function

--- a/src/cpp/multisolver_interface/SolverXpress.h
+++ b/src/cpp/multisolver_interface/SolverXpress.h
@@ -52,10 +52,16 @@ public:
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
 public:
-	virtual void write_prob(const char* name, const char* flags);
-    virtual void read_prob(const char* prob_name, const char* flags);
+    virtual void write_prob_mps(const std::string& filename);
+    virtual void write_prob_lp(const std::string& filename);
+
+    virtual void read_prob_mps(const std::string& filename);
+    virtual void read_prob_lp(const std::string& filename);
     virtual void copy_prob(const SolverAbstract::Ptr fictif_solv);
 
+private:
+
+    virtual void read_prob(const char* prob_name, const char* flags);
 
 /*************************************************************************************************
 -----------------------    Get general informations about problem    ----------------------------

--- a/src/cpp/multisolver_interface/include/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/multisolver_interface/SolverAbstract.h
@@ -119,21 +119,34 @@ public:
 -------------------------------    Reading & Writing problems    -------------------------------
 *************************************************************************************************/
 public:
+
     /**
-    * @brief writes an optimization problem in a file
+    * @brief writes an optimization problem in a MPS file
     *
     * @param name   : name of the file to write
-    * @param falgs  : char* containing the file format (LP, MPS) 
+    */
+    virtual void write_prob_mps(const std::string& filename) = 0;
+
+    /**
+    * @brief writes an optimization problem in a LP file
+    *
+    * @param name   : name of the file to write
     */    
-	virtual void write_prob(const char* name, const char* flags) = 0;
+	virtual void write_prob_lp(const std::string& filename) = 0;
 	
     /**
-    * @brief reads an optimization problem contained in a file
+    * @brief reads an optimization problem contained in a MPS file
     *
     * @param name   : name of the file to read
-    * @param falgs  : char* containing the file format (LP, MPS) 
     */
-    virtual void read_prob(const char* prob_name, const char* flags) = 0;
+    virtual void read_prob_mps(const std::string& filename) = 0;
+
+    /**
+    * @brief reads an optimization problem contained in a MPS file
+    *
+    * @param name   : name of the file to read
+    */
+    virtual void read_prob_lp(const std::string& filename) = 0;
 	
     /**
     * @brief copy an existing problem

--- a/tests/cpp/solvers_interface/test_modifying_problem.cpp
+++ b/tests/cpp/solvers_interface/test_modifying_problem.cpp
@@ -22,7 +22,7 @@ TEST_CASE("Modification: deleting rows", "[modif][del-rows]") {
             // solver declaration
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            solver->read_prob(instance.c_str(), "MPS");
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Deleting a row and checking new constraints matrix
@@ -67,7 +67,7 @@ TEST_CASE("Modification: add rows", "[modif][add-rows]") {
                 // solver declaration
                 SolverAbstract::Ptr solver = factory.create_solver(solver_name);
                 solver->init();
-                solver->read_prob(instance.c_str(), "MPS");
+                solver->read_prob_mps(instance);
 
                 //========================================================================================
                 // Add a row to problem : creating row structure
@@ -155,7 +155,7 @@ TEST_CASE("Modification: change obj", "[modif][chg-obj]") {
             // solver declaration
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            solver->read_prob(instance.c_str(), "MPS");
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Modify objective function
@@ -199,7 +199,7 @@ TEST_CASE("Modification: change right-hand side", "[modif][chg-rhs]") {
             // solver declaration
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            solver->read_prob(instance.c_str(), "MPS");
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Change constraints right hand sides
@@ -241,7 +241,7 @@ TEST_CASE("Modification: change matrix coefficient", "[modif][chg-coef]") {
             // solver declaration
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            solver->read_prob(instance.c_str(), "MPS");
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Change matrix coefficient
@@ -299,7 +299,7 @@ TEST_CASE("Modification: add columns", "[modif][add-cols]") {
                 // solver declaration
                 SolverAbstract::Ptr solver = factory.create_solver(solver_name);
                 solver->init();
-                solver->read_prob(instance.c_str(), "MPS");
+                solver->read_prob_mps(instance);
 
                 //========================================================================================
                 // Add new variable to problem
@@ -428,7 +428,7 @@ TEST_CASE("Modification: change name of row and column", "[modif][chg-names]") {
             std::string instance = datas[inst]._path;
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            solver->read_prob(instance.c_str(), "MPS");
+            solver->read_prob_mps(instance);
 
             // Test change col name
             // Modifying name of Column of index 1
@@ -470,7 +470,7 @@ TEST_CASE("Modification: add cols and a row associated to those columns", "[modi
             std::string instance = datas[inst]._path;
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            solver->read_prob(instance.c_str(), "MPS");
+            solver->read_prob_mps(instance);
 
             /*--------------------------------------------------------------------------------*/
             // adding 4 columns, the first with obj 1 and the three others wih obj 0

--- a/tests/cpp/solvers_interface/test_reading_problem.cpp
+++ b/tests/cpp/solvers_interface/test_reading_problem.cpp
@@ -50,8 +50,7 @@ TEST_CASE("MPS file can be read and we can get number of columns", "[read][read-
             // initalization and read problem
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+            solver->read_prob_mps(instance);
             
             //========================================================================================
             // Get number of columns
@@ -78,8 +77,7 @@ TEST_CASE("MPS file can be read and we can get number of rows", "[read][read-row
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get numer of rows
@@ -106,8 +104,8 @@ TEST_CASE("MPS file can be read and we can get number of integer variables", "[r
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get number of integer variables
@@ -134,8 +132,8 @@ TEST_CASE("MPS file can be read and we can get number of non zero elements in th
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get number of non zero elements in matrix
@@ -164,8 +162,8 @@ TEST_CASE("MPS file can be read and we can get objective function coefficients",
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get objective function
@@ -199,8 +197,8 @@ TEST_CASE("MPS file can be read and we can get matrix coefficients", "[read][rea
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get necessary datas from solver
@@ -247,8 +245,8 @@ TEST_CASE("MPS file can be read and we can get right hand side", "[read][read-rh
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());          
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get Constraints Right Hand Sides
@@ -285,8 +283,8 @@ TEST_CASE("MPS file can be read and we can get row types", "[read][read-rowtypes
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
 
             REQUIRE(solver->get_nrows() == datas[inst]._nrows);
@@ -322,8 +320,8 @@ TEST_CASE("MPS file can be read and we can get types of columns", "[read][read-c
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get column types
@@ -356,8 +354,8 @@ TEST_CASE("MPS file can be read and we can get lower bounds on variables", "[rea
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get lower bounds on variables
@@ -390,8 +388,8 @@ TEST_CASE("MPS file can be read and we can get upper bounds on variables", "[rea
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Get upper bounds on variables
@@ -431,8 +429,8 @@ TEST_CASE("MPS file can be read and we can get every information about the probl
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Required datas
@@ -539,13 +537,13 @@ TEST_CASE("We can get the names of variables and constraints present in MPS file
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
             
             if (solver_name == "XPRESS") {
                 std::string prb_name = "test" + ind;
-                solver->write_prob(prb_name.c_str(), "MPS");
+                solver->write_prob_mps(prb_name);
                 ind++;
             }
             //========================================================================================
@@ -596,13 +594,13 @@ TEST_CASE("We can get the indices of rows and columns by their names", "[read][g
             REQUIRE(solver->get_number_of_instances() == 1);
             solver->init();
 
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+
+            solver->read_prob_mps(instance);
 
 
             if (solver_name == "XPRESS") {
                 std::string prb_name = "test" + ind;
-                solver->write_prob(prb_name.c_str(), "MPS");
+                solver->write_prob_mps(prb_name);
                 ind++;
             }
             //========================================================================================
@@ -644,7 +642,7 @@ TEST_CASE("Testing copy constructor", "[init][copy-constructor]") {
             // Intial solver declaration and read problem
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            solver->read_prob(instance.c_str(), "MPS");
+            solver->read_prob_mps(instance);
             REQUIRE(solver->get_number_of_instances() == 1);
 
             REQUIRE(solver->get_ncols() == datas[inst]._ncols);

--- a/tests/cpp/solvers_interface/test_solving_problem.cpp
+++ b/tests/cpp/solvers_interface/test_solving_problem.cpp
@@ -24,8 +24,7 @@ TEST_CASE("A LP problem is solved", "[solve-lp]") {
             // Solver declaration and read problem
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Solve as LP
@@ -76,8 +75,7 @@ TEST_CASE("A LP problem is solved and we can get the LP value", "[solve-lp][get-
             // Solver declaration 
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Solve as LP
@@ -139,8 +137,7 @@ TEST_CASE("A LP problem is solved and we can get the LP solution", "[solve-lp][g
             // Solver declaration and read problem
             SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->init();
-            const std::string flags = "MPS";
-            solver->read_prob(instance.c_str(), flags.c_str());
+            solver->read_prob_mps(instance);
 
             //========================================================================================
             // Solve as LP and get solution
@@ -230,8 +227,7 @@ TEST_CASE("A problem is solved and we can get the optimal solution", "[solve-mip
                 // Solver declaration
                 SolverAbstract::Ptr solver = factory.create_solver(solver_name);
                 solver->init();
-                const std::string flags = "MPS";
-                solver->read_prob(instance.c_str(), flags.c_str());
+                solver->read_prob_mps(instance);
 
                 //========================================================================================
                 // Solve as MIP


### PR DESCRIPTION
Major changes : 
- for ClP use of `_clp.writeLp` to write LP file instead of `_clp.writeMps`
- small refactor for CbC model definition
- for CbC use of `_clp_inner_solver.readLp to read LP` file instead of `_clp_inner_solver.readMps`