### PR TITLE
review get_row_names and get_col_names

### DIFF
--- a/src/cpp/benders_sequential/launcher.h
+++ b/src/cpp/benders_sequential/launcher.h
@@ -83,8 +83,7 @@ public:
 		std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS] = nrows;
 		std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NELES] = nelems;
 
-		_colNames.resize(ncols);
-		solver_p->get_col_names(0, ncols - 1, _colNames);
+        _colNames = solver_p->get_col_names(0, ncols - 1);
 
 		std::get<Attribute::INT_VECTOR>(_data)[IntVectorAttribute::MSTART].clear();
 		std::get<Attribute::INT_VECTOR>(_data)[IntVectorAttribute::MSTART].resize(nrows + 1);

--- a/src/cpp/lpnamer/IntercoDataMps.cpp
+++ b/src/cpp/lpnamer/IntercoDataMps.cpp
@@ -330,8 +330,7 @@ void Candidates::createMpsFileAndFillCouplings(std::string const & mps_name,
 	// All the names are retrieved before the loop.
 	// The vector might be huge. The names can be retrieved one by one from the solver in the loop
 	// but it could be longer.
-	std::vector<std::string> outVarNames(out_prblm->get_ncols());
-	out_prblm->get_col_names(0, out_prblm->get_ncols() - 1, outVarNames);
+    std::vector<std::string> outVarNames = out_prblm->get_col_names(0, out_prblm->get_ncols() - 1);
 
 	/* Xavier : This check is useless as the names are not necessary and seem to be 
 	* no present in "in_prblm"

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -343,35 +343,38 @@ int SolverCbc::get_col_index(std::string const& name) const {
 	return -1;
 }
 
-int SolverCbc::get_row_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverCbc::get_row_names(int first, int last)
 {
+    int size = 1 + last - first;
+    std::vector<std::string> names;
+    names.reserve(size);
+
 	std::vector<std::string> solver_row_names = _clp_inner_solver.getRowNames();
-	if (solver_row_names.size() < names.size()) {
-		std::cout << "ERROR : all required rows don't have a name. Impossible to get row names."
-			<< std::endl;
-		std::exit(1);
+	if (solver_row_names.size() < size) {
+        throw InvalidRowSizeException(size,solver_row_names.size());
 	}
 
 	for (int i(first); i < last + 1; i++) {
-		names[i - first] = solver_row_names[i];
+		names.push_back(solver_row_names[i]);
 	}
-	return 0;
+	return names;
 }
 
-int SolverCbc::get_col_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverCbc::get_col_names(int first, int last)
 {
-	std::vector<std::string> solver_col_names = _clp_inner_solver.getColNames();
+    int size = 1 + last - first;
+    std::vector<std::string> names;
+    names.reserve(size);
 
-	if (solver_col_names.size() < names.size()) {
-		std::cout << "ERROR : all required columns don't have a name. Impossible to get col names."
-			<< std::endl;
-		std::exit(1);
+	std::vector<std::string> solver_col_names = _clp_inner_solver.getColNames();
+	if (solver_col_names.size() < size) {
+        throw InvalidColSizeException(size,solver_col_names.size());
 	}
 
 	for (int i(first); i < last + 1; i++) {
-		names[i - first] = solver_col_names[i];
+        names.push_back(solver_col_names[i]);
 	}
-	return 0;
+	return names;
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverCbc.h
+++ b/src/cpp/multisolver_interface/SolverCbc.h
@@ -90,8 +90,8 @@ public:
 
 	virtual int get_row_index(std::string const& name) const;
 	virtual int get_col_index(std::string const& name) const;
-	virtual int get_row_names(int first, int last, std::vector<std::string>& names);
-	virtual int get_col_names(int first, int last, std::vector<std::string>& names);
+    virtual std::vector<std::string> get_row_names(int first, int last);
+    virtual std::vector<std::string> get_col_names(int first, int last);
 
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -270,20 +270,26 @@ int SolverClp::get_col_index(std::string const& name) const {
 	return -1;
 }
 
-int SolverClp::get_row_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverClp::get_row_names(int first, int last)
 {
+    std::vector<std::string> names;
+    names.reserve(1 + last - first);
+
 	for (int i = first; i < last + 1; i++) {
-		names[i - first] = _clp.getRowName(i);
+		names.push_back(_clp.getRowName(i));
 	}
-	return 0;
+	return names;
 }
 
-int SolverClp::get_col_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverClp::get_col_names(int first, int last)
 {
+    std::vector<std::string> names;
+    names.reserve(1 + last - first);
+
 	for (int i = first; i < last + 1; i++) {
-		names[i - first] = _clp.getColumnName(i);
+		names.push_back(_clp.getColumnName(i));
 	}
-	return 0;
+	return names;
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverClp.h
+++ b/src/cpp/multisolver_interface/SolverClp.h
@@ -92,8 +92,8 @@ public:
 
 	virtual int get_row_index(std::string const& name) const;
 	virtual int get_col_index(std::string const& name) const;
-	virtual int get_row_names(int first, int last, std::vector<std::string>& names);
-	virtual int get_col_names(int first, int last, std::vector<std::string>& names);
+    virtual std::vector<std::string> get_row_names(int first, int last);
+    virtual std::vector<std::string> get_col_names(int first, int last);
 
 /*************************************************************************************************
 ------------------------------    Methods to modify problem    ----------------------------------

--- a/src/cpp/multisolver_interface/SolverCplex.cpp
+++ b/src/cpp/multisolver_interface/SolverCplex.cpp
@@ -210,38 +210,43 @@ int SolverCplex::get_col_index(std::string const& name) const {
 	return id;
 }
 
-int SolverCplex::get_row_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverCplex::get_row_names(int first, int last)
 {
+    std::vector<std::string> names;
+    names.reserve(1 + last - first);
+
 	int status = 0;
 	const int charSize = 100;
 	char cur_name[charSize];
 	std::vector<char*> namesPtr(charSize);
 	for (int i = 0; i < last - first + 1; i++) {
-		status = CPXgetrowname(_env, _prb, namesPtr.data(), cur_name, charSize, 
+		int status = CPXgetrowname(_env, _prb, namesPtr.data(), cur_name, charSize,
 			NULL, i + first, i + first);
 		zero_status_check(status, "get row name");
-		names[i] = cur_name;
+		names.push_back(cur_name);
 		memset(cur_name, 0, 100);
 	}
 
-	return status;
+	return names;
 }
 
-int SolverCplex::get_col_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverCplex::get_col_names(int first, int last, std::vector<std::string>& names)
 {
-	int status = 0;
+    std::vector<std::string> names;
+    names.reserve(1 + last - first);
+
 	const int charSize = 100;
 	char cur_name[charSize];
 	std::vector<char*> namesPtr(charSize);
 	for (int i = 0; i < last - first + 1; i++) {
-		status = CPXgetcolname(_env, _prb, namesPtr.data(), cur_name, charSize, 
+		int status = CPXgetcolname(_env, _prb, namesPtr.data(), cur_name, charSize,
 			NULL, i + first, i + first);
 		zero_status_check(status, "get column name");
-		names[i] = cur_name;
+		names.push_back(cur_name);
 		memset(cur_name, 0, 100);
 	}
 
-	return status;
+	return names;
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverCplex.h
+++ b/src/cpp/multisolver_interface/SolverCplex.h
@@ -90,8 +90,8 @@ public:
 
 	virtual int get_row_index(std::string const& name) const;
 	virtual int get_col_index(std::string const& name) const;
-	virtual int get_row_names(int first, int last, std::vector<std::string>& names);
-	virtual int get_col_names(int first, int last, std::vector<std::string>& names);
+    virtual std::vector<std::string> get_row_names(int first, int last);
+    virtual std::vector<std::string> get_col_names(int first, int last);
 
 /*************************************************************************************************
 ------------------------------    Methods to modify problem    ----------------------------------

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -222,32 +222,34 @@ int SolverXpress::get_col_index(std::string const& name) const {
 	return id;
 }
 
-int SolverXpress::get_row_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverXpress::get_row_names(int first, int last)
 {
-	int status = 0;
+    std::vector<std::string> names;
+    names.reserve(1 + last - first);
 	char cur_name[100];
 	for (int i = 0; i < last - first + 1; i++) {
-		status = XPRSgetnames(_xprs, 1, cur_name, i + first, i + first);
+		int status = XPRSgetnames(_xprs, 1, cur_name, i + first, i + first);
 		zero_status_check(status, "get row names.");
-		names[i] = cur_name;
+        names.push_back(cur_name);
 		memset(cur_name, 0, 100);
 	}
 	
-	return status;
+	return names;
 }
 
-int SolverXpress::get_col_names(int first, int last, std::vector<std::string>& names)
+std::vector<std::string> SolverXpress::get_col_names(int first, int last)
 {
-	int status = 0;
+    std::vector<std::string> names;
+    names.reserve(1 + last - first);
 	char cur_name[100];
 	for (int i = 0; i < last - first + 1; i++) {
-		status = XPRSgetnames(_xprs, 2, cur_name, i + first, i + first);
+		int status = XPRSgetnames(_xprs, 2, cur_name, i + first, i + first);
 		zero_status_check(status, "get column names.");
-		names[i] = cur_name;
+        names.push_back(cur_name);
 		memset(cur_name, 0, 100);
 	}
 
-	return status;
+	return names;
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverXpress.h
+++ b/src/cpp/multisolver_interface/SolverXpress.h
@@ -83,8 +83,8 @@ public:
 
 	virtual int get_row_index(std::string const& name) const;
 	virtual int get_col_index(std::string const& name) const;
-	virtual int get_row_names(int first, int last, std::vector<std::string>& names);
-	virtual int get_col_names(int first, int last, std::vector<std::string>& names);
+	virtual std::vector<std::string> get_row_names(int first, int last);
+	virtual std::vector<std::string> get_col_names(int first, int last);
 
 /*************************************************************************************************
 ------------------------------    Methods to modify problem    ----------------------------------

--- a/src/cpp/multisolver_interface/include/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/multisolver_interface/SolverAbstract.h
@@ -17,6 +17,24 @@ public:
     }
 };
 
+class InvalidRowSizeException : public std::runtime_error {
+public:
+    InvalidRowSizeException(int expected_size, int actual_size)
+            :std::runtime_error("Invalid row size for solver. " + std::to_string(actual_size) + " rows available ("+std::to_string(expected_size)+" expected)")
+    {
+
+    }
+};
+
+class InvalidColSizeException : public std::runtime_error {
+public:
+    InvalidColSizeException(int expected_size, int actual_size)
+            :std::runtime_error("Invalid col size for solver. " + std::to_string(actual_size) + " cols available ("+std::to_string(expected_size)+" expected)")
+    {
+
+    }
+};
+
 // Definition of optimality codes
 enum SOLVER_STATUS {
 	OPTIMAL,
@@ -285,10 +303,9 @@ public:
     *
     * @param first : first index from which name has be returned
     * @param last  : last index from which name has be returned
-    * @param names : vector of names, the size of vector has to be set by user before 
-                    calling the method
+    * @return names : vector of names
     */
-    virtual int get_row_names(int first, int last, std::vector<std::string> &names) = 0;
+    virtual std::vector<std::string> get_row_names(int first, int last) = 0;
 
     /**
     * @brief Returns the names of columns from index first to last
@@ -296,10 +313,9 @@ public:
     *
     * @param first : first index from which name has be returned
     * @param last  : last index from which name has be returned
-    * @param names : vector of names, the size of vector has to be set by user before 
-                    calling the method
+    * @return names : vector of names
     */
-    virtual int get_col_names(int first, int last, std::vector<std::string>& names) = 0;
+    virtual std::vector<std::string> get_col_names(int first, int last) = 0;
 
 /*************************************************************************************************
 ------------------------------    Methods to modify problem    ----------------------------------

--- a/tests/cpp/solvers_interface/test_exceptions.cpp
+++ b/tests/cpp/solvers_interface/test_exceptions.cpp
@@ -3,7 +3,7 @@
 #include "multisolver_interface/Solver.h"
 
 
-TEST_CASE("InvalidStatusException", "[exceptions]") {
+TEST_CASE("InvalidStatusException", "[exceptions][invalid_status]") {
 
     SolverFactory factory;
     for (auto const& solver_name : factory.get_solvers_list()) {
@@ -20,5 +20,42 @@ TEST_CASE("InvalidStatusException", "[exceptions]") {
         }
     }
 }
+
+TEST_CASE("InvalidRowSizeException", "[exceptions][invalid_row_size]") {
+
+    SolverFactory factory;
+    std::string  solver_name = "CBC";
+    //========================================================================================
+    // solver declaration
+    SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+    solver->init();
+
+    try{
+        std::vector<std::string> names = solver->get_row_names(0,9);
+    }catch(InvalidRowSizeException& ex)
+    {
+        REQUIRE(std::string(ex.what()) == "Invalid row size for solver. 0 rows available (10 expected)");
+    }
+}
+
+TEST_CASE("InvalidColSizeException", "[exceptions][invalid_col_size]") {
+
+    SolverFactory factory;
+    std::string  solver_name = "CBC";
+    //========================================================================================
+    // solver declaration
+    SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+    solver->init();
+
+
+    try{
+        std::vector<std::string> names = solver->get_col_names(0,9);
+    }catch(InvalidColSizeException& ex)
+    {
+        REQUIRE(std::string(ex.what()) == "Invalid col size for solver. 0 cols available (10 expected)");
+    }
+}
+
+
 
 

--- a/tests/cpp/solvers_interface/test_modifying_problem.cpp
+++ b/tests/cpp/solvers_interface/test_modifying_problem.cpp
@@ -435,8 +435,7 @@ TEST_CASE("Modification: change name of row and column", "[modif][chg-names]") {
             std::string newColName = "testColumn";
             solver->chg_col_name(1, newColName);
 
-            std::vector<std::string> solverColNames(1);
-            solver->get_col_names(1, 1, solverColNames);
+            std::vector<std::string> solverColNames = solver->get_col_names(1, 1);
             /*
             WARNING : Xpress Solver adds sometimes spaces at the end of the names.
             In order to perform comparison, we only compare the str.size() first characters 
@@ -449,8 +448,7 @@ TEST_CASE("Modification: change name of row and column", "[modif][chg-names]") {
             std::string newRowName = "testRow";
             solver->chg_row_name(1, newRowName);
 
-            std::vector<std::string> solverRowNames(1);
-            solver->get_row_names(1, 1, solverRowNames);
+            std::vector<std::string> solverRowNames= solver->get_row_names(1, 1);
             REQUIRE(solverRowNames[0].compare(0, newRowName.size(), newRowName) == 0);
         }
     }

--- a/tests/cpp/solvers_interface/test_reading_problem.cpp
+++ b/tests/cpp/solvers_interface/test_reading_problem.cpp
@@ -551,11 +551,11 @@ TEST_CASE("We can get the names of variables and constraints present in MPS file
             int n_vars = solver->get_ncols();
             int n_rows = solver->get_nrows();
 
-            std::vector<std::string> rowNames(n_rows);
-            std::vector<std::string> colNames(n_vars);
+            std::vector<std::string> rowNames = solver->get_row_names(0, n_rows - 1);
+            std::vector<std::string> colNames = solver->get_col_names(0, n_vars - 1);
 
-            solver->get_row_names(0, n_rows - 1, rowNames);
-            solver->get_col_names(0, n_vars - 1, colNames);
+
+
 
             int ind = 0;
             std::string cur_name;
@@ -668,8 +668,7 @@ TEST_CASE("Testing copy constructor", "[init][copy-constructor]") {
             //========================================================================================
             // Check variable names
             int ncols_copied = solver2->get_ncols();
-            std::vector<std::string> copiedNames(ncols_copied);
-            solver2->get_col_names(0, ncols_copied - 1, copiedNames);
+            std::vector<std::string> copiedNames = solver2->get_col_names(0, ncols_copied - 1);
 
             std::string cur_name = "";
             for (int i = 0; i < ncols_copied; i++) {


### PR DESCRIPTION
- `get_row_names `and `get_col_names `return instead of reference
- add exceptions in case of invalid col or row size available (only for Cbc)