### PR TITLE
Fix/broken medium tests

### DIFF
--- a/docs/build/4-Tests.md
+++ b/docs/build/4-Tests.md
@@ -20,7 +20,8 @@ This is the list of the available labels :
 | `unit_launcher`  | `unit`  |Unit test Antares-Xpansion python launcher|
 | `examples_medium_sequential`  | `medium` `medium_sequential` |Non-parallel end-to-end tests with examples antares studies (medium duration)|
 | `examples_medium_mpi`  | `medium` `medium_mpi` |Parallel end-to-end tests with examples antares study (medium duration)|
-| `examples_long`  | `long`  |End to end tests with examples antares study (long duration)|
+| `examples_long_sequential`  | `long` `long sequential`  |Non-parallel end-to-end tests with examples antares studies (long duration)|
+| `examples_long_mpi`  | `long` `long mpi`  |Parallel end-to-end tests with examples antares studies (long duration)|
 | `mpibenders`  | `benders-mpi`  |End to end tests for benders mpi optimization|
 | `sequential`  | `sequential`  |End to end tests for benders sequential optimization|
 | `merge_mps`  | `merge-mps`  |End to end tests for merge mps optimization|

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,11 +38,18 @@ if (PYTHON_MODULE_pytest_FOUND AND PYTHON_MODULE_numpy_FOUND)
     set_property(TEST examples_medium_mpi PROPERTY LABELS "medium;medium_mpi")
 
     add_test(
-        NAME examples_long
-        COMMAND Python3::Interpreter -m pytest -m long --installDir=$<TARGET_FILE_DIR:lp_namer> example_test.py
+        NAME examples_long_sequential
+        COMMAND Python3::Interpreter -m pytest -m long_sequential --installDir=$<TARGET_FILE_DIR:lp_namer> example_test.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/end_to_end/examples
     )
-    set_property(TEST examples_long PROPERTY LABELS long)
+    set_property(TEST examples_long_sequential PROPERTY LABELS "long;long_sequential")
+
+    add_test(
+        NAME examples_long_mpi
+        COMMAND Python3::Interpreter -m pytest -m long_mpi --installDir=$<TARGET_FILE_DIR:lp_namer> example_test.py
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/end_to_end/examples
+    )
+    set_property(TEST examples_long_mpi PROPERTY LABELS "long;long_mpi")
 	
 	# benders end to end tests
     add_test(

--- a/tests/end_to_end/examples/example_test.py
+++ b/tests/end_to_end/examples/example_test.py
@@ -11,27 +11,28 @@ import pytest
 
 from candidates_reader import CandidatesReader
 
-ALL_STUDIES_PATH = Path('../../../data_test/examples')
+ALL_STUDIES_PATH = Path("../../../data_test/examples")
 
 
 def get_first_json_filepath_output(output_dir):
     op = []
     for path in Path(output_dir).iterdir():
-        for jsonpath in Path(path / "lp").rglob('out.json'):
+        for jsonpath in Path(path / "lp").rglob("out.json"):
             op.append(jsonpath)
     assert len(op) == 1
     return op[0]
 
 
 def remove_outputs(study_path):
-    output_path = study_path / 'output'
+    output_path = study_path / "output"
     if os.path.isdir(output_path):
         for f in Path(output_path).iterdir():
             if f.is_dir():
                 shutil.rmtree(f)
 
+
 def backup_links(study_path):
-    
+
     input_path = os.path.join(study_path, "input")
     links_path = os.path.join(input_path, "links")
     tmp_links_path = os.path.join(input_path, "tmp_links")
@@ -40,7 +41,7 @@ def backup_links(study_path):
         shutil.rmtree(tmp_links_path)
 
     shutil.copytree(links_path, tmp_links_path)
-    
+
     return tmp_links_path
 
 
@@ -50,11 +51,12 @@ def restore_links(study_path, tmp_links_path):
 
     if os.path.isdir(links_path):
         shutil.rmtree(links_path)
-    
+
     shutil.copytree(tmp_links_path, links_path)
-    
+
     if os.path.isdir(tmp_links_path):
         shutil.rmtree(tmp_links_path)
+
 
 def launch_xpansion(install_dir, study_path, method):
     # Clean study output
@@ -62,8 +64,20 @@ def launch_xpansion(install_dir, study_path, method):
 
     install_dir_full = str(Path(install_dir).resolve())
 
-    command = [sys.executable, "../../../src/python/launch.py", "--installDir", install_dir_full, "--dataDir",
-               str(study_path), "--method", method, "--step", "full", "-n", "2"]
+    command = [
+        sys.executable,
+        "../../../src/python/launch.py",
+        "--installDir",
+        install_dir_full,
+        "--dataDir",
+        str(study_path),
+        "--method",
+        method,
+        "--step",
+        "full",
+        "-n",
+        "2",
+    ]
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=None)
     output = process.communicate()
 
@@ -72,10 +86,10 @@ def launch_xpansion(install_dir, study_path, method):
 
 
 def verify_solution(study_path, expected_values, expected_investment_solution):
-    output_path = study_path / 'output'
+    output_path = study_path / "output"
     json_path = get_first_json_filepath_output(output_path)
 
-    with open(str(json_path), 'r') as json_file:
+    with open(str(json_path), "r") as json_file:
         json_data = json.load(json_file)
 
     solution = json_data["solution"]
@@ -86,111 +100,144 @@ def verify_solution(study_path, expected_values, expected_investment_solution):
     RELATIVE_TOLERANCE = 1e-4
 
     np.testing.assert_allclose(
-        solution["investment_cost"], expected_values["investment_cost"], rtol=RELATIVE_TOLERANCE)
-    np.testing.assert_allclose(solution["operational_cost"], expected_values["operational_cost"],
-                               rtol=RELATIVE_TOLERANCE)
+        solution["investment_cost"],
+        expected_values["investment_cost"],
+        rtol=RELATIVE_TOLERANCE,
+    )
     np.testing.assert_allclose(
-        solution["overall_cost"], expected_values["overall_cost"], rtol=RELATIVE_TOLERANCE)
+        solution["operational_cost"],
+        expected_values["operational_cost"],
+        rtol=RELATIVE_TOLERANCE,
+    )
     np.testing.assert_allclose(
-        solution["optimality_gap"], expected_values["optimality_gap"], rtol=RELATIVE_TOLERANCE)
+        solution["overall_cost"],
+        expected_values["overall_cost"],
+        rtol=RELATIVE_TOLERANCE,
+    )
     np.testing.assert_allclose(
-        solution["relative_gap"], expected_values["relative_gap"], rtol=RELATIVE_TOLERANCE)
+        solution["optimality_gap"],
+        expected_values["optimality_gap"],
+        rtol=RELATIVE_TOLERANCE,
+    )
+    np.testing.assert_allclose(
+        solution["relative_gap"],
+        expected_values["relative_gap"],
+        rtol=RELATIVE_TOLERANCE,
+    )
 
     for investment in expected_investment_solution.keys():
-        assert investment in investment_solution.keys(), "Investment " + investment + \
-            " not found in solution"
-        np.testing.assert_allclose(expected_investment_solution[investment], investment_solution[investment],
-                                   rtol=RELATIVE_TOLERANCE)
+        assert investment in investment_solution.keys(), (
+            "Investment " + investment + " not found in solution"
+        )
+        np.testing.assert_allclose(
+            expected_investment_solution[investment],
+            investment_solution[investment],
+            rtol=RELATIVE_TOLERANCE,
+        )
 
 
 def verify_study_update(study_path, expected_investment_solution):
     candidate_reader = CandidatesReader(
-        study_path / "user" / "expansion" / "candidates.ini")
+        study_path / "user" / "expansion" / "candidates.ini"
+    )
     for link in candidate_reader.get_link_list():
         candidate_name_list = candidate_reader.get_link_candidate(link)
-        already_installed_capacity = candidate_reader.get_candidate_already_install_capacity(
-            candidate_name_list[0])
-        already_installed_link_profile_array = candidate_reader.get_candidate_already_installed_link_profile_array(
-            study_path, candidate_name_list[0])
-        expected_link_capacity = already_installed_capacity * \
-            already_installed_link_profile_array
+        already_installed_capacity = (
+            candidate_reader.get_candidate_already_install_capacity(
+                candidate_name_list[0]
+            )
+        )
+        already_installed_link_profile_array = (
+            candidate_reader.get_candidate_already_installed_link_profile_array(
+                study_path, candidate_name_list[0]
+            )
+        )
+        expected_link_capacity = (
+            already_installed_capacity * already_installed_link_profile_array
+        )
 
         for candidate in candidate_name_list:
             investment = expected_investment_solution[candidate]
             link_profile_array = candidate_reader.get_candidate_link_profile_array(
-                study_path, candidate)
-            assert link_profile_array.shape == already_installed_link_profile_array.shape
+                study_path, candidate
+            )
+            assert (
+                link_profile_array.shape == already_installed_link_profile_array.shape
+            )
             expected_link_capacity += investment * link_profile_array
 
-        study_link = candidate_reader.get_link_antares_link_file(
-            study_path, link)
+        study_link = candidate_reader.get_link_antares_link_file(study_path, link)
         study_link_array = np.loadtxt(study_link, delimiter="\t")
         link_capacity = study_link_array[:, [0, 1]]
 
-        np.testing.assert_allclose(
-            link_capacity, expected_link_capacity, rtol=1e-4)
-    
+        np.testing.assert_allclose(link_capacity, expected_link_capacity, rtol=1e-4)
 
 
 ## TESTS ##
 long_parameters_names = "study_path, expected_values, expected_investment_solution"
 long_parameters_values = [
-        (
-            ALL_STUDIES_PATH / "xpansion-test-02",
-            {
-                "optimality_gap": -1.430511474609375e-06,
-                "investment_cost": 289923159.11118174,
-                "operational_cost": 1065480665.4781473,
-                "overall_cost": 1355403824.589329,
-                "relative_gap": -1.0554134853816003e-15,
-            },
-            {
-                "battery": 5.66e02,
-                "peak1": 6.0e02,
-                "peak2": 1.0e03,
-                "pv": 4.4267733994e02,
-                "semibase1": 6.0e02,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "xpansion-test-02-new",
-            {
-                "optimality_gap": 709.42435598373413,
-                "investment_cost": 256299462.08039832,
-                "operational_cost": 1067318031.6309935,
-                "overall_cost": 1323617493.7113919,
-                "relative_gap": 5.3597384391960929e-07,
-            },
-            {
-                "battery": 508.74183466608417,
-                "peak1": 800.0,
-                "peak2": 1000.0,
-                "pv": 447.28156522682048,
-                "semibase1": 0.0,
-                "semibase2": 200.0,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "xpansion-test-05-area-uppercase",
-            {
-                "optimality_gap": 558.44661593437195,
-                "investment_cost": 451995209.27069736,
-                "operational_cost": 1324857537.5020638,
-                "overall_cost": 1776852746.7727611,
-                "relative_gap": 3.1428975583298067e-07,
-            },
-            {
-                "elec_grid": 709.95027341942216,
-                "h2_grid": 600.01391420346658,
-                "p2g_marg_area1": 1125.0003565560044,
-                "p2g_marg_area2": 2000.0,
-            },
-        ),
-    ]
+    (
+        ALL_STUDIES_PATH / "xpansion-test-02",
+        {
+            "optimality_gap": -1.430511474609375e-06,
+            "investment_cost": 289923159.11118174,
+            "operational_cost": 1065480665.4781473,
+            "overall_cost": 1355403824.589329,
+            "relative_gap": -1.0554134853816003e-15,
+        },
+        {
+            "battery": 5.66e02,
+            "peak1": 6.0e02,
+            "peak2": 1.0e03,
+            "pv": 4.4267733994e02,
+            "semibase1": 6.0e02,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "xpansion-test-02-new",
+        {
+            "optimality_gap": 709.42435598373413,
+            "investment_cost": 256299462.08039832,
+            "operational_cost": 1067318031.6309935,
+            "overall_cost": 1323617493.7113919,
+            "relative_gap": 5.3597384391960929e-07,
+        },
+        {
+            "battery": 508.74183466608417,
+            "peak1": 800.0,
+            "peak2": 1000.0,
+            "pv": 447.28156522682048,
+            "semibase1": 0.0,
+            "semibase2": 200.0,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "xpansion-test-05-area-uppercase",
+        {
+            "optimality_gap": 558.44661593437195,
+            "investment_cost": 451995209.27069736,
+            "operational_cost": 1324857537.5020638,
+            "overall_cost": 1776852746.7727611,
+            "relative_gap": 3.1428975583298067e-07,
+        },
+        {
+            "elec_grid": 709.95027341942216,
+            "h2_grid": 600.01391420346658,
+            "p2g_marg_area1": 1125.0003565560044,
+            "p2g_marg_area2": 2000.0,
+        },
+    ),
+]
 
-@pytest.mark.parametrize(long_parameters_names, long_parameters_values, )
+
+@pytest.mark.parametrize(
+    long_parameters_names,
+    long_parameters_values,
+)
 @pytest.mark.long_sequential
-def test_full_study_long_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_long_sequential(
+    install_dir, study_path, expected_values, expected_investment_solution
+):
     tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "sequential")
     verify_solution(study_path, expected_values, expected_investment_solution)
@@ -199,9 +246,14 @@ def test_full_study_long_sequential(install_dir, study_path, expected_values, ex
     restore_links(study_path, tmp_links_path)
 
 
-@pytest.mark.parametrize(long_parameters_names, long_parameters_values, )
+@pytest.mark.parametrize(
+    long_parameters_names,
+    long_parameters_values,
+)
 @pytest.mark.long_mpi
-def test_full_study_long_mpi(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_long_mpi(
+    install_dir, study_path, expected_values, expected_investment_solution
+):
     tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "mpibenders")
     verify_solution(study_path, expected_values, expected_investment_solution)
@@ -212,169 +264,174 @@ def test_full_study_long_mpi(install_dir, study_path, expected_values, expected_
 
 medium_parameters_names = "study_path, expected_values, expected_investment_solution"
 medium_parameters_values = [
-        (
-            ALL_STUDIES_PATH / "xpansion-test-01",
-            {
-                "optimality_gap": 3.0517578125e-05,
-                "investment_cost": 224600000.00003052,
-                "operational_cost": 22513655727.899261,
-                "overall_cost": 22738255727.899292,
-                "relative_gap": 1.3421248529435642e-15,
-            },
-            {
-                "battery": 1.0e03,
-                "peak": 1.4e03,
-                "pv": 1.0e03,
-                "semibase": 2.0e02,
-                "transmission_line": 0.0,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "xpansion-test-03",
-            {
-                "optimality_gap": -1.1920928955078125e-06,
-                "investment_cost": 201999999.99999976,
-                "operational_cost": 1161894495.7433052,
-                "overall_cost": 1363894495.743305,
-                "relative_gap": -8.7403600441846301e-16,
-            },
-            {"peak": 2500.0, "transmission_line": 1600.0, "semibase": 400.0},
-        ),
-        (
-            ALL_STUDIES_PATH / "xpansion-test-04-mps-rounding",
-            {
-                "optimality_gap": -1.1444091796875e-05,
-                "investment_cost": 115399999.99999619,
-                "operational_cost": 21942458064.791809,
-                "overall_cost": 22057858064.791805,
-                "relative_gap": -5.1882153576560404e-16,
-            },
-            {
-                "battery": 1000.0000000000124,
-                "peak": 0.0,
-                "pv": 1000.0,
-                "semibase": 0.0,
-                "transmission_line": 0.0,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "xpansion-test-01-weights",
-            {
-                "optimality_gap": -3.814697265625e-06,
-                "investment_cost": 230600000.00001144,
-                "operational_cost": 24001577891.450439,
-                "overall_cost": 24232177891.450451,
-                "relative_gap": -1.5742279883851852e-16,
-            },
-            {
-                "battery": 1000.0,
-                "peak": 1500.0,
-                "pv": 1000.0,
-                "semibase": 200.0,
-                "transmission_line": 0.0,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "xpansion-test-one-link-two-candidates",
-            {
-                "optimality_gap": -1.9073486328125e-06,
-                "investment_cost": 15999999.999994278,
-                "operational_cost": 11800333780.786646,
-                "overall_cost": 11816333780.78664,
-                "relative_gap": -1.6141627921122616e-16,
-            },
-            {"transmission_line": 800.0, "transmission_line_2": 800.0},
-        ),
-        (
-            ALL_STUDIES_PATH / "xpansion-test-01-hurdles-cost",
-            {
-                "optimality_gap": -7.62939453125e-06,
-                "investment_cost": 224599999.99996948,
-                "operational_cost": 22516674015.060184,
-                "overall_cost": 22741274015.060154,
-                "relative_gap": -3.3548668057020544e-16,
-            },
-            {
-                "battery": 1.0e03,
-                "peak": 1.4e03,
-                "pv": 1.0e03,
-                "semibase": 2.0e02,
-                "transmission_line": 0.0,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "additionnal-constraints",
-            {
-                "optimality_gap": 3.0517578125e-05,
-                "investment_cost": 224600000.00003052,
-                "operational_cost": 22513655727.899261,
-                "overall_cost": 22738255727.899292,
-                "relative_gap": 1.3421248529435642e-15,
-            },
-            {
-                "battery": 1.0e03,
-                "peak": 1.4e03,
-                "pv": 1.0e03,
-                "semibase": 2.0e02,
-                "transmission_line": 0.0,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "additionnal-constraints-binary",
-            {
-                "optimality_gap": -7.62939453125e-06,
-                "investment_cost": 220499999.99999809,
-                "operational_cost": 13501512886.702877,
-                "overall_cost": 13722012886.702875,
-                "relative_gap": -5.5599674728794044e-16,
-            },
-            {
-                "battery": 885,
-                "peak": 1800,
-                "pv": 1.0e03,
-                "semibase": 0.0,
-                "transmission_line": 400.0,
-            },
-        ),
-        (
-            ALL_STUDIES_PATH / "hurdles-cost-profile-value-over-one",
-            {
-                "optimality_gap": 239316.41654706001,
-                "investment_cost": 231999999.99999976,
-                "operational_cost": 1089603112.1225781,
-                "overall_cost": 1321603112.1225779,
-                "relative_gap": 0.00018108039724778097,
-            },
-            {"peak": 1300.0, "semibase": 1600.0, "transmission_line": 1000.0},
-        ),
-        (
-            ALL_STUDIES_PATH / "link-profile-with-empty-week",
-            {
-                "optimality_gap": -7.62939453125e-06,
-                "investment_cost": 27585000000.000004,
-                "operational_cost": 10629896636.069275,
-                "overall_cost": 38214896636.069275,
-                "relative_gap": -1.9964451569519531e-16,
-            },
-            {"base": 51150.0, "pointe": 33500, "semibase_winter": 0.0},
-        ),
-        (
-            ALL_STUDIES_PATH / "empty-link-profile",
-            {
-                "optimality_gap": -0.0001373291015625,
-                "investment_cost": 27584999999.999992,
-                "operational_cost": 10629896636.069145,
-                "overall_cost": 38214896636.069138,
-                "relative_gap": -3.5936012825135282e-15,
-            },
-            {"base": 51150.0, "pointe": 33500, "semibase_empty": 0.0},
-        ),
-    ]
+    (
+        ALL_STUDIES_PATH / "xpansion-test-01",
+        {
+            "optimality_gap": 3.0517578125e-05,
+            "investment_cost": 224600000.00003052,
+            "operational_cost": 22513655727.899261,
+            "overall_cost": 22738255727.899292,
+            "relative_gap": 1.3421248529435642e-15,
+        },
+        {
+            "battery": 1.0e03,
+            "peak": 1.4e03,
+            "pv": 1.0e03,
+            "semibase": 2.0e02,
+            "transmission_line": 0.0,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "xpansion-test-03",
+        {
+            "optimality_gap": -1.1920928955078125e-06,
+            "investment_cost": 201999999.99999976,
+            "operational_cost": 1161894495.7433052,
+            "overall_cost": 1363894495.743305,
+            "relative_gap": -8.7403600441846301e-16,
+        },
+        {"peak": 2500.0, "transmission_line": 1600.0, "semibase": 400.0},
+    ),
+    (
+        ALL_STUDIES_PATH / "xpansion-test-04-mps-rounding",
+        {
+            "optimality_gap": -1.1444091796875e-05,
+            "investment_cost": 115399999.99999619,
+            "operational_cost": 21942458064.791809,
+            "overall_cost": 22057858064.791805,
+            "relative_gap": -5.1882153576560404e-16,
+        },
+        {
+            "battery": 1000.0000000000124,
+            "peak": 0.0,
+            "pv": 1000.0,
+            "semibase": 0.0,
+            "transmission_line": 0.0,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "xpansion-test-01-weights",
+        {
+            "optimality_gap": -3.814697265625e-06,
+            "investment_cost": 230600000.00001144,
+            "operational_cost": 24001577891.450439,
+            "overall_cost": 24232177891.450451,
+            "relative_gap": -1.5742279883851852e-16,
+        },
+        {
+            "battery": 1000.0,
+            "peak": 1500.0,
+            "pv": 1000.0,
+            "semibase": 200.0,
+            "transmission_line": 0.0,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "xpansion-test-one-link-two-candidates",
+        {
+            "optimality_gap": -1.9073486328125e-06,
+            "investment_cost": 15999999.999994278,
+            "operational_cost": 11800333780.786646,
+            "overall_cost": 11816333780.78664,
+            "relative_gap": -1.6141627921122616e-16,
+        },
+        {"transmission_line": 800.0, "transmission_line_2": 800.0},
+    ),
+    (
+        ALL_STUDIES_PATH / "xpansion-test-01-hurdles-cost",
+        {
+            "optimality_gap": -7.62939453125e-06,
+            "investment_cost": 224599999.99996948,
+            "operational_cost": 22516674015.060184,
+            "overall_cost": 22741274015.060154,
+            "relative_gap": -3.3548668057020544e-16,
+        },
+        {
+            "battery": 1.0e03,
+            "peak": 1.4e03,
+            "pv": 1.0e03,
+            "semibase": 2.0e02,
+            "transmission_line": 0.0,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "additionnal-constraints",
+        {
+            "optimality_gap": 3.0517578125e-05,
+            "investment_cost": 224600000.00003052,
+            "operational_cost": 22513655727.899261,
+            "overall_cost": 22738255727.899292,
+            "relative_gap": 1.3421248529435642e-15,
+        },
+        {
+            "battery": 1.0e03,
+            "peak": 1.4e03,
+            "pv": 1.0e03,
+            "semibase": 2.0e02,
+            "transmission_line": 0.0,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "additionnal-constraints-binary",
+        {
+            "optimality_gap": -7.62939453125e-06,
+            "investment_cost": 220499999.99999809,
+            "operational_cost": 13501512886.702877,
+            "overall_cost": 13722012886.702875,
+            "relative_gap": -5.5599674728794044e-16,
+        },
+        {
+            "battery": 885,
+            "peak": 1800,
+            "pv": 1.0e03,
+            "semibase": 0.0,
+            "transmission_line": 400.0,
+        },
+    ),
+    (
+        ALL_STUDIES_PATH / "hurdles-cost-profile-value-over-one",
+        {
+            "optimality_gap": 239316.41654706001,
+            "investment_cost": 231999999.99999976,
+            "operational_cost": 1089603112.1225781,
+            "overall_cost": 1321603112.1225779,
+            "relative_gap": 0.00018108039724778097,
+        },
+        {"peak": 1300.0, "semibase": 1600.0, "transmission_line": 1000.0},
+    ),
+    (
+        ALL_STUDIES_PATH / "link-profile-with-empty-week",
+        {
+            "optimality_gap": -7.62939453125e-06,
+            "investment_cost": 27585000000.000004,
+            "operational_cost": 10629896636.069275,
+            "overall_cost": 38214896636.069275,
+            "relative_gap": -1.9964451569519531e-16,
+        },
+        {"base": 51150.0, "pointe": 33500, "semibase_winter": 0.0},
+    ),
+    (
+        ALL_STUDIES_PATH / "empty-link-profile",
+        {
+            "optimality_gap": -0.0001373291015625,
+            "investment_cost": 27584999999.999992,
+            "operational_cost": 10629896636.069145,
+            "overall_cost": 38214896636.069138,
+            "relative_gap": -3.5936012825135282e-15,
+        },
+        {"base": 51150.0, "pointe": 33500, "semibase_empty": 0.0},
+    ),
+]
 
 
-@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values, )
+@pytest.mark.parametrize(
+    medium_parameters_names,
+    medium_parameters_values,
+)
 @pytest.mark.medium_sequential
-def test_full_study_medium_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_medium_sequential(
+    install_dir, study_path, expected_values, expected_investment_solution
+):
     tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "sequential")
     verify_solution(study_path, expected_values, expected_investment_solution)
@@ -383,9 +440,14 @@ def test_full_study_medium_sequential(install_dir, study_path, expected_values, 
     restore_links(study_path, tmp_links_path)
 
 
-@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values, )
+@pytest.mark.parametrize(
+    medium_parameters_names,
+    medium_parameters_values,
+)
 @pytest.mark.medium_mpi
-def test_full_study_medium_parallel(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_medium_parallel(
+    install_dir, study_path, expected_values, expected_investment_solution
+):
     tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "mpibenders")
     verify_solution(study_path, expected_values, expected_investment_solution)

--- a/tests/end_to_end/examples/example_test.py
+++ b/tests/end_to_end/examples/example_test.py
@@ -30,6 +30,31 @@ def remove_outputs(study_path):
             if f.is_dir():
                 shutil.rmtree(f)
 
+def backup_links(study_path):
+    
+    input_path = os.path.join(study_path, "input")
+    links_path = os.path.join(input_path, "links")
+    tmp_links_path = os.path.join(input_path, "tmp_links")
+
+    if os.path.isdir(tmp_links_path):
+        shutil.rmtree(tmp_links_path)
+
+    shutil.copytree(links_path, tmp_links_path)
+    
+    return tmp_links_path
+
+
+def restore_links(study_path, tmp_links_path):
+    input_path = os.path.join(study_path, "input")
+    links_path = os.path.join(input_path, "links")
+
+    if os.path.isdir(links_path):
+        shutil.rmtree(links_path)
+    
+    shutil.copytree(tmp_links_path, links_path)
+    
+    if os.path.isdir(tmp_links_path):
+        shutil.rmtree(tmp_links_path)
 
 def launch_xpansion(install_dir, study_path, method):
     # Clean study output
@@ -163,22 +188,26 @@ long_parameters_values = [
         ),
     ]
 
-@pytest.mark.parametrize(long_parameters_names, long_parameters_values)
+@pytest.mark.parametrize(long_parameters_names, long_parameters_values, )
 @pytest.mark.long_sequential
-def verify_full_study_long_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_long_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+    tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "sequential")
     verify_solution(study_path, expected_values, expected_investment_solution)
     verify_study_update(study_path, expected_investment_solution)
     remove_outputs(study_path)
+    restore_links(study_path, tmp_links_path)
 
 
-@pytest.mark.parametrize(long_parameters_names, long_parameters_values)
+@pytest.mark.parametrize(long_parameters_names, long_parameters_values, )
 @pytest.mark.long_mpi
-def verify_full_study_long_mpi(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_long_mpi(install_dir, study_path, expected_values, expected_investment_solution):
+    tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "mpibenders")
     verify_solution(study_path, expected_values, expected_investment_solution)
     verify_study_update(study_path, expected_investment_solution)
     remove_outputs(study_path)
+    restore_links(study_path, tmp_links_path)
 
 
 medium_parameters_names = "study_path, expected_values, expected_investment_solution"
@@ -343,19 +372,23 @@ medium_parameters_values = [
     ]
 
 
-@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values)
+@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values, )
 @pytest.mark.medium_sequential
-def verify_full_study_medium_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_medium_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+    tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "sequential")
     verify_solution(study_path, expected_values, expected_investment_solution)
     verify_study_update(study_path, expected_investment_solution)
     remove_outputs(study_path)
+    restore_links(study_path, tmp_links_path)
 
 
-@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values)
+@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values, )
 @pytest.mark.medium_mpi
-def verify_full_study_medium_parallel(install_dir, study_path, expected_values, expected_investment_solution):
+def test_full_study_medium_parallel(install_dir, study_path, expected_values, expected_investment_solution):
+    tmp_links_path = backup_links(study_path)
     launch_xpansion(install_dir, study_path, "mpibenders")
     verify_solution(study_path, expected_values, expected_investment_solution)
     verify_study_update(study_path, expected_investment_solution)
     remove_outputs(study_path)
+    restore_links(study_path, tmp_links_path)

--- a/tests/end_to_end/examples/example_test.py
+++ b/tests/end_to_end/examples/example_test.py
@@ -59,7 +59,6 @@ def verify_solution(study_path, expected_values, expected_investment_solution):
     json_file.close()
 
     RELATIVE_TOLERANCE = 1e-4
-    ABSOLUTE_TOLERANCE = 0.1
 
     np.testing.assert_allclose(
         solution["investment_cost"], expected_values["investment_cost"], rtol=RELATIVE_TOLERANCE)
@@ -67,6 +66,10 @@ def verify_solution(study_path, expected_values, expected_investment_solution):
                                rtol=RELATIVE_TOLERANCE)
     np.testing.assert_allclose(
         solution["overall_cost"], expected_values["overall_cost"], rtol=RELATIVE_TOLERANCE)
+    np.testing.assert_allclose(
+        solution["optimality_gap"], expected_values["optimality_gap"], rtol=RELATIVE_TOLERANCE)
+    np.testing.assert_allclose(
+        solution["relative_gap"], expected_values["relative_gap"], rtol=RELATIVE_TOLERANCE)
 
     for investment in expected_investment_solution.keys():
         assert investment in investment_solution.keys(), "Investment " + investment + \
@@ -101,19 +104,12 @@ def verify_study_update(study_path, expected_investment_solution):
 
         np.testing.assert_allclose(
             link_capacity, expected_link_capacity, rtol=1e-4)
-
-
-def verify_full_study(install_dir, study_path, expected_values, expected_investment_solution, solver: str):
-    launch_xpansion(install_dir, study_path, solver)
-    verify_solution(study_path, expected_values, expected_investment_solution)
-    verify_study_update(study_path, expected_investment_solution)
-    remove_outputs(study_path)
+    
 
 
 ## TESTS ##
-@pytest.mark.parametrize(
-    "study_path, expected_values, expected_investment_solution",
-    [
+long_parameters_names = "study_path, expected_values, expected_investment_solution"
+long_parameters_values = [
         (
             ALL_STUDIES_PATH / "xpansion-test-02",
             {
@@ -165,91 +161,201 @@ def verify_full_study(install_dir, study_path, expected_values, expected_investm
                 "p2g_marg_area2": 2000.0,
             },
         ),
-    ],
-)
-@pytest.mark.long
-def test_full_study_long(install_dir, study_path, expected_values, expected_investment_solution):
-    verify_full_study(install_dir, study_path, expected_values,
-                      expected_investment_solution, "sequential")
-    verify_full_study(install_dir, study_path, expected_values,
-                      expected_investment_solution, "mpibenders")
+    ]
+
+@pytest.mark.parametrize(long_parameters_names, long_parameters_values)
+@pytest.mark.long_sequential
+def verify_full_study_long_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+    launch_xpansion(install_dir, study_path, "sequential")
+    verify_solution(study_path, expected_values, expected_investment_solution)
+    verify_study_update(study_path, expected_investment_solution)
+    remove_outputs(study_path)
+
+
+@pytest.mark.parametrize(long_parameters_names, long_parameters_values)
+@pytest.mark.long_mpi
+def verify_full_study_long_mpi(install_dir, study_path, expected_values, expected_investment_solution):
+    launch_xpansion(install_dir, study_path, "mpibenders")
+    verify_solution(study_path, expected_values, expected_investment_solution)
+    verify_study_update(study_path, expected_investment_solution)
+    remove_outputs(study_path)
 
 
 medium_parameters_names = "study_path, expected_values, expected_investment_solution"
-medium_paramters_values = [
-    (ALL_STUDIES_PATH / "xpansion-test-01",
-     {"gap": -1.1444091796875e-05, "investment_cost": 224599999.99999237,
-      "operational_cost": 22513656189.121899, "overall_cost": 22738256189.121891},
-     {"battery": 1.0e+03, "peak": 1.4e+03, "pv": 1.0e+03,
-         "semibase": 2.0e+02, "transmission_line": 0.0}
-     ),
-    (ALL_STUDIES_PATH / "xpansion-test-03",
-     {"gap": -1.1920928955078125e-06, "investment_cost": 201999999.99999976, "operational_cost": 1161894495.7433052,
-      "overall_cost": 1363894495.743305},
-     {"peak": 2500.0, "transmission_line": 1600.0, "semibase": 400.0}
-     ),
-    (ALL_STUDIES_PATH / "xpansion-test-04-mps-rounding",
-     {"gap": -0.000560760498046875, "investment_cost": 115399999.99998856, "operational_cost": 21942457893.943958,
-      "overall_cost": 22057857893.943947},
-     {"battery": 1000.0000000000124, "peak": 0.0, "pv": 1000.0,
-         "semibase": 0.0, "transmission_line": 0.0}
-     ),
-    (ALL_STUDIES_PATH / "xpansion-test-01-weights",
-     {"gap": 3.814697265625e-06, "investment_cost": 230600000.00002289, "operational_cost": 24001577891.450424,
-      "overall_cost": 24232177891.450447},
-     {"battery": 1000.0, "peak": 1500.0, "pv": 1000.0,
-         "semibase": 200.0, "transmission_line": 0.0}
-     ),
-    (ALL_STUDIES_PATH / "xpansion-test-one-link-two-candidates",
-     {"gap": -1.9073486328125e-06, "investment_cost": 15999999.999994278, "operational_cost": 11800333780.786646,
-      "overall_cost": 11816333780.78664},
-     {"transmission_line": 800.0, "transmission_line_2": 800.0}
-     ),
-    (ALL_STUDIES_PATH / "xpansion-test-01-hurdles-cost",
-     {"gap": -7.62939453125e-06, "investment_cost": 224599999.99996948,
-      "operational_cost": 22516674015.060184, "overall_cost": 22741274015.060154},
-     {"battery": 1.0e+03, "peak": 1.4e+03, "pv": 1.0e+03,
-         "semibase": 2.0e+02, "transmission_line": 0.0}
-     ),
-    (ALL_STUDIES_PATH / "additionnal-constraints",
-     {"gap": 3.0517578125e-05, "investment_cost": 224600000.00003052,
-      "operational_cost": 22513655727.899261, "overall_cost": 22738255727.899292},
-     {"battery": 1.0e+03, "peak": 1.4e+03, "pv": 1.0e+03,
-         "semibase": 2.0e+02, "transmission_line": 0.0}
-     ),
-    (ALL_STUDIES_PATH / "additionnal-constraints-binary",
-     {"gap": -7.62939453125e-06, "investment_cost": 220499999.99999809,
-      "operational_cost": 13501512886.702877, "overall_cost": 13722012886.702875},
-     {"battery": 885, "peak": 1800, "pv": 1.0e+03,
-         "semibase": 0.0, "transmission_line": 400.0}
-     ),
-    (ALL_STUDIES_PATH / "hurdles-cost-profile-value-over-one",
-     {"gap": 239316.41654706001, "investment_cost": 231999999.99999976,
-      "operational_cost": 1089603112.1225781, "overall_cost": 1321603112.1225779},
-     {"peak": 1300.0, "semibase": 1600.0, "transmission_line": 1000.0}
-     ),
-    (ALL_STUDIES_PATH / "link-profile-with-empty-week",
-     {"gap": 0.00983428955078125, "investment_cost": 27585000000.000111,
-      "operational_cost": 10629896636.068903, "overall_cost": 38214896636.069016},
-     {"base": 51150.0, "pointe": 33500, "semibase_winter": 0.0}
-     ),
-    (ALL_STUDIES_PATH / "empty-link-profile",
-     {"gap": 0.0098419189453125, "investment_cost": 27585000000.000114,
-      "operational_cost": 10629896636.068903, "overall_cost": 38214896636.069016},
-     {"base": 51150.0, "pointe": 33500, "semibase_empty": 0.0}
-     )
-]
+medium_parameters_values = [
+        (
+            ALL_STUDIES_PATH / "xpansion-test-01",
+            {
+                "optimality_gap": 3.0517578125e-05,
+                "investment_cost": 224600000.00003052,
+                "operational_cost": 22513655727.899261,
+                "overall_cost": 22738255727.899292,
+                "relative_gap": 1.3421248529435642e-15,
+            },
+            {
+                "battery": 1.0e03,
+                "peak": 1.4e03,
+                "pv": 1.0e03,
+                "semibase": 2.0e02,
+                "transmission_line": 0.0,
+            },
+        ),
+        (
+            ALL_STUDIES_PATH / "xpansion-test-03",
+            {
+                "optimality_gap": -1.1920928955078125e-06,
+                "investment_cost": 201999999.99999976,
+                "operational_cost": 1161894495.7433052,
+                "overall_cost": 1363894495.743305,
+                "relative_gap": -8.7403600441846301e-16,
+            },
+            {"peak": 2500.0, "transmission_line": 1600.0, "semibase": 400.0},
+        ),
+        (
+            ALL_STUDIES_PATH / "xpansion-test-04-mps-rounding",
+            {
+                "optimality_gap": -1.1444091796875e-05,
+                "investment_cost": 115399999.99999619,
+                "operational_cost": 21942458064.791809,
+                "overall_cost": 22057858064.791805,
+                "relative_gap": -5.1882153576560404e-16,
+            },
+            {
+                "battery": 1000.0000000000124,
+                "peak": 0.0,
+                "pv": 1000.0,
+                "semibase": 0.0,
+                "transmission_line": 0.0,
+            },
+        ),
+        (
+            ALL_STUDIES_PATH / "xpansion-test-01-weights",
+            {
+                "optimality_gap": -3.814697265625e-06,
+                "investment_cost": 230600000.00001144,
+                "operational_cost": 24001577891.450439,
+                "overall_cost": 24232177891.450451,
+                "relative_gap": -1.5742279883851852e-16,
+            },
+            {
+                "battery": 1000.0,
+                "peak": 1500.0,
+                "pv": 1000.0,
+                "semibase": 200.0,
+                "transmission_line": 0.0,
+            },
+        ),
+        (
+            ALL_STUDIES_PATH / "xpansion-test-one-link-two-candidates",
+            {
+                "optimality_gap": -1.9073486328125e-06,
+                "investment_cost": 15999999.999994278,
+                "operational_cost": 11800333780.786646,
+                "overall_cost": 11816333780.78664,
+                "relative_gap": -1.6141627921122616e-16,
+            },
+            {"transmission_line": 800.0, "transmission_line_2": 800.0},
+        ),
+        (
+            ALL_STUDIES_PATH / "xpansion-test-01-hurdles-cost",
+            {
+                "optimality_gap": -7.62939453125e-06,
+                "investment_cost": 224599999.99996948,
+                "operational_cost": 22516674015.060184,
+                "overall_cost": 22741274015.060154,
+                "relative_gap": -3.3548668057020544e-16,
+            },
+            {
+                "battery": 1.0e03,
+                "peak": 1.4e03,
+                "pv": 1.0e03,
+                "semibase": 2.0e02,
+                "transmission_line": 0.0,
+            },
+        ),
+        (
+            ALL_STUDIES_PATH / "additionnal-constraints",
+            {
+                "optimality_gap": 3.0517578125e-05,
+                "investment_cost": 224600000.00003052,
+                "operational_cost": 22513655727.899261,
+                "overall_cost": 22738255727.899292,
+                "relative_gap": 1.3421248529435642e-15,
+            },
+            {
+                "battery": 1.0e03,
+                "peak": 1.4e03,
+                "pv": 1.0e03,
+                "semibase": 2.0e02,
+                "transmission_line": 0.0,
+            },
+        ),
+        (
+            ALL_STUDIES_PATH / "additionnal-constraints-binary",
+            {
+                "optimality_gap": -7.62939453125e-06,
+                "investment_cost": 220499999.99999809,
+                "operational_cost": 13501512886.702877,
+                "overall_cost": 13722012886.702875,
+                "relative_gap": -5.5599674728794044e-16,
+            },
+            {
+                "battery": 885,
+                "peak": 1800,
+                "pv": 1.0e03,
+                "semibase": 0.0,
+                "transmission_line": 400.0,
+            },
+        ),
+        (
+            ALL_STUDIES_PATH / "hurdles-cost-profile-value-over-one",
+            {
+                "optimality_gap": 239316.41654706001,
+                "investment_cost": 231999999.99999976,
+                "operational_cost": 1089603112.1225781,
+                "overall_cost": 1321603112.1225779,
+                "relative_gap": 0.00018108039724778097,
+            },
+            {"peak": 1300.0, "semibase": 1600.0, "transmission_line": 1000.0},
+        ),
+        (
+            ALL_STUDIES_PATH / "link-profile-with-empty-week",
+            {
+                "optimality_gap": -7.62939453125e-06,
+                "investment_cost": 27585000000.000004,
+                "operational_cost": 10629896636.069275,
+                "overall_cost": 38214896636.069275,
+                "relative_gap": -1.9964451569519531e-16,
+            },
+            {"base": 51150.0, "pointe": 33500, "semibase_winter": 0.0},
+        ),
+        (
+            ALL_STUDIES_PATH / "empty-link-profile",
+            {
+                "optimality_gap": -0.0001373291015625,
+                "investment_cost": 27584999999.999992,
+                "operational_cost": 10629896636.069145,
+                "overall_cost": 38214896636.069138,
+                "relative_gap": -3.5936012825135282e-15,
+            },
+            {"base": 51150.0, "pointe": 33500, "semibase_empty": 0.0},
+        ),
+    ]
 
 
-@pytest.mark.parametrize(medium_parameters_names, medium_paramters_values, )
+@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values)
 @pytest.mark.medium_sequential
-def test_full_study_medium_sequential(install_dir, study_path, expected_values, expected_investment_solution):
-    verify_full_study(install_dir, study_path, expected_values,
-                      expected_investment_solution, "sequential")
+def verify_full_study_medium_sequential(install_dir, study_path, expected_values, expected_investment_solution):
+    launch_xpansion(install_dir, study_path, "sequential")
+    verify_solution(study_path, expected_values, expected_investment_solution)
+    verify_study_update(study_path, expected_investment_solution)
+    remove_outputs(study_path)
 
 
-@pytest.mark.parametrize(medium_parameters_names, medium_paramters_values, )
+@pytest.mark.parametrize(medium_parameters_names, medium_parameters_values)
 @pytest.mark.medium_mpi
-def test_full_study_medium_parallel(install_dir, study_path, expected_values, expected_investment_solution):
-    verify_full_study(install_dir, study_path, expected_values,
-                      expected_investment_solution, "mpibenders")
+def verify_full_study_medium_parallel(install_dir, study_path, expected_values, expected_investment_solution):
+    launch_xpansion(install_dir, study_path, "mpibenders")
+    verify_solution(study_path, expected_values, expected_investment_solution)
+    verify_study_update(study_path, expected_investment_solution)
+    remove_outputs(study_path)

--- a/tests/end_to_end/examples/pytest.ini
+++ b/tests/end_to_end/examples/pytest.ini
@@ -2,5 +2,7 @@
 [pytest]
 markers =
     short: mark a test as short
-    medium: mark a test as medium
-    long: mark a test as long
+    medium_sequential: mark a test as non-parallel medium
+    medium_mpi: mark a test as parallel medium
+    long_sequential: mark a test as non-parallel long
+    long_mpi: mark a test as parallel long


### PR DESCRIPTION
- Split long tests in sequential and mpi in the same way as medium tests
- Restore the Antares study in its initial state after running the tests
- Check that `optimality_gap` and `relative_gap` match the expected values
- Restore the expected values introduced in PR #291 that were overwritten when merging PR #284 

This PR closes #300 