### PR TITLE
remove xpress uncontrolled stdout

### DIFF
--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -18,11 +18,10 @@ SolverXpress::SolverXpress() {
 	_NumberOfProblems += 1;
 
 	_xprs = NULL;
-	_stream.push_back(&std::cout);
 }
 
 SolverXpress::SolverXpress(const SolverAbstract::Ptr toCopy) : SolverXpress() {
-	init();
+    SolverXpress::init();
 	int status = 0;
 
 	// Try to cast the solver in fictif to a SolverCPLEX
@@ -33,14 +32,14 @@ SolverXpress::SolverXpress(const SolverAbstract::Ptr toCopy) : SolverXpress() {
 	}
 	else {
 		_NumberOfProblems -= 1;
-		free();
+        SolverXpress::free();
         throw InvalidSolverForCopyException(toCopy->get_solver_name(),get_solver_name());
 	}
 }
 
 SolverXpress::~SolverXpress() {
 	_NumberOfProblems -= 1;
-	free();
+    SolverXpress::free();
 
 	if (_NumberOfProblems == 0) {
 		int status = XPRSfree();
@@ -477,7 +476,7 @@ void SolverXpress::set_simplex_iter(int iter){
 	zero_status_check(status, "set simplex max iter");
 }
 
-void XPRS_CC optimizermsg(XPRSprob prob, void* strPtr, const char* sMsg, int nLen,
+const void XPRS_CC optimizermsg(XPRSprob prob, void* strPtr, const char* sMsg, int nLen,
 	int nMsglvl) {
 	std::list<std::ostream* >* ptr = NULL;
 	if (strPtr != NULL)ptr = (std::list<std::ostream* >*)strPtr;

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -33,7 +33,7 @@ SolverXpress::SolverXpress(const SolverAbstract::Ptr toCopy) : SolverXpress() {
 	else {
 		_NumberOfProblems -= 1;
         SolverXpress::free();
-        throw InvalidSolverForCopyException(toCopy->get_solver_name(),get_solver_name());
+        throw InvalidSolverForCopyException(toCopy->get_solver_name(),SolverXpress::get_solver_name());
 	}
 }
 
@@ -63,6 +63,7 @@ void SolverXpress::init() {
 	int status = XPRScreateprob(&_xprs);
 	zero_status_check(status, "create XPRESS problem");
 
+    SolverXpress::set_output_log_level(0);
 	status = XPRSloadlp(_xprs, "empty", 0, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 	zero_status_check(status, "generate empty prob in XPRS interface init method");
 }


### PR DESCRIPTION
Tis fix aims to remove the stop Xpress from printing log information on the tdout that concern the reading phase of empty problems.
This fix does remove several prints of this type that precede the messages that `benders`writes for the user
```
Reading Problem empty
Problem Statistics
           0 (      0 spare) rows
           0 (      0 spare) structural columns
           0 (      0 spare) non-zero elements
Global Statistics
           0 entities        0 sets        0 set members

```

This fix does not look for a solution for the solvers logs.
A separate issue should be created