### PR TITLE
any whitespace is a separator

### DIFF
--- a/src/python/antares_xpansion/input_checker.py
+++ b/src/python/antares_xpansion/input_checker.py
@@ -26,14 +26,14 @@ def check_profile_file(filename_path):
 
     two_profiles = False
     with open(filename_path, 'r') as profile_file:
-        two_profiles = (len(profile_file.readline().strip().split("\t")) == 2)
+        two_profiles = (len(profile_file.readline().strip().split()) == 2)
 
     with open(filename_path, 'r') as profile_file:
         first_profile = []
         indirect_profile = []
         for idx, line in enumerate(profile_file):
             try:
-                line_vals = line.strip().split("\t")
+                line_vals = line.strip().split()
 
                 if (len(line_vals) == 1) and not two_profiles:
                     first_profile.append(float(line_vals[0]))


### PR DESCRIPTION
Closes #115 
- allow any whitespace as separator in link-profiles
