### PR TITLE
Make absence of numpy/pytest fatal

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,7 +78,7 @@ if (PYTHON_MODULE_pytest_FOUND AND PYTHON_MODULE_numpy_FOUND)
     set_property(TEST lpnamer_end_to_end PROPERTY LABELS lpnamer)
 
 else()   
-  message(FATAL "Module pytest or numpy not installed : can't run python scripts for end to end tests" )
+  message(FATAL_ERROR "Module pytest or numpy not installed : can't run python scripts for end to end tests" )
 endif()
 
 add_subdirectory(cpp)


### PR DESCRIPTION
- `message(FATAL "something")` prints "FATALsomething" and continues
- `message(FATAL_ERROR "something")` prints "something" and triggers an exit with error 1.

With `FATAL`, the tests may be silently ignored by the CI if pytest/numpy are not properly installed, which is probably not the intended behavior.