### PR TITLE
fix crash when weight file and non-contiguos-playlist are used at the same time

### DIFF
--- a/src/python/antares_xpansion/config_loader.py
+++ b/src/python/antares_xpansion/config_loader.py
@@ -33,8 +33,8 @@ class ConfigLoader:
         self.candidates_list = []
         self._verify_settings_ini_file_exists()
 
-        self.nb_active_years = GeneralDataIniReader(
-            Path(self.general_data())).get_nb_activated_year()
+        self.active_years = GeneralDataIniReader(
+            Path(self.general_data())).get_active_years()
 
         self.options = self._get_options_from_settings_inifile()
 
@@ -239,7 +239,7 @@ class ConfigLoader:
         """
         # computing the weight of slaves
         options_values = self._config.options_default
-        options_values["SLAVE_WEIGHT_VALUE"] = str(self.nb_active_years)
+        options_values["SLAVE_WEIGHT_VALUE"] = str(len(self.active_years))
         options_values["JSON_FILE"] = self.json_file_path()
         options_values["ABSOLUTE_GAP"] = self.get_absolute_optimality_gap()
         options_values["RELATIVE_GAP"] = self.get_relative_optimality_gap()

--- a/src/python/antares_xpansion/driver.py
+++ b/src/python/antares_xpansion/driver.py
@@ -37,7 +37,7 @@ class XpansionDriver:
                                                                                     user_weights_file_path=self.config_loader.weights_file_path(),
                                                                                     weight_file_name_for_lp=self.config_loader.weight_file_name(),
                                                                                     lp_namer_exe_path=self.config_loader.lp_namer_exe(),
-                                                                                    nb_active_years=self.config_loader.nb_active_years
+                                                                                    active_years=self.config_loader.active_years
                                                                                     ))
 
         self.benders_driver = BendersDriver(
@@ -101,7 +101,7 @@ class XpansionDriver:
 
     def launch_benders_step(self):
         self.config_loader.benders_pre_actions()
-        if(self.config_loader.log_level() > 0):
+        if self.config_loader.log_level() > 0:
             self.benders_driver.set_benders_log_file(self.config_loader.benders_log_file())
         self.benders_driver.launch(
             self.config_loader.simulation_output_path(),

--- a/src/python/antares_xpansion/general_data_reader.py
+++ b/src/python/antares_xpansion/general_data_reader.py
@@ -35,6 +35,7 @@ class GeneralDataIniReader:
         self.file_lines = open(file_path, 'r').readlines()
 
         self._mc_years: int = int(self.config["general"]["nbyears"])
+        self._user_playlist = str(self.config["general"]["user-playlist"])
         self._playlist_reset_option: bool = True
         self._active_year_list: List[int] = []
         self._inactive_year_list: List[int] = []
@@ -42,10 +43,34 @@ class GeneralDataIniReader:
     def get_nb_years(self) -> int:
         return self._mc_years
 
-    def get_nb_activated_year(self):
-        self._set_playlist_reset_option()
-        self._set_playlist_year_lists()
-        return self._compute_nb_activated_years()
+    def get_active_years(self):
+
+        if self._user_playlist == "true":
+            self._set_playlist_reset_option()
+            self._set_playlist_year_lists()
+            return self._get_active_years()
+        else:
+            return list(range(1, self._mc_years+1))
+
+    def _get_active_years(self):
+        if self._playlist_reset_option is True:
+            return self._active_years_from_inactive_list()
+        else:
+            return self._active_years_from_active_list()
+
+    def _active_years_from_active_list(self):
+        active_years = []
+        for year in range(self._mc_years):
+            if year in self._active_year_list:
+                active_years.append(year+1)
+        return active_years
+
+    def _active_years_from_inactive_list(self):
+        active_years = []
+        for year in range(self._mc_years):
+            if year not in self._inactive_year_list:
+                active_years.append(year+1)
+        return active_years
 
     def _set_playlist_reset_option(self):
         # Default : all mc years are activated
@@ -73,24 +98,4 @@ class GeneralDataIniReader:
         elif key == 'playlist_year -':
             self._inactive_year_list.append(int(val))
 
-    def _compute_nb_activated_years(self) -> int:
-        if self._playlist_reset_option:
-            nb_activated_year = self._count_years_from_inactive_years_list()
-        else:
-            nb_activated_year = self._count_years_from_active_years_list()
-        return nb_activated_year
-
-    def _count_years_from_active_years_list(self):
-        nb_activated_year = 0
-        for active_year in self._active_year_list:
-            if int(active_year) < self._mc_years:
-                nb_activated_year += 1
-        return nb_activated_year
-
-    def _count_years_from_inactive_years_list(self):
-        nb_activated_year = self._mc_years
-        for inactive_year in self._inactive_year_list:
-            if int(inactive_year) < self._mc_years:
-                nb_activated_year -= 1
-        return nb_activated_year
 

--- a/src/python/antares_xpansion/problem_generator_driver.py
+++ b/src/python/antares_xpansion/problem_generator_driver.py
@@ -5,6 +5,8 @@
 import shutil
 import os
 import subprocess
+from typing import List
+
 import sys
 from datetime import datetime
 from dataclasses import dataclass
@@ -23,14 +25,14 @@ class ProblemGeneratorData:
     additional_constraints: str
     user_weights_file_path: Path
     weight_file_name_for_lp: str
-    lp_namer_exe_path : Path
-    nb_active_years: int
+    lp_namer_exe_path: Path
+    active_years: List
 
 
 class ProblemGeneratorDriver:
-
     class BasicException(Exception):
         pass
+
     class AreaFileException(BasicException):
         pass
 
@@ -49,7 +51,6 @@ class ProblemGeneratorDriver:
     class LPNamerExecutionError(BasicException):
         pass
 
-
     def __init__(self, problem_generator_data: ProblemGeneratorData) -> None:
 
         self.lp_namer_exe_path = Path(problem_generator_data.lp_namer_exe_path)
@@ -58,7 +59,7 @@ class ProblemGeneratorDriver:
         self.additional_constraints = problem_generator_data.additional_constraints
         self.user_weights_file_path = problem_generator_data.user_weights_file_path
         self.weight_file_name_for_lp = problem_generator_data.weight_file_name_for_lp
-        self.nb_active_years = problem_generator_data.nb_active_years
+        self.active_years = problem_generator_data.active_years
         self.MPS_TXT = "mps.txt"
         self.is_relaxed = False
         self._lp_path = None
@@ -142,9 +143,10 @@ class ProblemGeneratorDriver:
         os.makedirs(self._lp_path)
 
         if self.weight_file_name_for_lp:
-            XpansionStudyReader.check_weights_file(self.user_weights_file_path, self.nb_active_years)
+            XpansionStudyReader.check_weights_file(self.user_weights_file_path, len(self.active_years))
             weight_list = XpansionStudyReader.get_years_weight_from_file(self.user_weights_file_path)
-            YearlyWeightWriter(Path(self.output_path)).create_weight_file(weight_list, self.weight_file_name_for_lp)
+            YearlyWeightWriter(Path(self.output_path)).create_weight_file(weight_list, self.weight_file_name_for_lp,
+                                                                          self.active_years)
 
         with open(self.get_lp_namer_log_filename(), 'w') as output_file:
 
@@ -175,6 +177,5 @@ class ProblemGeneratorDriver:
 
         return [self.lp_namer_exe_path, "-o", str(self.output_path), "-f", is_relaxed, "-e",
                 self.additional_constraints]
-
 
     output_path = property(get_output_path, set_output_path)

--- a/src/python/antares_xpansion/yearly_weight_writer.py
+++ b/src/python/antares_xpansion/yearly_weight_writer.py
@@ -16,22 +16,23 @@ class YearlyWeightWriter:
     def output_dir(self):
         return self.simulation_path / self.MPS_DIR
 
-    def create_weight_file(self, weight_list: List[float], file_name: str):
+    def create_weight_file(self, weight_list: List[float], file_name: str, active_years):
         self.file_content = []
-        self._add_mps_lines_with_weights_to_content(weight_list)
+        self._add_mps_lines_with_weights_to_content(weight_list, active_years)
         self._add_last_line_to_content(weight_list)
         self._write_content_to_file(file_name)
 
-    def _add_mps_lines_with_weights_to_content(self, weight_list):
+    def _add_mps_lines_with_weights_to_content(self, weight_list, active_years):
         sorted_dir = sorted(os.listdir(self.simulation_path))
-        for instance in sorted_dir:
-            if self._file_should_be_added(instance):
-                self._add_line_to_file_content(instance, weight_list)
+        for mps_file in sorted_dir:
+            if self._file_should_be_added(mps_file):
+                self._add_mps_file_to_output_file_content(mps_file, weight_list,  active_years)
 
-    def _add_line_to_file_content(self, file_name, weight_list):
+    def _add_mps_file_to_output_file_content(self, file_name, weight_list,  active_years):
         year = self._get_year_index_from_name(file_name)
+        year_index = active_years.index(int(year))
         mps_file_name = Path(file_name).with_suffix('').name
-        self.file_content.append(mps_file_name + " " + str(weight_list[year - 1]) + "\n")
+        self.file_content.append(mps_file_name + " " + str(weight_list[year_index]) + "\n")
 
     def _add_last_line_to_content(self, weight_list):
         self.file_content.append("WEIGHT_SUM " + str(sum(weight_list)))

--- a/tests/python/test_ini_reader.py
+++ b/tests/python/test_ini_reader.py
@@ -5,15 +5,12 @@ from antares_xpansion.general_data_reader import GeneralDataIniReader, IniFileNo
 
 class TestGetNbActivatedYear:
 
-    def _create_reader(self, tmp_path, content):
-        file_path = tmp_path / 'test.ini'
-        file_path.write_text(content)
-        self.ini_reader = GeneralDataIniReader(file_path)
-
     @staticmethod
-    def _create_nb_year_content(nb_years: int) -> str:
+    def _create_nb_year_content(nb_years: int, user_playlist: bool) -> str:
+        playlist = "true" if user_playlist else "false"
         content = "[general]\n" \
-                  f"nbyears = {nb_years}\n"
+                  f"nbyears = {nb_years}\n" \
+                  f"user-playlist = {playlist}\n"
         return content
 
     @staticmethod
@@ -44,38 +41,67 @@ class TestGetNbActivatedYear:
         "nb_years", [1, 12, 14],
     )
     def test_read_nb_years(self, tmp_path, nb_years: int):
-        content = self._create_nb_year_content(nb_years)
-        self._create_reader(tmp_path, content)
-        assert self.ini_reader.get_nb_years() == nb_years
+        content = self._create_nb_year_content(nb_years, True)
+        file_path = tmp_path / 'test.ini'
+        file_path.write_text(content)
+
+        ini_reader = GeneralDataIniReader(file_path)
+        assert ini_reader.get_nb_years() == nb_years
 
     @pytest.mark.parametrize(
         "nb_years", [1, 12, 14],
     )
     def test_read_nb_activated_year_no_playlist(self, tmp_path, nb_years):
-        content = self._create_nb_year_content(nb_years)
-        self._create_reader(tmp_path, content)
-        assert self.ini_reader.get_nb_activated_year() == nb_years
+        content = self._create_nb_year_content(nb_years, True)
+        file_path = tmp_path / 'test.ini'
+        file_path.write_text(content)
+
+        ini_reader = GeneralDataIniReader(file_path)
+        assert len(ini_reader.get_active_years()) == nb_years
 
     @pytest.mark.parametrize(
-        "nb_years, playlist_reset, active_years, inactive_years, nb_activated_years",
+        "nb_years, playlist_reset, add_years, remove_years, nb_activated_years, active_years",
         [
-            (12, False, [], [], 0),
-            (12, False, [6, 7], [], 2),
-            (12, False, [6, 7, 8], [], 3),
-            (12, False, [6, 7, 20], [], 2),
-            (12, False, [6, 7], [1, 5], 2),
-            (12, True, [], [], 12),
-            (12, True, [0, 4, 5, 6], [], 12),
-            (2, True, [0, 4, 5, 6, 40, 45, 50, 99], [], 2),
-            (12, True, [], [0, 5], 10),
-            (12, True, [], [0, 5, 15, 20], 10)
+            (2, False, [], [], 0, []),
+            (4, False, [2, 3], [], 2, [3, 4]),
+            (4, False, [2, 3, 4], [], 2, [3, 4]),
+            (4, False, [2, 3], [2, 3], 2, [3, 4]),
+            (2, True, [], [], 2, [1, 2]),
+            (2, True, [1, 4], [], 2, [1, 2]),
+            (4, True, [], [2, 4], 3, [1, 2, 4]),
         ],
     )
-    def test_read_nb_activated_year(self, tmp_path, nb_years, playlist_reset, active_years, inactive_years,
-                                    nb_activated_years):
-        content = self._create_nb_year_content(nb_years)
+    def test_read_nb_activated_year(self, tmp_path, nb_years, playlist_reset, add_years, remove_years,
+                                    nb_activated_years, active_years):
+        content = self._create_nb_year_content(nb_years, True)
         content += self._create_playlist_section(playlist_reset)
-        content += self._create_active_years_content(active_years)
-        content += self._create_inactive_years_content(inactive_years)
-        self._create_reader(tmp_path, content)
-        assert self.ini_reader.get_nb_activated_year() == nb_activated_years
+        content += self._create_active_years_content(add_years)
+        content += self._create_inactive_years_content(remove_years)
+        file_path = tmp_path / 'test.ini'
+        file_path.write_text(content)
+
+        ini_reader = GeneralDataIniReader(file_path)
+        assert ini_reader.get_active_years() == active_years
+
+    @pytest.mark.parametrize(
+        "nb_years, playlist_reset, add_years, remove_years, nb_activated_years, active_years",
+        [
+            (2, False, [], [], 2, [1, 2]),
+            (4, False, [2, 4], [], 4, [1, 2, 3, 4]),
+            (4, False, [2, 3], [2, 3], 4, [1, 2, 3, 4]),
+            (2, True, [], [], 2, [1, 2]),
+            (2, True, [1, 4], [], 2, [1, 2]),
+            (4, True, [], [2, 3], 2, [1, 2, 3, 4]),
+        ],
+    )
+    def test_active_years_is_unchanged_if_user_playlist_is_false(self, tmp_path, nb_years, playlist_reset, add_years, remove_years,
+                                    nb_activated_years, active_years):
+        content = self._create_nb_year_content(nb_years, False)
+        content += self._create_playlist_section(playlist_reset)
+        content += self._create_active_years_content(add_years)
+        content += self._create_inactive_years_content(remove_years)
+        file_path = tmp_path / 'test.ini'
+        file_path.write_text(content)
+
+        ini_reader = GeneralDataIniReader(file_path)
+        assert ini_reader.get_active_years() == active_years

--- a/tests/python/test_problem_generator_driver.py
+++ b/tests/python/test_problem_generator_driver.py
@@ -26,7 +26,7 @@ class TestProblemGeneratorDriver:
                                                         weight_file_name_for_lp="",
                                                         lp_namer_exe_path=Path(
                                                             ""),
-                                                        nb_active_years=0)
+                                                        active_years=[])
 
     def test_problem_generator_data(self):
 
@@ -80,7 +80,7 @@ class TestProblemGeneratorDriver:
         with pytest.raises(ProblemGeneratorDriver.IntercoFilesException):
             problem_generator_driver.launch(tmp_path, False)
 
-    def test_lp_namer_exe_not_exit(self, tmp_path):
+    def test_lp_namer_exe_does_not_exit(self, tmp_path):
 
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
@@ -132,7 +132,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=Path(""),
                                              weight_file_name_for_lp="",
                                              lp_namer_exe_path=lp_exe_file,
-                                             nb_active_years=1)
+                                             active_years=[])
 
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
@@ -148,7 +148,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=Path(""),
                                              weight_file_name_for_lp="",
                                              lp_namer_exe_path="",
-                                             nb_active_years=1)
+                                             active_years=[])
 
         problem_generator_driver = ProblemGeneratorDriver(pblm_gen_data)
         with pytest.raises(ProblemGeneratorDriver.LPNamerPathError):
@@ -163,7 +163,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=Path(""),
                                              weight_file_name_for_lp="",
                                              lp_namer_exe_path=lp_namer_file,
-                                             nb_active_years=1)
+                                             active_years=[])
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
 
@@ -188,7 +188,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=Path(""),
                                              weight_file_name_for_lp="",
                                              lp_namer_exe_path=lp_namer_file,
-                                             nb_active_years=1)
+                                             active_years=[])
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
 
@@ -200,12 +200,9 @@ class TestProblemGeneratorDriver:
         lp_dir.mkdir()
         lp_dir_sub_file_1 = lp_dir / "file1"
         lp_dir_sub_file_1.write_text("")
-        lp_dir_sub_file_2 = lp_dir / "file2"
-        lp_dir_sub_file_2.write_text("")
 
         assert lp_dir.exists()
         assert lp_dir_sub_file_1.exists()
-        assert lp_dir_sub_file_2.exists()
         problem_generator_driver = ProblemGeneratorDriver(pblm_gen_data)
         with patch(SUBPROCESS_RUN, autospec=True) as run_function:
             run_function.return_value.returncode = 0
@@ -213,7 +210,6 @@ class TestProblemGeneratorDriver:
 
         assert lp_dir.exists()
         assert not lp_dir_sub_file_1.exists()
-        assert not lp_dir_sub_file_2.exists()
 
     def test_weight_file_name_fails_if_file_does_not_exist(self, tmp_path):
 
@@ -225,7 +221,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=file_path,
                                              weight_file_name_for_lp=Path(""),
                                              lp_namer_exe_path=lp_namer_file,
-                                             nb_active_years=1)
+                                             active_years=[])
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
 
@@ -249,7 +245,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=file_path,
                                              weight_file_name_for_lp=weight_file_name,
                                              lp_namer_exe_path=lp_namer_file,
-                                             nb_active_years=2)
+                                             active_years=[])
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
 
@@ -273,7 +269,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=file_path,
                                              weight_file_name_for_lp=weight_file_name,
                                              lp_namer_exe_path=lp_namer_file,
-                                             nb_active_years=2)
+                                             active_years=[1, 2])
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
         expected_message = f'file {str(file_path)} : all values are null'
@@ -296,7 +292,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=file_path,
                                              weight_file_name_for_lp=weight_file_name,
                                              lp_namer_exe_path=lp_namer_file,
-                                             nb_active_years=5)
+                                             active_years=[1, 2, 3])
         self._create_empty_area_file(tmp_path)
         self._create_empty_interco_file(tmp_path)
         expected_message = f'file {str(file_path)} : invalid weight number : 4 values / 5 expected'
@@ -319,7 +315,7 @@ class TestProblemGeneratorDriver:
                                              user_weights_file_path=file_path,
                                              weight_file_name_for_lp=weight_file_name,
                                              lp_namer_exe_path=lp_namer_file,
-                                             nb_active_years=2)
+                                             active_years=[1, 2])
 
         list_generated_files = self._get_expected_mps_txt(tmp_path)
         mps_files = [week_files[0] for week_files in list_generated_files]
@@ -387,7 +383,7 @@ class TestProblemGeneratorDriver:
 
         what_time = hour + minute + second
         file_name = prefix + "-" + year + "-" + week + "-" + \
-            today_date + "-" + what_time + "." + extension
+                    today_date + "-" + what_time + "." + extension
         return file_name
 
     def _create_empty_area_file(self, tmp_path):
@@ -400,7 +396,7 @@ class TestProblemGeneratorDriver:
 
         TestProblemGeneratorDriver.number += 1
         fname = prefix + \
-            str(TestProblemGeneratorDriver.number) + "." + extension
+                str(TestProblemGeneratorDriver.number) + "." + extension
         file = tmp_path / fname
         file.write_text("")
 

--- a/tests/python/test_yearly_weigth_writer.py
+++ b/tests/python/test_yearly_weigth_writer.py
@@ -7,27 +7,25 @@ from file_creation import _create_weight_file, _create_empty_file_from_list
 def test_weight_file_write(tmp_path):
     input_weight_file_name = "weight_file"
     file_path: Path = tmp_path / input_weight_file_name
-    weight_list = [1, 2, 3]
+    weight_list = [1.1, 2.1, 3.1]
+    active_years = [1, 2, 4]
     _create_weight_file(file_path, weight_list)
 
     mps_files = (
-    "problem-1-1-AAAAMMDD-hhmmss.mps", "problem-1-2-AAAAMMDD-hhmmss.mps", "problem-1-24-AAAAMMDD-hhmmss.mps",
-    "problem-2-1-AAAAMMDD-hhmmss.mps", "problem-2-2-AAAAMMDD-hhmmss.mps", "problem-2-24-AAAAMMDD-hhmmss.mps",
-    "problem-3-1-AAAAMMDD-hhmmss.mps", "problem-3-2-AAAAMMDD-hhmmss.mps", "problem-3-24-AAAAMMDD-hhmmss.mps")
+        f"problem-{active_years[0]}-1-AAAAMMDD-hhmmss.mps", f"problem-{active_years[0]}-24-AAAAMMDD-hhmmss.mps",
+        f"problem-{active_years[1]}-1-AAAAMMDD-hhmmss.mps", f"problem-{active_years[1]}-24-AAAAMMDD-hhmmss.mps",
+        f"problem-{active_years[2]}-1-AAAAMMDD-hhmmss.mps", f"problem-{active_years[2]}-24-AAAAMMDD-hhmmss.mps")
 
     _create_empty_file_from_list(tmp_path, mps_files)
-    YearlyWeightWriter(tmp_path).create_weight_file(weight_list, input_weight_file_name)
+    YearlyWeightWriter(tmp_path).create_weight_file(weight_list, input_weight_file_name, active_years)
 
-    expected_content = "problem-1-1-AAAAMMDD-hhmmss 1\n" \
-                       "problem-1-2-AAAAMMDD-hhmmss 1\n" \
-                       "problem-1-24-AAAAMMDD-hhmmss 1\n" \
-                       "problem-2-1-AAAAMMDD-hhmmss 2\n" \
-                       "problem-2-2-AAAAMMDD-hhmmss 2\n" \
-                       "problem-2-24-AAAAMMDD-hhmmss 2\n" \
-                       "problem-3-1-AAAAMMDD-hhmmss 3\n" \
-                       "problem-3-2-AAAAMMDD-hhmmss 3\n" \
-                       "problem-3-24-AAAAMMDD-hhmmss 3\n" \
-                       "WEIGHT_SUM 6"
+    expected_content = f"problem-{active_years[0]}-1-AAAAMMDD-hhmmss {weight_list[0]}\n" \
+                       f"problem-{active_years[0]}-24-AAAAMMDD-hhmmss {weight_list[0]}\n" \
+                       f"problem-{active_years[1]}-1-AAAAMMDD-hhmmss {weight_list[1]}\n" \
+                       f"problem-{active_years[1]}-24-AAAAMMDD-hhmmss {weight_list[1]}\n" \
+                       f"problem-{active_years[2]}-1-AAAAMMDD-hhmmss {weight_list[2]}\n" \
+                       f"problem-{active_years[2]}-24-AAAAMMDD-hhmmss {weight_list[2]}\n" \
+                       f"WEIGHT_SUM {sum(weight_list)}"
 
     with open(YearlyWeightWriter(tmp_path).output_dir / input_weight_file_name, 'r') as write_file:
         content = write_file.read()


### PR DESCRIPTION
closes #382 
When a weight file is used, `YearlyWeightWriter` needs to write a text file containing each mps file and its assigned weight.
`YearlyWeightWriter` reads the MC-year-number from the filename of the MPS file and uses it to read the weight from the list of weight previously read form the user-generated weight-file.
If a playlist is used some MC years could be skipped and the used years can be:
1,3,4 (skipping the 2)
the list of weights (`weights=[1,2,3]`) is composed by three elements and a failure was observed when reading `weights[4]`

This PR fixes another bug: 
closes #386

The numebr of active years was badly estimated by `GeneralDataReader` when a playlist was indicated but ignored in the antares study `["general"]["user-playlist"]=false`


