### PR TITLE
Fix pytest warnings on marks

### DIFF
--- a/tests/end_to_end/examples/pytest.ini
+++ b/tests/end_to_end/examples/pytest.ini
@@ -6,3 +6,5 @@ markers =
     medium_mpi: mark a test as parallel medium
     long_sequential: mark a test as non-parallel long
     long_mpi: mark a test as parallel long
+    short_sequential: mark a test as non-parallel short
+    short_mpi: mark a test as parallel short


### PR DESCRIPTION
Fix warning that appears when running shorts test.
This warning indicates that some custom marks are not registered. The fix is to register them properly in pytest.ini