### PR TITLE
Force storenewset to true, fix chronicles_checker

### DIFF
--- a/src/cpp/lpnamer/model/ChronicleMapProvider.cpp
+++ b/src/cpp/lpnamer/model/ChronicleMapProvider.cpp
@@ -2,24 +2,31 @@
 // Created by marechaljas on 29/04/2022.
 //
 
-#include "ChronicleMapReader.h"
-#include <utility>
-#include <fstream>
-#include <filesystem>
-#include <gtest/gtest.h>
 #include "ChronicleMapProvider.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <utility>
+
+#include "ChronicleMapReader.h"
 std::map<unsigned int, unsigned int>
 DirectAccessScenarioToChronicleProvider::GetMap(
     const std::string& link_from, const std::string& link_to) const {
   std::filesystem::path file_path = GetPath(link_from, link_to);
   file_path.replace_extension("txt");
   std::ifstream file(file_path);
-  /* We could check antares custom-ts-numbers to see if there is a scenario
+  /* We could check antares storenewset to see if there is a scenario
    * however this would mean reading antares configuration files which is not
    * expected at the moment
    * */
   if (!file.is_open()) {
-    std::cout << "No scenario builder output found for link at destination: " << file_path << std::endl;
+    std::cout << "No scenario builder output found for link at destination: "
+              << file_path << std::endl;
+    std::cout << " => All MC years for link " + link_from + " - " + link_to +
+                     " will use the first chronicle"
+              << std::endl;
     return {};
   }
   return chronicle_map_reader_.read(file);

--- a/src/cpp/lpnamer/model/ChronicleMapProvider.cpp
+++ b/src/cpp/lpnamer/model/ChronicleMapProvider.cpp
@@ -4,8 +4,6 @@
 
 #include "ChronicleMapProvider.h"
 
-#include <gtest/gtest.h>
-
 #include <filesystem>
 #include <fstream>
 #include <utility>

--- a/src/cpp/lpnamer/problem_modifier/LinkParametersCSVOverwriter.cpp
+++ b/src/cpp/lpnamer/problem_modifier/LinkParametersCSVOverwriter.cpp
@@ -51,7 +51,7 @@ void LinkParametersCSVOverWriter::FillRecord(std::string basic_string_1,
     if (!already_warned_) {
       std::cout << "WARNING: Missing entries in : " <<
                 link_parameters_file_path_.string() <<
-                ". Missing valus were populated with 0."
+                ". Missing values were populated with 0."
                 << std::endl;
       already_warned_ = true;
     }

--- a/src/python/antares_xpansion/candidates_reader.py
+++ b/src/python/antares_xpansion/candidates_reader.py
@@ -1,6 +1,6 @@
 from configparser import ConfigParser
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import numpy as np
 
@@ -48,7 +48,7 @@ class CandidatesReader:
         return list(self.candidates_map.keys())
 
     def _get_candidate_index(self, candidate: str):
-        if not candidate in self.get_candidates_list():
+        if candidate not in self.get_candidates_list():
             raise CandidateNotFound
         return self.candidates_map[candidate]
 
@@ -115,7 +115,7 @@ class CandidatesReader:
         area1, area2 = self.get_candidate_areas(candidate)
         return study_path / "input" / "links" / area1 / "capacities" / str(area2 + "_indirect.txt")
 
-    def get_candidate_link_profile(self, study_path: Path, candidate: str) -> (str, str):
+    def get_candidate_link_profile(self, study_path: Path, candidate: str) -> Tuple[str, str]:
         index = self._get_candidate_index(candidate)
         direct_link_profile_path = ""
         indirect_link_profile_path = ""

--- a/src/python/antares_xpansion/chronicles_checker.py
+++ b/src/python/antares_xpansion/chronicles_checker.py
@@ -53,7 +53,7 @@ class ChronicleChecker:
                 if antares_direct_link.shape != direct_link_profile.shape:
                     raise NTC_And_Candidate_Mismatch
             elif candidate_reader.has_installed_profile(self._study_path, candidate):
-                if antares_direct_link != installed_direct_link_profile.shape:
+                if antares_direct_link.shape != installed_direct_link_profile.shape:
                     raise NTC_And_Candidate_Mismatch
             if candidate_reader.has_installed_profile(self._study_path, candidate) and\
                     candidate_reader.has_profile(self._study_path, candidate) and\

--- a/src/python/antares_xpansion/general_data_processor.py
+++ b/src/python/antares_xpansion/general_data_processor.py
@@ -13,8 +13,12 @@ class GeneralDataFileExceptions:
 class GeneralDataProcessor:
     def __init__(self, general_data_file_root: Path, is_accurate: bool) -> None:
 
-        self.general_data_ini = 'generaldata.ini'
-        self.general_data_ini_file = Path(os.path.normpath(os.path.join(general_data_file_root, self.general_data_ini)))
+        self.general_data_ini = "generaldata.ini"
+        self.general_data_ini_file = Path(
+            os.path.normpath(
+                os.path.join(general_data_file_root, self.general_data_ini)
+            )
+        )
         self.is_accurate = is_accurate
 
     """
@@ -26,21 +30,22 @@ class GeneralDataProcessor:
             self._general_data_ini_file = general_data_ini_file
         else:
             raise GeneralDataFileExceptions.GeneralDataFileNotFound(
-                "General data file %s not found " % general_data_ini_file)
+                "General data file %s not found " % general_data_ini_file
+            )
 
     def get_general_data_ini_file(self) -> Path:
         return self._general_data_ini_file
 
     def change_general_data_file_to_configure_antares_execution(self):
         flushed_print("-- pre antares")
-        with open(self._general_data_ini_file, 'r') as reader:
+        with open(self._general_data_ini_file, "r") as reader:
             lines = reader.readlines()
 
-        with open(self._general_data_ini_file, 'w') as writer:
+        with open(self._general_data_ini_file, "w") as writer:
             current_section = ""
             for line in lines:
                 if IniReader.line_is_not_a_section_header(line):
-                    key = line.split('=')[0].strip()
+                    key = line.split("=")[0].strip()
                     line = self._get_new_line(line, current_section, key)
                 else:
                     current_section = line.strip()
@@ -48,28 +53,36 @@ class GeneralDataProcessor:
                 if line:
                     writer.write(line)
 
-    general_data_ini_file = property(get_general_data_ini_file, set_general_data_ini_file)
+    general_data_ini_file = property(
+        get_general_data_ini_file, set_general_data_ini_file
+    )
 
     def _get_new_line(self, line, section, key):
         changed_val = self._get_values_to_change_general_data_file()
         if (section, key) in changed_val:
             new_val = changed_val[(section, key)]
             if new_val:
-                line = key + ' = ' + new_val + '\n'
+                line = key + " = " + new_val + "\n"
             else:
                 line = None
         return line
 
     def _get_values_to_change_general_data_file(self):
-        optimization = '[optimization]'
+        optimization = "[optimization]"
 
-        return {(optimization, 'include-exportmps'): 'true',
-                (optimization, 'include-exportstructure'): 'true',
-                (optimization, 'include-tc-minstablepower'): 'true' if self.is_accurate else 'false',
-                (optimization, 'include-tc-min-ud-time'): 'true' if self.is_accurate else 'false',
-                (optimization, 'include-dayahead'): 'true' if self.is_accurate else 'false',
-                ('[general]', 'mode'): 'expansion' if self.is_accurate else 'Economy',
-                (
-                    '[other preferences]',
-                    'unit-commitment-mode'): 'accurate' if self.is_accurate else 'fast'
-                }
+        return {
+            (optimization, "include-exportmps"): "true",
+            (optimization, "include-exportstructure"): "true",
+            (optimization, "include-tc-minstablepower"): "true"
+            if self.is_accurate
+            else "false",
+            (optimization, "include-tc-min-ud-time"): "true"
+            if self.is_accurate
+            else "false",
+            (optimization, "include-dayahead"): "true" if self.is_accurate else "false",
+            ("general]", "mode"): "expansion" if self.is_accurate else "Economy",
+            ("[output]", "storenewset"): "true",
+            ("[other preferences]", "unit-commitment-mode"): "accurate"
+            if self.is_accurate
+            else "fast",
+        }

--- a/src/python/antares_xpansion/general_data_processor.py
+++ b/src/python/antares_xpansion/general_data_processor.py
@@ -80,7 +80,7 @@ class GeneralDataProcessor:
             if self.is_accurate
             else "false",
             (optimization, "include-dayahead"): "true" if self.is_accurate else "false",
-            ("general]", "mode"): "expansion" if self.is_accurate else "Economy",
+            ("[general]", "mode"): "expansion" if self.is_accurate else "Economy",
             ("[output]", "storenewset"): "true",
             ("[other preferences]", "unit-commitment-mode"): "accurate"
             if self.is_accurate

--- a/tests/python/test_antares_driver.py
+++ b/tests/python/test_antares_driver.py
@@ -7,14 +7,16 @@ import yaml
 
 from antares_xpansion.general_data_reader import IniReader
 from antares_xpansion.antares_driver import AntaresDriver
-from antares_xpansion.general_data_processor import GeneralDataFileExceptions, GeneralDataProcessor
+from antares_xpansion.general_data_processor import (
+    GeneralDataFileExceptions,
+    GeneralDataProcessor,
+)
 from tests.build_config_reader import get_antares_solver_path
 
 SUBPROCESS_RUN = "antares_xpansion.antares_driver.subprocess.run"
 
 
 class TestGeneralDataProcessor:
-
     def setup_method(self):
         self.generaldata_filename = "generaldata.ini"
 
@@ -53,45 +55,53 @@ class TestGeneralDataProcessor:
         gen_data_path = settings_dir / self.generaldata_filename
 
         is_accurate = True
-        optimization = '[optimization]'
-        general = '[general]'
-        random_section = '[random_section]'
+        optimization = "[optimization]"
+        general = "[general]"
+        random_section = "[random_section]"
+        output = "[output]"
 
-        other_preferences = '[other preferences]'
-        default_val = "[general] \n" \
-                      "mode = expansion\n" \
-                      "[optimization] \n" \
-                      "include-exportmps = false\n" \
-                      "include-tc-minstablepower = false\n" \
-                      "include-dayahead = NO\n" \
-                      "include-usexprs = value\n" \
-                      "include-inbasis = value\n" \
-                      "include-outbasis = value\n" \
-                      "include-trace = value\n" \
-                      "[other preferences] \n" \
-                      "unit-commitment-mode = fast\n" \
-                      "[random_section] \n" \
-                      "key1 = value1\n" \
-                      "key2 = value2\n"
+        other_preferences = "[other preferences]"
+        default_val = (
+            "[general] \n"
+            "mode = unrelevant\n"
+            "[optimization] \n"
+            "include-exportmps = false\n"
+            "include-tc-minstablepower = false\n"
+            "include-dayahead = NO\n"
+            "include-usexprs = value\n"
+            "include-inbasis = value\n"
+            "include-outbasis = value\n"
+            "include-trace = value\n"
+            "[output]\n"
+            "storenewset = false\n"
+            "[other preferences] \n"
+            "unit-commitment-mode = fast\n"
+            "[random_section] \n"
+            "key1 = value1\n"
+            "key2 = value2\n"
+        )
 
         gen_data_path.write_text(default_val)
-        expected_val = {(optimization, 'include-exportmps'): 'true',
-                        (optimization, 'include-exportstructure'): 'true',
-                        (optimization, 'include-tc-minstablepower'): 'true',
-                        (optimization, 'include-tc-min-ud-time'): 'true',
-                        (optimization, 'include-dayahead'): 'true',
-                        (general, 'mode'): 'expansion',
-                        (other_preferences, 'unit-commitment-mode'): 'accurate',
-                        (random_section, "key1"): "value1",
-                        (random_section, "key2"): "value2"
-                        }
+        expected_val = {
+            (optimization, "include-exportmps"): "true",
+            (optimization, "include-exportstructure"): "true",
+            (optimization, "include-tc-minstablepower"): "true",
+            (optimization, "include-tc-min-ud-time"): "true",
+            (optimization, "include-dayahead"): "true",
+            (general, "mode"): "expansion",
+            (output, "storenewset"): "true",
+            (other_preferences, "unit-commitment-mode"): "accurate",
+            (random_section, "key1"): "value1",
+            (random_section, "key2"): "value2",
+        }
 
         gen_data_proc = GeneralDataProcessor(settings_dir, is_accurate)
 
         gen_data_proc.change_general_data_file_to_configure_antares_execution()
         general_data_ini_file = gen_data_proc.general_data_ini_file
         self.verify_that_general_data_contains_expected_vals(
-            general_data_ini_file, expected_val)
+            general_data_ini_file, expected_val
+        )
 
     def test_values_change_in_general_file_fast_mode(self, tmp_path):
         study_path = tmp_path
@@ -100,54 +110,64 @@ class TestGeneralDataProcessor:
         general_data_path = settings_dir / self.generaldata_filename
 
         is_accurate = False
-        optimization = '[optimization]'
-        general = '[general]'
-        random_section = '[random_section]'
-        other_preferences = '[other preferences]'
+        optimization = "[optimization]"
+        general = "[general]"
+        random_section = "[random_section]"
+        other_preferences = "[other preferences]"
+        output = "[output]"
 
-        default_val = "[general] \n" \
-                      "mode = expansion\n" \
-                      "[optimization] \n" \
-                      "include-exportmps = false\n" \
-                      "include-tc-minstablepower = false\n" \
-                      "include-dayahead = NO\n" \
-                      "include-usexprs = value\n" \
-                      "include-inbasis = value\n" \
-                      "include-outbasis = value\n" \
-                      "include-trace = value\n" \
-                      "[other preferences] \n" \
-                      "unit-commitment-mode = dada\n" \
-                      "[random_section] \n" \
-                      "key1 = value1\n" \
-                      "key2 = value2\n"
+        default_val = (
+            "[general] \n"
+            "mode = expansion\n"
+            "[optimization] \n"
+            "include-exportmps = false\n"
+            "include-tc-minstablepower = false\n"
+            "include-dayahead = NO\n"
+            "include-usexprs = value\n"
+            "include-inbasis = value\n"
+            "include-outbasis = value\n"
+            "include-trace = value\n"
+            "[output]\n"
+            "storenewset = false\n"
+            "[other preferences] \n"
+            "unit-commitment-mode = dada\n"
+            "[random_section] \n"
+            "key1 = value1\n"
+            "key2 = value2\n"
+        )
 
         general_data_path.write_text(default_val)
 
-        expected_val = {(optimization, 'include-exportmps'): 'true',
-                        (optimization, 'include-exportstructure'): 'true',
-                        (optimization, 'include-tc-minstablepower'): 'false',
-                        (optimization, 'include-tc-min-ud-time'): 'false',
-                        (optimization, 'include-dayahead'): 'false',
-                        (general, 'mode'): 'Economy',
-                        (other_preferences, 'unit-commitment-mode'): 'fast',
-                        (random_section, "key1"): "value1",
-                        (random_section, "key2"): "value2"
-                        }
+        expected_val = {
+            (optimization, "include-exportmps"): "true",
+            (optimization, "include-exportstructure"): "true",
+            (optimization, "include-tc-minstablepower"): "false",
+            (optimization, "include-tc-min-ud-time"): "false",
+            (optimization, "include-dayahead"): "false",
+            (general, "mode"): "Economy",
+            (output, "storenewset"): "true",
+            (other_preferences, "unit-commitment-mode"): "fast",
+            (random_section, "key1"): "value1",
+            (random_section, "key2"): "value2",
+        }
 
         gen_data_proc = GeneralDataProcessor(settings_dir, is_accurate)
         gen_data_proc.change_general_data_file_to_configure_antares_execution()
 
         self.verify_that_general_data_contains_expected_vals(
-            general_data_path, expected_val)
+            general_data_path, expected_val
+        )
 
-    def verify_that_general_data_contains_expected_vals(self, general_data_ini_file, expected_val):
+    def verify_that_general_data_contains_expected_vals(
+        self, general_data_ini_file, expected_val
+    ):
         with open(general_data_ini_file, "r") as reader:
             current_section = ""
             lines = reader.readlines()
             for line in lines:
                 if IniReader.line_is_not_a_section_header(line):
-                    key = line.split('=')[0].strip()
-                    value = line.split('=')[1].strip()
+                    key = line.split("=")[0].strip()
+                    value = line.split("=")[1].strip()
                     if (current_section, key) in expected_val:
                         assert value == expected_val[(current_section, key)]
                 else:
@@ -159,7 +179,6 @@ class TestGeneralDataProcessor:
 
 
 class TestAntaresDriver:
-
     def test_antares_cmd(self, tmp_path):
         study_dir = tmp_path
         exe_path = "/Path/to/bin1"
@@ -169,7 +188,8 @@ class TestAntaresDriver:
             antares_driver.launch(study_dir, 1)
             expected_cmd = [exe_path, study_dir, "--force-parallel", "1"]
             run_function.assert_called_once_with(
-                expected_cmd, shell=False, stdout=-3, stderr=-3)
+                expected_cmd, shell=False, stdout=-3, stderr=-3
+            )
 
     def test_antares_cmd_force_parallel_option(self, tmp_path):
         study_dir = tmp_path
@@ -178,10 +198,10 @@ class TestAntaresDriver:
         antares_driver = AntaresDriver(exe_path)
         with patch(SUBPROCESS_RUN, autospec=True) as run_function:
             antares_driver.launch(study_dir, n_cpu)
-            expected_cmd = [exe_path, study_dir,
-                            "--force-parallel", str(n_cpu)]
+            expected_cmd = [exe_path, study_dir, "--force-parallel", str(n_cpu)]
             run_function.assert_called_once_with(
-                expected_cmd, shell=False, stdout=-3, stderr=-3)
+                expected_cmd, shell=False, stdout=-3, stderr=-3
+            )
 
     def test_invalid_n_cpu(self, tmp_path):
         study_dir = tmp_path
@@ -191,24 +211,29 @@ class TestAntaresDriver:
         antares_driver = AntaresDriver(exe_path)
         with patch(SUBPROCESS_RUN, autospec=True) as run_function:
             antares_driver.launch(study_dir, n_cpu)
-            expected_cmd = [exe_path, study_dir,
-                            "--force-parallel", str(expected_n_cpu)]
+            expected_cmd = [
+                exe_path,
+                study_dir,
+                "--force-parallel",
+                str(expected_n_cpu),
+            ]
             run_function.assert_called_once_with(
-                expected_cmd, shell=False, stdout=-3, stderr=-3)
+                expected_cmd, shell=False, stdout=-3, stderr=-3
+            )
 
     def test_remove_log_file(self, tmp_path):
         study_dir = tmp_path
         exe_path = tmp_path
-        log_file = str(exe_path) + '.log'
+        log_file = str(exe_path) + ".log"
         log_file = Path(log_file).touch()
         n_cpu = 13
         antares_driver = AntaresDriver(exe_path)
         with patch(SUBPROCESS_RUN, autospec=True) as run_function:
             antares_driver.launch(study_dir, n_cpu)
-            expected_cmd = [str(exe_path), study_dir,
-                            "--force-parallel", str(n_cpu)]
+            expected_cmd = [str(exe_path), study_dir, "--force-parallel", str(n_cpu)]
             run_function.assert_called_once_with(
-                expected_cmd, shell=False, stdout=-3, stderr=-3)
+                expected_cmd, shell=False, stdout=-3, stderr=-3
+            )
 
     def test_non_valid_exe_empty(self, tmp_path):
         study_dir = tmp_path
@@ -248,7 +273,8 @@ class TestAntaresDriver:
 
             expected_cmd = [str(exe_path), study_dir, "--force-parallel", "1"]
             run_function.assert_called_once_with(
-                expected_cmd, shell=False, stdout=-3, stderr=-3)
+                expected_cmd, shell=False, stdout=-3, stderr=-3
+            )
 
         for file in files_to_remove:
             assert not file.exists()
@@ -257,19 +283,21 @@ class TestAntaresDriver:
         settings_dir = study_dir / "settings"
         settings_dir.mkdir()
         general_data_path = settings_dir / "generaldata.ini"
-        default_val = "[general] \n" \
-                      "mode = expansion\n" \
-                      "[optimization] \n" \
-                      "include-exportmps = false\n" \
-                      "include-tc-minstablepower = false\n" \
-                      "include-dayahead = NO\n" \
-                      "include-usexprs = value\n" \
-                      "include-inbasis = value\n" \
-                      "include-outbasis = value\n" \
-                      "include-trace = value\n" \
-                      "[other preferences] \n" \
-                      "unit-commitment-mode = dada\n" \
-                      "[random_section] \n" \
-                      "key1 = value1\n" \
-                      "key2 = value2\n"
+        default_val = (
+            "[general] \n"
+            "mode = expansion\n"
+            "[optimization] \n"
+            "include-exportmps = false\n"
+            "include-tc-minstablepower = false\n"
+            "include-dayahead = NO\n"
+            "include-usexprs = value\n"
+            "include-inbasis = value\n"
+            "include-outbasis = value\n"
+            "include-trace = value\n"
+            "[other preferences] \n"
+            "unit-commitment-mode = dada\n"
+            "[random_section] \n"
+            "key1 = value1\n"
+            "key2 = value2\n"
+        )
         general_data_path.write_text(default_val)


### PR DESCRIPTION
Two fixes :
- Fix missing `.shape` in chronicle checker
- Force `storenewset` to `true` in order to always have the output of Antares scenario builder and be able to choose the right chronicle for the right MC year
- Fix some typos and improve a warning message