### PR TITLE
Fix input checker for relaxed gap

### DIFF
--- a/src/python/antares_xpansion/input_checker.py
+++ b/src/python/antares_xpansion/input_checker.py
@@ -333,6 +333,7 @@ options_types_and_legal_values = {
     "master": (type_str, ["relaxed", "integer"]),
     "optimality_gap": (type_float, None),
     "relative_gap": (type_float, None),
+    "relaxed_optimality_gap": (type_float, None),
     "max_iteration": (type_int, None),
     "solver": (type_str, None),
     "timelimit": (type_int, None),


### PR DESCRIPTION
Fix a bug when using the `relaxed_optimality_gap` option