### PR TITLE
Get rid of mps.txt

### DIFF
--- a/src/cpp/lpnamer/input_reader/MpsTxtWriter.h
+++ b/src/cpp/lpnamer/input_reader/MpsTxtWriter.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "common_lpnamer.h"
 
@@ -17,31 +18,34 @@ using MpsVariableConstraintsFiles =
 
 // dict to associate YearAndWeek --> MpsVariableConstraintsFiles
 using YearWeekAndFilesDict = std::map<YearAndWeek, MpsVariableConstraintsFiles>;
-class MpsTxtWriter {
+
+struct ProblemData {
+  ProblemData(const std::string& problem_mps, const std::string& variables_txt)
+      : _problem_mps(problem_mps), _variables_txt(variables_txt) {}
+  std::string _problem_mps;
+  std::string _variables_txt;
+};
+
+class FilesMapper {
  public:
-  explicit MpsTxtWriter(const std::filesystem::path& antares_archive_path,
-                        const std::filesystem::path& output_file_path)
-      : antares_archive_path_(antares_archive_path),
-        output_file_path_(output_file_path) {}
-  void Write();
+  explicit FilesMapper(const std::filesystem::path& antares_archive_path)
+      : antares_archive_path_(antares_archive_path) {}
+  YearWeekAndFilesDict FilesMap() {
+    FillMap();
+    return year_week_and_files_dict_;
+  }
+  std::vector<ProblemData> MpsAndVariablesFilesVect();
 
  private:
   YearWeekAndFilesDict year_week_and_files_dict_;
   std::filesystem::path antares_archive_path_;
-  std::filesystem::path output_file_path_;
-  void FillDict();
-  void FillDictWithMpsFiles(
-      const std::vector<std::filesystem::path>& mps_files);
-  void FillDictWithVariablesFiles(
+  void FillMap();
+  void FillMapWithMpsFiles(const std::vector<std::filesystem::path>& mps_files);
+  void FillMapWithVariablesFiles(
       const std::vector<std::filesystem::path>& variables_files);
-  void FillDictWithConstraintsFiles(
+  void FillMapWithConstraintsFiles(
       const std::vector<std::filesystem::path>& variables_files);
   YearAndWeek YearAndWeekFromFileName(
-      const std::filesystem::path& file_name) const {
-    auto split_file_name =
-        common_lpnamer::split(common_lpnamer::trim(file_name.string()), '-');
-    return {std::atoi(split_file_name[1].c_str()),
-            std::atoi(split_file_name[2].c_str())};
-  }
+      const std::filesystem::path& file_name) const;
 };
 #endif  // SRC_CPP_LPNAMER_INPUTREADER_MPSTXTWRITER_H

--- a/src/cpp/lpnamer/main/RunProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/RunProblemGeneration.cpp
@@ -44,13 +44,6 @@ void ProcessWeights(
   yearly_weight_writer.CreateWeightFile();
 }
 
-void WriteMpsTxt(const std::filesystem::path& antares_archive_path,
-                 const std::filesystem::path& xpansion_output_dir) {
-  auto mps_txt_writer = MpsTxtWriter(
-      antares_archive_path, xpansion_output_dir / common_lpnamer::MPS_TXT);
-  mps_txt_writer.Write();
-}
-
 void ExtractUtilsFiles(
     const std::filesystem::path& antares_archive_path,
     const std::filesystem::path& xpansion_output_dir,
@@ -76,8 +69,6 @@ void RunProblemGeneration(
     ProcessWeights(xpansion_output_dir, antares_archive_path, weights_file,
                    logger);
   }
-
-  WriteMpsTxt(antares_archive_path, xpansion_output_dir);
 
   ExtractUtilsFiles(antares_archive_path, xpansion_output_dir, logger);
 

--- a/src/cpp/lpnamer/main/include/RunProblemGeneration.h
+++ b/src/cpp/lpnamer/main/include/RunProblemGeneration.h
@@ -19,8 +19,6 @@ void ProcessWeights(
     const std::filesystem::path& antares_archive_path,
     const std::filesystem::path& weights_file,
     ProblemGenerationLog::ProblemGenerationLoggerSharedPointer logger);
-void WriteMpsTxt(const std::filesystem::path& antares_archive_path,
-                 const std::filesystem::path& xpansion_output_dir);
 void ExtractUtilsFiles(
     const std::filesystem::path& antares_archive_path,
     const std::filesystem::path& xpansion_output_dir,

--- a/src/cpp/lpnamer/problem_modifier/LinkProblemsGenerator.h
+++ b/src/cpp/lpnamer/problem_modifier/LinkProblemsGenerator.h
@@ -11,6 +11,7 @@
 #include "ArchiveWriter.h"
 #include "Candidate.h"
 #include "FileInBuffer.h"
+#include "MpsTxtWriter.h"
 #include "ProblemGenerationLogger.h"
 #include "ProblemModifier.h"
 #include "common_lpnamer.h"
@@ -24,12 +25,6 @@ typedef std::pair<std::string, std::filesystem::path>
     CandidateNameAndMpsFilePath;
 typedef unsigned int ColId;
 typedef std::map<CandidateNameAndMpsFilePath, ColId> Couplings;
-
-struct ProblemData {
-  ProblemData(const std::string& problem_mps, const std::string& variables_txt);
-  std::string _problem_mps;
-  std::string _variables_txt;
-};
 
 class LinkProblemsGenerator {
  public:
@@ -48,9 +43,6 @@ class LinkProblemsGenerator {
                  Couplings& couplings);
 
  private:
-  std::vector<ProblemData> readMPSList(
-      const std::filesystem::path& mps_filePath_p) const;
-
   void treat(const std::filesystem::path& root, ProblemData const&,
              Couplings& couplings, ArchiveReader& reader) const;
   void treat(const std::filesystem::path& root, ProblemData const&,

--- a/tests/cpp/lp_namer/MpsTxtWriterTest.cpp
+++ b/tests/cpp/lp_namer/MpsTxtWriterTest.cpp
@@ -19,24 +19,17 @@ auto const empty_files_archive = std::filesystem::path("data_test") /
 class MpsTxtWriterTest : public ::testing::Test {};
 
 TEST_F(MpsTxtWriterTest, CheckMpsTxtContent) {
-  auto mps_txt = std::filesystem::temp_directory_path() / "mps.txt";
-  auto mps_txt_writer = MpsTxtWriter(empty_files_archive, mps_txt);
-  mps_txt_writer.Write();
+  auto files_mapper = FilesMapper(empty_files_archive);
+  auto year_week_files = files_mapper.FilesMap();
+  std::vector<MpsVariableConstraintsFiles> files_map;
 
-  ASSERT_TRUE(std::filesystem::exists(mps_txt));
+  std::transform(year_week_files.cbegin(), year_week_files.cend(),
+                 std::back_inserter(files_map),
+                 [](const std::pair<YearAndWeek, MpsVariableConstraintsFiles>&
+                        year_week_files) {
+                   auto& [year_week, files] = year_week_files;
+                   return files;
+                 });
 
-  std::ifstream mps_txt_file(mps_txt);
-  std::string line;
-  std::vector<MpsVariableConstraintsFiles> mps_txt_content;
-  while (std::getline(mps_txt_file, line)) {
-    std::istringstream instream(line);
-    std::string mps_file;
-    std::string vars_file;
-    std::string constraints_file;
-    instream >> mps_file >> vars_file >> constraints_file;
-    ;
-    mps_txt_content.push_back({mps_file, vars_file, constraints_file});
-  }
-
-  ASSERT_EQ(EXPECTED_RESULTS, mps_txt_content);
+  ASSERT_EQ(EXPECTED_RESULTS, files_map);
 }


### PR DESCRIPTION
get mps<->variables files map directly from archive without writing this map in mps.txt.
  