### PR TITLE
Update badges link in developer guide

### DIFF
--- a/docs/developer-guide/install_from_sources/0-INSTALL.md
+++ b/docs/developer-guide/install_from_sources/0-INSTALL.md
@@ -13,7 +13,6 @@ Antares-Xpansion is built using CMake.
 
 Follow this [link][Doxygen_Code_Documentation] for Doxygen code documentation.
 
-
 ## Build and installation details
 
 - [Development requirements](1-Development-requirements.md)
@@ -23,10 +22,10 @@ Follow this [link][Doxygen_Code_Documentation] for Doxygen code documentation.
 - [UI creation](5-ui-creation.md)
 - [Installer creation](6-Installer-creation.md)
 
-[ubuntu_system_svg]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/linux-system.yml/badge.svg
-[ubuntu_system_link]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/linux-system.yml
-[windows_vcpkg_svg]: https://github.com/AntaresSimulatorTeam/antares-xpansion/workflows/Windows%20CI%20(VCPKG)/badge.svg
-[windows_vcpkg_link]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions?query=workflow%3A"Windows%20CI%20(VCPKG)"
-[centos_system_svg]: https://github.com/AntaresSimulatorTeam/antares-xpansion/workflows/Centos7%20CI%20(system%20libs)/badge.svg
-[centos_system_link]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions?query=workflow%3A"Centos7%20CI%20(system%20libs)"
+[ubuntu_system_svg]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/ubuntu-system-deps-build.yml/badge.svg
+[ubuntu_system_link]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/ubuntu-system-deps-build.yml
+[windows_vcpkg_svg]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/windows-vcpkg-deps-build.yml/badge.svg
+[windows_vcpkg_link]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/windows-vcpkg-deps-build.yml
+[centos_system_svg]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/centos7-system-deps-build.yml/badge.svg
+[centos_system_link]: https://github.com/AntaresSimulatorTeam/antares-xpansion/actions/workflows/centos7-system-deps-build.yml
 [Doxygen_Code_Documentation]: https://antaressimulatorteam.github.io/antares-xpansion/annotated.html


### PR DESCRIPTION
This is complementary to #743 where badges links have been updated on the home page