### PR TITLE
Replace INSTANTIATE_TEST_CASE_P by INSTANTIATE_TEST_SUITE_P

### DIFF
--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           submodules: true
 
+      - uses: ./.github/workflows/compile-gtest
       - name: Checkout xpressmp linux
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/compile-gtest/action.yml
+++ b/.github/workflows/compile-gtest/action.yml
@@ -1,0 +1,14 @@
+name: "Download and build gtest"
+description: "build gtest for centos7"
+runs:
+  using: "composite"
+  steps:
+    - id: build-gtest
+      shell: bash
+      run: |
+        source /opt/rh/devtoolset-10/enable
+        git clone -b v1.14.0 https://github.com/google/googletest.git
+        cd googletest
+        cmake3 -G"Unix Makefiles"
+        make -j8
+        make install

--- a/tests/cpp/full_run/FullRunTest.cpp
+++ b/tests/cpp/full_run/FullRunTest.cpp
@@ -147,5 +147,5 @@ auto GetData() {
       {"benders_by_batch", BENDERSMETHOD::BENDERSBYBATCH},
       {"mergeMPS", BENDERSMETHOD::MERGEMPS}});
 }
-INSTANTIATE_TEST_CASE_P(Method, FullRunOptionsParserTestParameterizedMethod,
-                        GetData());
+INSTANTIATE_TEST_SUITE_P(Method, FullRunOptionsParserTestParameterizedMethod,
+                         GetData());

--- a/tests/cpp/lp_namer/ProblemConstructionTest.cpp
+++ b/tests/cpp/lp_namer/ProblemConstructionTest.cpp
@@ -35,7 +35,8 @@ TEST_P(ProblemConstructionTest, ExtractSeveralFileNameCase) {
   auto const& input = GetParam();
   EXPECT_EQ(MCYear(input.problem_name), input.expected_mc_year);
 }
-INSTANTIATE_TEST_CASE_P(BulkTest, ProblemConstructionTest, testing::ValuesIn(cases));
+INSTANTIATE_TEST_SUITE_P(BulkTest, ProblemConstructionTest,
+                         testing::ValuesIn(cases));
 
 TEST_F(ProblemConstructionTest, ExtractMCYearFromPath) {
   std::filesystem::path path = std::filesystem::path("path") / "To" / "inner-dir" / "problem-2-1-20220214-124051.mps";


### PR DESCRIPTION
INSTANTIATE_TEST_CASE_P is deprecated in newer version of GTest and should be replaced by INSTANTIATE_TEST_SUITE_P

Unfortunately on CentOS7, default GTest is too old for INSTANTIATE_TEST_SUITE_P. We need to build it from sources