### PR TITLE
Produce only one asset (with xpress)

### DIFF
--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -74,9 +74,11 @@ jobs:
     container: 'antaresrte/rte-antares:centos7-system-deps'
     strategy:
       matrix:
-        xprs: [ { value: XPRESS-ON, ref: 8.13a },
+        xprs: [
+          # { value: XPRESS-ON, ref: 8.13a },
                 { value: XPRESS-ON, ref: 9.2.5 },
-                { value: XPRESS-OFF } ]
+          #        { value: XPRESS-OFF }
+        ]
     env:
       XPRESSDIR: ${{ github.workspace }}/xpress
       XPRESS: ${{ github.workspace }}/xpress/bin

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -48,9 +48,10 @@ jobs:
     container: 'oraclelinux:8'
     strategy:
       matrix:
-        xprs: [ { value: XPRESS-ON, ref: 8.13a },
+        xprs: [ #{ value: XPRESS-ON, ref: 8.13a },
                 { value: XPRESS-ON, ref: 9.2.5 },
-                { value: XPRESS-OFF } ]
+          #        { value: XPRESS-OFF }
+        ]
     needs: [ versions ]
     env:
       XPRESSDIR: ${{ github.workspace }}/xpress

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -20,9 +20,11 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        xprs: [ { value: XPRESS-ON, ref: 8.13a },
+        xprs: [
+          #{ value: XPRESS-ON, ref: 8.13a },
                 { value: XPRESS-ON, ref: 9.2.5 },
-                { value: XPRESS-OFF } ]
+          #        { value: XPRESS-OFF }
+        ]
     env:
       XPRESSDIR: ${{ github.workspace }}/xpress
       XPRESS: ${{ github.workspace }}/xpress/bin

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -21,9 +21,10 @@ jobs:
       matrix:
         os: [ windows-latest ]
         triplet: [ x64-windows ]
-        xprs: [ { value: XPRESS-ON, ref: 8.13a },
+        xprs: [ #{ value: XPRESS-ON, ref: 8.13a },
                 { value: XPRESS-ON, ref: 9.2.5 },
-                { value: XPRESS-OFF } ]
+          #{ value: XPRESS-OFF }
+        ]
     env:
       XPRESSDIR: ${{ github.workspace }}\xpress
       XPRESS: ${{ github.workspace }}\xpress\bin

--- a/.github/workflows/centos-release.yml
+++ b/.github/workflows/centos-release.yml
@@ -110,7 +110,10 @@ jobs:
     container: 'antaresrte/rte-antares:centos7-system-deps'
     strategy:
       matrix:
-        xprs: [ XPRESS-ON, XPRESS-OFF ]
+        xprs: [
+          XPRESS-ON,
+          #XPRESS-OFF
+        ]
     env:
       XPRESSDIR: ${{ github.workspace }}/xpress
       XPRESS: ${{ github.workspace }}/xpress/bin

--- a/.github/workflows/ol8-release.yml
+++ b/.github/workflows/ol8-release.yml
@@ -81,8 +81,10 @@ jobs:
     container: 'oraclelinux:8'
     strategy:
       matrix:
-        xprs: [ { value: XPRESS-ON, ref: 9.2.5 },
-                { value: XPRESS-OFF } ]
+        xprs: [
+          { value: XPRESS-ON, ref: 9.2.5 },
+          #{ value: XPRESS-OFF }
+        ]
     env:
       XPRESSDIR: ${{ github.workspace }}/xpress
       XPRESS: ${{ github.workspace }}/xpress/bin

--- a/.github/workflows/ubuntu-release.yml
+++ b/.github/workflows/ubuntu-release.yml
@@ -55,7 +55,10 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        xprs: [ XPRESS-ON, XPRESS-OFF ]
+        xprs: [
+          XPRESS-ON,
+          #XPRESS-OFF
+        ]
     env:
       XPRESSDIR: ${{ github.workspace }}/xpress
       XPRESS: ${{ github.workspace }}/xpress/bin

--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -55,7 +55,10 @@ jobs:
       matrix:
         os: [ windows-latest ]
         triplet: [ x64-windows ]
-        xprs: [ XPRESS-ON, XPRESS-OFF ]
+        xprs: [
+          XPRESS-ON,
+          #XPRESS-OFF
+        ]
     env:
       XPRESSDIR: ${{ github.workspace }}\xpress
       XPRESS: ${{ github.workspace }}\xpress\bin


### PR DESCRIPTION
Given xpress is now dynamically loaded at runtime it is no more necessary to produce several assets.