### PR TITLE
Revert to checkout v3 for centOS

### DIFF
--- a/.github/workflows/centos-release.yml
+++ b/.github/workflows/centos-release.yml
@@ -54,7 +54,7 @@ jobs:
       pdf-name: ${{ steps.create-user-guide.outputs.pdf-name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
       - name: Read antares-xpansion version
         id: antares-xpansion-version
@@ -83,7 +83,7 @@ jobs:
       antares-xpansion-version: ${{steps.antares-xpansion-version.outputs.result}}
       antares-deps-version: ${{steps.antares-deps-version.outputs.result}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Read antares-solver version
         id: antares-version
         uses: ./.github/actions/read-json-value
@@ -130,7 +130,7 @@ jobs:
         uses: tj-actions/branch-names@v6
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -168,7 +168,7 @@ jobs:
           path: docs/
 
       - name: Checkout xpressmp linux
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.AS_TOKEN }}
           repository: rte-france/xpress-mp

--- a/.github/workflows/centos7-system-deps-build.yml
+++ b/.github/workflows/centos7-system-deps-build.yml
@@ -42,7 +42,7 @@ jobs:
       antares-xpansion-version: ${{steps.antares-xpansion-version.outputs.result}}
       antares-deps-version: ${{steps.antares-deps-version.outputs.result}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Read antares-solver version
         id: antares-version
         uses: ./.github/actions/read-json-value
@@ -74,7 +74,7 @@ jobs:
       - id: branch-name
         uses: tj-actions/branch-names@v6
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           submodules: true
 


### PR DESCRIPTION
checkout@v4 uses node 20 which depends on GLIBC_2.27 unavailable on centOS7