### PR TITLE
fix single file name

### DIFF
--- a/.github/workflows/windows-vcpkg.yml
+++ b/.github/workflows/windows-vcpkg.yml
@@ -68,6 +68,7 @@ jobs:
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
     outputs:
       zip_name: ${{ steps.zip_name.outputs.zip_name }}
+      singlefile_name: ${{steps.zip_name.outputs.singlefile_name}}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
there is a bug in windows release workflows, the single file archive is not uploaded.