### PR TITLE
Fix performance issue

### DIFF
--- a/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
+++ b/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
@@ -286,7 +286,7 @@ void BendersByBatch::GetSubproblemCut(
       worker->fix_to(_data.x_cut);
       worker->solve(subproblem_data.lpstatus, Options().OUTPUTROOT,
                     Options().LAST_MASTER_MPS + MPS_SUFFIX, _writer);
-      worker->get_solution(subproblem_data.solution);
+      // worker->get_solution(subproblem_data.solution);
       worker->get_value(subproblem_data.subproblem_cost);  // solution phi(x,s)
       worker->get_subgradient(
           subproblem_data.var_name_and_subgradient);  // dual pi_s


### PR DESCRIPTION
For now, outer loop is not implemented in Benders by batch, and the current implementation in Benders is not efficient due to #813. For benders by batch users, we do not want to introduce performance loss as the algorithm has not changed, that is the goal of this PR