### PR TITLE
Fix criterion computation

### DIFF
--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -1007,7 +1007,7 @@ std::vector<double> BendersBase::ComputeOuterLoopCriterion(
           solution > criterion_count_threshold)
         // 1h of no supplied energy
         outer_loop_criterion_per_sub_problem[pattern_index] +=
-            subproblem_weight / number_of_scenarios;
+            subproblem_weight;
     }
   }
   return outer_loop_criterion_per_sub_problem;


### PR DESCRIPTION
The weight of the criterion is only given by `subproblem_weight` which already takes into account the number of scenarios. This PR is just a quick fix, further work will be needed to clean the useless information about scenario retrieval from configuration file, see #818 .