### PR TITLE
Fix regex

### DIFF
--- a/src/cpp/benders/benders_core/OuterLoopInputDataReader.cpp
+++ b/src/cpp/benders/benders_core/OuterLoopInputDataReader.cpp
@@ -17,7 +17,7 @@ OuterLoopPattern::OuterLoopPattern(std::string prefix,
  * just cat ;)
  */
 std::regex OuterLoopPattern::MakeRegex() const {
-  auto pattern = "(^" + prefix_ + ").*" + body_;
+  auto pattern = "(^" + prefix_ + "area<" + body_ + ">" + ")";
   return std::regex(pattern);
 }
 const std::string &OuterLoopPattern::GetPrefix() const { return prefix_; }

--- a/tests/cpp/outer_loop/outer_loop_test.cpp
+++ b/tests/cpp/outer_loop/outer_loop_test.cpp
@@ -161,12 +161,15 @@ TEST_F(OuterLoopPatternTest, RegexGivenPrefixAndBody) {
 
   auto ret_regex = o.MakeRegex();
 
-  ASSERT_EQ(std::regex_search(prefix + body, ret_regex), true);
+  ASSERT_EQ(std::regex_search(prefix + body, ret_regex), false);
   ASSERT_EQ(std::regex_search(prefix + "::" + body + "::suffix", ret_regex),
-            true);
+            false);
   ASSERT_EQ(std::regex_search(body + prefix, ret_regex), false);
   ASSERT_EQ(std::regex_search(prefix + "::", ret_regex), false);
   ASSERT_EQ(std::regex_search(body, ret_regex), false);
+  ASSERT_EQ(std::regex_search(prefix + "area<" + body + ">", ret_regex), true);
+  ASSERT_EQ(std::regex_search(prefix + "area<" + body + ">::suffix", ret_regex), true);
+  ASSERT_EQ(std::regex_search(prefix + "area<" + body + "_other_area>::suffix", ret_regex), false);
 }
 
 class OuterLoopInputFromYamlTest : public ::testing::Test {};


### PR DESCRIPTION
The regex to match variables from patterns in the config file `outer_loop.yml` was too permissive (for instance `area: "fr"` matched the positive unsupplied energy from area `ve_fr` which was not wanted), this PR fixes it.