### PR TITLE
Fix vcpkg caching issues

### DIFF
--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -145,12 +145,15 @@ jobs:
           pushd vcpkg
           git fetch --unshallow
           ./bootstrap-vcpkg.sh -disableMetrics
+          echo "VCPKG_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg_cache" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg_cache,readwrite" >> $GITHUB_ENV
 
       - name: Restore vcpkg binary dir from cache
         id: cache-vcpkg-binary
         uses: actions/cache/restore@v3
         with:
-          path: ${{ github.workspace }}/vcpkg_cache
+          path: ${{ env.VCPKG_CACHE_DIR }}
           key: vcpkg-cache-centOS-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
           # Allows to restore a cache when deps have only partially changed (like adding a dependency)
           restore-keys: vcpkg-cache-centOS-
@@ -176,7 +179,7 @@ jobs:
         id: save-cache-vcpkg-binary
         uses: actions/cache/save@v3
         with:
-          path: ${{ github.workspace }}/vcpkg_cache
+          path: ${{ env.VCPKG_CACHE_DIR }}
           key: vcpkg-cache-centOS-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
 
       - name: Running unit tests

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -111,12 +111,15 @@ jobs:
           pushd vcpkg
           git fetch --unshallow
           ./bootstrap-vcpkg.sh -disableMetrics
+          echo "VCPKG_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg_cache" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,$GITHUB_WORKSPACE/vcpkg_cache,readwrite" >> $GITHUB_ENV
 
       - name: Restore vcpkg binary dir from cache
         id: cache-vcpkg-binary
         uses: actions/cache/restore@v4
         with:
-          path: ${{ github.workspace }}/vcpkg_cache
+          path: ${{ env.VCPKG_CACHE_DIR }}
           key: vcpkg-cache-oracle8-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
           # Allows to restore a cache when deps have only partially changed (like adding a dependency)
           restore-keys: vcpkg-cache-oracle8-
@@ -151,7 +154,7 @@ jobs:
         id: save-cache-vcpkg-binary
         uses: actions/cache/save@v4
         with:
-          path: ${{ github.workspace }}/vcpkg_cache
+          path: ${{ env.VCPKG_CACHE_DIR }}
           key: vcpkg-cache-oracle8-${{ hashFiles('src/vcpkg.json', '.git/modules/vcpkg/HEAD') }}
 
       #######################

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -30,6 +30,7 @@ jobs:
       XPRESSDIR: ${{ github.workspace }}/xpress
       XPRESS: ${{ github.workspace }}/xpress/bin
       XPRS_LIB_Path: ${{ github.workspace }}/xpress/lib
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     outputs:
       TGZ_NAME: ${{ steps.export_output.outputs.TGZ_NAME }}
@@ -107,9 +108,6 @@ jobs:
           antares-version: ${{steps.antares-version.outputs.result}}
           os: ${{matrix.os}}
           os-full-name: Ubuntu-20.04
-
-      - run: |
-          mkdir -p ${{ github.workspace }}/vcpkg_cache
 
       - name: vcpkg install
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
+    env:
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     steps:
 

--- a/.github/workflows/ubuntu-system-deps-build.yml
+++ b/.github/workflows/ubuntu-system-deps-build.yml
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
+    env:
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows-vcpkg-deps-build.yml
+++ b/.github/workflows/windows-vcpkg-deps-build.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       # Indicates the location of the vcpkg as a Git submodule of the project repository.
       VCPKG_ROOT: ${{ github.workspace }}/vcpkg
+      VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg_cache,readwrite"
 
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 PROJECT(antaresXpansion VERSION 1.3.0)
 set(ANTARES_XPANSION_RC 5)
-
+ 
 # ===========================================================================
 # Default parameters
 # ===========================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 
 PROJECT(antaresXpansion VERSION 1.3.0)
 set(ANTARES_XPANSION_RC 5)
- 
+
 # ===========================================================================
 # Default parameters
 # ===========================================================================


### PR DESCRIPTION
VCPKG_BINARY_SOURCES env variable was missing in some case. This variable define the path where vcpkg cache things.
Since the variable was not set it used the default path which was different from the path set for cache action.