### PR TITLE
[ANT-1890] Properly handle playlist_reset in generaldata.ini

### DIFF
--- a/src/cpp/lpnamer/input_reader/GeneralDataReader.cpp
+++ b/src/cpp/lpnamer/input_reader/GeneralDataReader.cpp
@@ -27,8 +27,9 @@ class IniReaderUtils {
   }
 
   static std::pair<std::string, int> GetKeyValFromLine(std::string_view line) {
-    auto key = StringManip::trim(StringManip::split(line, '=')[0]);
-    auto val = std::stoi(StringManip::trim(StringManip::split(line, '=')[1]));
+    const auto splitLine = StringManip::split(line, '=');
+    auto key = StringManip::trim(splitLine[0]);
+    auto val = std::stoi(StringManip::trim(splitLine[1]));
     return {key, val};
   }
 };

--- a/src/cpp/lpnamer/input_reader/GeneralDataReader.cpp
+++ b/src/cpp/lpnamer/input_reader/GeneralDataReader.cpp
@@ -28,7 +28,7 @@ class IniReaderUtils {
 
   static std::pair<std::string, int> GetKeyValFromLine(std::string_view line) {
     auto key = StringManip::trim(StringManip::split(line, '=')[0]);
-    auto val = std::atoi(StringManip::trim(StringManip::split(line, '=')[1]).c_str());
+    auto val = std::stoi(StringManip::trim(StringManip::split(line, '=')[1]));
     return {key, val};
   }
 };
@@ -136,13 +136,18 @@ std::string GeneralDataIniReader::ReadPlaylist(
     const std::string& current_section, const std::string& line) {
   if (IniReaderUtils::LineIsNotASectionHeader(line)) {
     if (current_section == "playlist") {
-      auto [key, val] = IniReaderUtils::GetKeyValFromLine(line);
-      ReadPlaylistVal(key, val);
+      ReadPlaylist(line);
     }
   } else {
     return IniReaderUtils::ReadSectionHeader(line);
   }
   return current_section;
+}
+void GeneralDataIniReader::ReadPlaylist(const std::string& line) {
+  if (line.find("playlist_reset") == std::string::npos) {
+    auto [key, val] = IniReaderUtils::GetKeyValFromLine(line);
+    ReadPlaylistVal(key, val);
+  }
 }
 
 void GeneralDataIniReader::ReadPlaylistVal(const std::string& key, int val) {

--- a/src/cpp/lpnamer/input_reader/GeneralDataReader.h
+++ b/src/cpp/lpnamer/input_reader/GeneralDataReader.h
@@ -18,26 +18,6 @@ class IniFileNotFound : public std::runtime_error {
   explicit IniFileNotFound(const std::string& msg) : std::runtime_error(msg) {}
 };
 
-class IniReaderUtils {
- public:
-  static bool LineIsNotASectionHeader(const std::string& line) {
-    return StringManip::split(StringManip::trim(line), '=').size() == 2;
-  }
-
-  static std::string ReadSectionHeader(const std::string& line) {
-    auto str = StringManip::trim(line);
-    str.erase(std::remove(str.begin(), str.end(), '['), str.end());
-    str.erase(std::remove(str.begin(), str.end(), ']'), str.end());
-    return str;
-  }
-
-  static std::pair<std::string, int> GetKeyValFromLine(std::string_view line) {
-    auto key = StringManip::trim(StringManip::split(line, '=')[0]);
-    auto val = std::stoi(StringManip::trim(StringManip::split(line, '=')[1]));
-    return {key, val};
-  }
-};
-
 class GeneralDataIniReader {
  private:
   ProblemGenerationLog::ProblemGenerationLoggerSharedPointer logger_;

--- a/src/cpp/lpnamer/input_reader/GeneralDataReader.h
+++ b/src/cpp/lpnamer/input_reader/GeneralDataReader.h
@@ -37,6 +37,7 @@ class GeneralDataIniReader {
   std::string ReadPlaylist(const std::string& current_section,
                            const std::string& line);
   void ReadPlaylistVal(const std::string& key, int val);
+  void ReadPlaylist(const std::string& line);
 
  public:
   explicit GeneralDataIniReader(

--- a/tests/cpp/lp_namer/CMakeLists.txt
+++ b/tests/cpp/lp_namer/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable (lp_namer_tests
         WeightsFileReaderTest.cpp
         LpFilesExtractorTest.cpp
         MpsTxtWriterTest.cpp
+        GeneralDataReadetTests.cpp
 )
 
 target_link_libraries (lp_namer_tests PRIVATE

--- a/tests/cpp/lp_namer/GeneralDataReadetTests.cpp
+++ b/tests/cpp/lp_namer/GeneralDataReadetTests.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+
+#include "GeneralDataReader.h"
+
+//Test for the GeneralDataIniReader class
+class GeneralDataIniReaderTests : public testing::TestWithParam<bool> {
+ public:
+  GeneralDataIniReaderTests() = default;
+  ~GeneralDataIniReaderTests() override = default;
+};
+
+INSTANTIATE_TEST_SUITE_P(reset_value, GeneralDataIniReaderTests,
+                         testing::Bool());
+TEST_P(GeneralDataIniReaderTests, ReadPlaylistReset_option) {
+  auto test_dir = std::filesystem::temp_directory_path() / std::tmpnam(nullptr);
+  std::filesystem::create_directory(test_dir);
+  auto ini_file = test_dir / "test.ini";
+  std::ofstream file(ini_file);
+  file << "[general]\n"
+          "nbyears=10\n"
+          "user-playlist=true\n"
+          "[playlist]\n"
+          "playlist_reset = ";
+  GetParam() ? file << "true\n" : file << "false\n";
+  file << "playlist_year += 0\n"
+          "playlist_year += 5\n"
+          "playlist_year += 8\n"
+          "playlist_year -= 1\n"
+          "playlist_year -= 2\n"
+          "playlist_year -= 3\n";
+  file.close();
+
+  GeneralDataIniReader reader(ini_file, nullptr);
+  //GetActiveYears() returns the active years whereas file contains index. year=index+1
+  //reset = false => Active playlist (+=)
+  //rest = true => !inactive playlist (-=)
+  if (GetParam()) {
+    EXPECT_EQ(reader.GetActiveYears(), std::vector<int>({1, 5, 6, 7, 8, 9, 10}));
+  } else {
+    EXPECT_EQ(reader.GetActiveYears(), std::vector<int>({1, 6, 9}));
+  }
+}

--- a/tests/cpp/lp_namer/GeneralDataReadetTests.cpp
+++ b/tests/cpp/lp_namer/GeneralDataReadetTests.cpp
@@ -21,7 +21,7 @@ TEST_P(GeneralDataIniReaderTests, ReadPlaylistReset_option) {
           "user-playlist=true\n"
           "[playlist]\n"
           "playlist_reset = ";
-  GetParam() ? file << "true\n" : file << "false\n";
+  file << (GetParam() ? "true\n" : "false\n");
   file << "playlist_year += 0\n"
           "playlist_year += 5\n"
           "playlist_year += 8\n"


### PR DESCRIPTION
Fix #864 
Properly handle data and avoid exception thrown when reading not numerical values with stoi when reading "playlist_reset" entry in general_data.ini