### PR TITLE
update changelog 

### DIFF
--- a/docs/changelog/CHANGELOG.md
+++ b/docs/changelog/CHANGELOG.md
@@ -7,6 +7,8 @@ v1.3.1 (07/2024)
 ### Features
 
 - **outer_loop** option is renamed **adequacy_criterion**
+- New output file **criterions.txt** is added under **lp/** dir to store adequacy criterions for all valid patterns (area+criterion)
+- New output file **PositiveUnsuppliedEnergy.txt** is added under **lp/** dir to store the amount of unsupplied energy for all valid patterns (area+criterion)
 
 ### Bug Fixes
 

--- a/docs/user-guide/get-started/adequacy-criterion.md
+++ b/docs/user-guide/get-started/adequacy-criterion.md
@@ -47,5 +47,5 @@ Several log files are written:
 
 - `reportbenders.txt` gives information on the progress of the algorithm with an operational perspective,
 - `benders_solver.log` contains more detailed information on all data of interest to follow the progress of the algorithm (`lambda_min`, `lambda_max`, detailed solving times, ...).
-- New output file **criterions.txt** is added under **lp/** dir to store adequacy criterions for all valid patterns (area+criterion)
-- New output file **PositiveUnsuppliedEnergy.txt** is added under **lp/** dir to store the amount of unsupplied energy for all valid patterns (area+criterion)
+- New output file `criterions.txt` is added under `lp/` dir to store adequacy criterions for all valid patterns (area+criterion)
+- New output file `PositiveUnsuppliedEnergy.txt` is added under `lp/` dir to store the amount of unsupplied energy for all valid patterns (area+criterion)

--- a/docs/user-guide/get-started/adequacy-criterion.md
+++ b/docs/user-guide/get-started/adequacy-criterion.md
@@ -47,5 +47,5 @@ Several log files are written:
 
 - `reportbenders.txt` gives information on the progress of the algorithm with an operational perspective,
 - `benders_solver.log` contains more detailed information on all data of interest to follow the progress of the algorithm (`lambda_min`, `lambda_max`, detailed solving times, ...).
-- New output file `criterions.txt` is added under `lp/` dir to store adequacy criterions for all valid patterns (area+criterion)
-- New output file `PositiveUnsuppliedEnergy.txt` is added under `lp/` dir to store the amount of unsupplied energy for all valid patterns (area+criterion)
+- The file `criterions.txt` under `lp/` dir stores adequacy criterions for all valid patterns (area+criterion)
+- The file `PositiveUnsuppliedEnergy.txt` under `lp/` dir stores the amount of unsupplied energy for all valid patterns (area+criterion)

--- a/docs/user-guide/get-started/adequacy-criterion.md
+++ b/docs/user-guide/get-started/adequacy-criterion.md
@@ -47,3 +47,5 @@ Several log files are written:
 
 - `reportbenders.txt` gives information on the progress of the algorithm with an operational perspective,
 - `benders_solver.log` contains more detailed information on all data of interest to follow the progress of the algorithm (`lambda_min`, `lambda_max`, detailed solving times, ...).
+- New output file **criterions.txt** is added under **lp/** dir to store adequacy criterions for all valid patterns (area+criterion)
+- New output file **PositiveUnsuppliedEnergy.txt** is added under **lp/** dir to store the amount of unsupplied energy for all valid patterns (area+criterion)


### PR DESCRIPTION

- New output file **criterions.txt** is added under **lp/** dir to store adequacy criterions for all valid patterns (area+criterion)
- New output file **PositiveUnsuppliedEnergy.txt** is added under **lp/** dir to store the amount of unsupplied energy for all valid patterns (area+criterion)