### PR TITLE
Handle Antares error -9

### DIFF
--- a/src/python/antares_xpansion/antares_driver.py
+++ b/src/python/antares_xpansion/antares_driver.py
@@ -7,9 +7,9 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+from antares_xpansion.__version__ import __antares_simulator_version__
 from antares_xpansion.logger import step_logger
 from antares_xpansion.study_output_cleaner import StudyOutputCleaner
-from antares_xpansion.__version__ import __antares_simulator_version__
 from packaging import version
 
 
@@ -75,6 +75,10 @@ class AntaresDriver:
         if returned_l.returncode == 1:
             raise AntaresDriver.AntaresExecutionError(
                 f"Error: exited antares with status {returned_l.returncode}")
+        elif returned_l.returncode == -9:
+            raise AntaresDriver.AntaresExecutionError(
+                f"Error: exited antares with status {returned_l.returncode}"
+                f" (probably due to memory limit)")
         elif returned_l.returncode != 0 and returned_l.returncode != 1:
             self.logger.info(
                 f"Warning: exited antares with status {returned_l.returncode}")


### PR DESCRIPTION
Output exemple

```
[XpansionDriver][ERROR 04-10-2024 14:53:04]  Antares exited with error, backup current general data file and revert original one
Traceback (most recent call last):
  File "/home/marechaljas/CLionProjects/antares-xpansion/src/python/launch.py", line 51, in <module>
    DRIVER.launch()
  File "/home/marechaljas/CLionProjects/antares-xpansion/src/python/antares_xpansion/driver.py", line 75, in launch
    self.launch_antares_step()
  File "/home/marechaljas/CLionProjects/antares-xpansion/src/python/antares_xpansion/driver.py", line 148, in launch_antares_step
    raise e
  File "/home/marechaljas/CLionProjects/antares-xpansion/src/python/antares_xpansion/driver.py", line 136, in launch_antares_step
    ret = self.antares_driver.launch(
  File "/home/marechaljas/CLionProjects/antares-xpansion/src/python/antares_xpansion/antares_driver.py", line 38, in launch
    return self._launch(antares_study_path)
  File "/home/marechaljas/CLionProjects/antares-xpansion/src/python/antares_xpansion/antares_driver.py", line 50, in _launch
    return self._run_antares()
  File "/home/marechaljas/CLionProjects/antares-xpansion/src/python/antares_xpansion/antares_driver.py", line 79, in _run_antares
    raise AntaresDriver.AntaresExecutionError(
antares_xpansion.antares_driver.AntaresExecutionError: Error: exited antares with status -9 (probably due to memory limit)

```