### PR TITLE
Fix generation of weights in API mode [ANT-2196]

### DIFF
--- a/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
+++ b/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <numeric>
+#include <ranges>
 
 #include "StringManip.h"
 
@@ -27,16 +28,16 @@ void YearlyWeightsWriter::CreateWeightFile() {
 
 void YearlyWeightsWriter::FillMpsWeightsMap() {
   mps_weights_.clear();
-  std::vector<std::filesystem::path> mps_files;
-  for (auto& p : std::filesystem::directory_iterator(xpansion_lp_dir_)) {
-    if (p.path().extension() == ".mps") mps_files.emplace_back(p.path());
-  }
-  for (auto& mps_file : mps_files) {
-    auto year = GetYearFromMpsName(mps_file.filename().string());
+  auto it = std::filesystem::directory_iterator(xpansion_lp_dir_);
+  auto mps_list = it | std::views::filter([](const auto& p) {
+                    return p.path().extension() == ".mps";
+                  });
+  for (auto& mps_file : mps_list ) {
+    auto year = GetYearFromMpsName(mps_file.path().filename().string());
     auto year_index =
         std::find(active_years_.begin(), active_years_.end(), year) -
         active_years_.begin();
-    mps_weights_[mps_file.filename()] = weights_vector_[year_index];
+    mps_weights_[mps_file.path().filename()] = weights_vector_[year_index];
   }
 }
 

--- a/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
+++ b/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
@@ -3,17 +3,14 @@
 #include <fstream>
 #include <numeric>
 
-#include "ArchiveReader.h"
 #include "StringManip.h"
 
 YearlyWeightsWriter::YearlyWeightsWriter(
     const std::filesystem::path& xpansion_output_dir,
-    const std::filesystem::path& antares_archive_path,
     const std::vector<double>& weights_vector,
     const std::filesystem::path& output_file,
     const std::vector<int>& active_years)
     : xpansion_output_dir_(xpansion_output_dir),
-      antares_archive_path_(antares_archive_path),
       weights_vector_(weights_vector),
       output_file_(output_file),
       active_years_(active_years) {
@@ -30,19 +27,17 @@ void YearlyWeightsWriter::CreateWeightFile() {
 
 void YearlyWeightsWriter::FillMpsWeightsMap() {
   mps_weights_.clear();
-  auto zip_reader = ArchiveReader(antares_archive_path_);
-  zip_reader.Open();
-  zip_reader.LoadEntriesPath();
-  const auto& mps_files = zip_reader.GetEntriesPathWithExtension(".mps");
+  std::vector<std::filesystem::path> mps_files;
+  for (auto& p : std::filesystem::directory_iterator(xpansion_lp_dir_)) {
+    if (p.path().extension() == ".mps") mps_files.emplace_back(p.path());
+  }
   for (auto& mps_file : mps_files) {
-    auto year = GetYearFromMpsName(mps_file.string());
+    auto year = GetYearFromMpsName(mps_file.filename().string());
     auto year_index =
         std::find(active_years_.begin(), active_years_.end(), year) -
         active_years_.begin();
     mps_weights_[mps_file.filename()] = weights_vector_[year_index];
   }
-  zip_reader.Close();
-  zip_reader.Delete();
 }
 
 int YearlyWeightsWriter::GetYearFromMpsName(

--- a/src/cpp/lpnamer/input_reader/WeightsFileWriter.h
+++ b/src/cpp/lpnamer/input_reader/WeightsFileWriter.h
@@ -7,7 +7,6 @@
 class YearlyWeightsWriter {
  public:
   explicit YearlyWeightsWriter(const std::filesystem::path& xpansion_output_dir,
-                               const std::filesystem::path& zipped_output_path,
                                const std::vector<double>& weights_vector,
                                const std::filesystem::path& output_file,
                                const std::vector<int>& active_years);

--- a/src/cpp/lpnamer/main/ProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/ProblemGeneration.cpp
@@ -120,7 +120,6 @@ std::shared_ptr<ArchiveReader> InstantiateZipReader(
     const std::filesystem::path& antares_archive_path);
 void ProblemGeneration::ProcessWeights(
     const std::filesystem::path& xpansion_output_dir,
-    const std::filesystem::path& antares_archive_path,
     const std::filesystem::path& weights_file,
     ProblemGenerationLog::ProblemGenerationLoggerSharedPointer logger) {
   const auto settings_dir = xpansion_output_dir / ".." / ".." / "settings";
@@ -314,8 +313,7 @@ void ProblemGeneration::RunProblemGeneration(
       });
 
   if (!weights_file.empty()) {
-    ProcessWeights(xpansion_output_dir, antares_archive_path, weights_file,
-                   logger);
+    ProcessWeights(xpansion_output_dir, weights_file, logger);
   }
 
   if (mode_ == SimulationInputMode::ARCHIVE) {

--- a/src/cpp/lpnamer/main/include/ProblemGeneration.h
+++ b/src/cpp/lpnamer/main/include/ProblemGeneration.h
@@ -38,7 +38,6 @@ class ProblemGeneration {
 
   void ProcessWeights(
       const std::filesystem::path& xpansion_output_dir,
-      const std::filesystem::path& antares_archive_path,
       const std::filesystem::path& weights_file,
       ProblemGenerationLog::ProblemGenerationLoggerSharedPointer logger);
   void ExtractUtilsFiles(

--- a/tests/cpp/lp_namer/CMakeLists.txt
+++ b/tests/cpp/lp_namer/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable (lp_namer_tests
         LoggerBuilder.cpp
         ProblemGenerationLoggerTest.cpp
         WeightsFileReaderTest.cpp
+        WeightsFileWriterTest.cpp
         LpFilesExtractorTest.cpp
         MpsTxtWriterTest.cpp
         AntaresProblemToXpansionProblemTranslatorTest.cpp

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -1,0 +1,45 @@
+#include <fstream>
+
+#include "WeightsFileWriter.h"
+#include "gtest/gtest.h"
+
+void writeDummyFileInTempLpDir(std::string name) {
+  auto tmp_path = std::filesystem::temp_directory_path() / "lp" / name;
+  std::ofstream writer;
+  writer.open(tmp_path);
+  writer << std::endl;
+  writer.close();
+}
+
+TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFile) {
+  auto tempDir = std::filesystem::temp_directory_path() / "lp";
+  if (!std::filesystem::is_directory(tempDir)) {
+    std::filesystem::create_directory(tempDir);
+  }
+  writeDummyFileInTempLpDir("problem-1-1--optim-nb-1.mps");
+  writeDummyFileInTempLpDir("problem-1-50--optim-nb-1.mps");
+  writeDummyFileInTempLpDir("problem-2-10--optim-nb-1.mps");
+  writeDummyFileInTempLpDir("problem-2-11--optim-nb-1.mps");
+  writeDummyFileInTempLpDir("problem-2-30--optim-nb-1.mps");
+  writeDummyFileInTempLpDir("problem-3-20--optim-nb-1.mps");
+  writeDummyFileInTempLpDir("problem-3-30--optim-nb-1.txt");
+
+  auto yearly_weight_writer =
+      YearlyWeightsWriter(std::filesystem::temp_directory_path(), {3, 5, 7},
+                          "weights_123.txt", {1, 2, 3});
+  yearly_weight_writer.CreateWeightFile();
+
+  std::ifstream reader(tempDir / "weights_123.txt");
+  std::string actual((std::istreambuf_iterator<char>(reader)),
+                     std::istreambuf_iterator<char>());
+  std::string expected = R"xxx(problem-1-1--optim-nb-1.mps 3
+problem-1-50--optim-nb-1.mps 3
+problem-2-10--optim-nb-1.mps 5
+problem-2-11--optim-nb-1.mps 5
+problem-2-30--optim-nb-1.mps 5
+problem-3-20--optim-nb-1.mps 7
+WEIGHT_SUM 15
+)xxx";
+
+  EXPECT_EQ(expected, actual);
+}

--- a/tests/end_to_end/cucumber/features/weights.feature
+++ b/tests/end_to_end/cucumber/features/weights.feature
@@ -4,6 +4,6 @@ Feature: add weights on MC years
   Scenario: handling different weights on MC years in API mode
     # For now, only check that the simulation succeeds
     # TODO : add more non-regression tests when we have more steps
-    Given the study path is "examples/SmallTestFiveCandidatesWithWeights"
+    Given the study path is "examples/SmallTestFiveCandidatesWithWeights" for a study with weights
     When I run antares-xpansion in memory with the benders method and 1 proc(s)
     Then the simulation succeeds

--- a/tests/end_to_end/cucumber/features/weights.feature
+++ b/tests/end_to_end/cucumber/features/weights.feature
@@ -1,0 +1,9 @@
+Feature: add weights on MC years
+
+  @slow @short @full-launch
+  Scenario: handling different weights on MC years in API mode
+    # For now, only check that the simulation succeeds
+    # TODO : add more non-regression tests when we have more steps
+    Given the study path is "examples/SmallTestFiveCandidatesWithWeights"
+    When I run antares-xpansion in memory with the benders method and 1 proc(s)
+    Then the simulation succeeds

--- a/tests/end_to_end/cucumber/steps/steps.py
+++ b/tests/end_to_end/cucumber/steps/steps.py
@@ -62,7 +62,7 @@ def run_antares_xpansion(context, method, n):
     process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, shell=True)
     out, err = process.communicate()
     context.return_code = process.returncode
-    context.outputs = read_outputs(Path(parse_output_folder_from_logs(out)) / "expansion" / "out.json")
+    context.outputs = read_outputs(Path(get_results_file_path_from_logs(out)))
 
 
 @then("the simulation takes less than {seconds:d} seconds")
@@ -97,8 +97,8 @@ def check_solution(context):
     assert_dict_allclose(context.outputs["solution"]["values"], expected_solution)
 
 
-def parse_output_folder_from_logs(logs: bytes) -> str:
+def get_results_file_path_from_logs(logs: bytes) -> str:
     for line in logs.splitlines():
-        if b'Output folder : ' in line:
-            return line.split(b'Output folder : ')[1].decode('ascii')
-    raise LookupError("Could not parse output folder in output logs")
+        if b'Optimization results available in : ' in line:
+            return line.split(b'Optimization results available in : ')[1].decode('ascii')
+    raise LookupError("Could not find results file path in output logs")


### PR DESCRIPTION
When generating weights.txt, instead of using list of MPS files generated by simulator in the archive, use the list of MPS files generated by XPANSION in output_dir/lp.
This makes it compatible with API mode.

Also added a cucumber test with a new step to launch xpansion (and fixed the "simulation succeeds" step)