### PR TITLE
trigger only by push

### DIFF
--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - develop
-      - dependabot/*
+      - feature/*
+      - features/*
+      - fix/*
+      - issue-*
       - release/*
-  pull_request:
+      - doc/*
+      - dependabot/*
   release:
     types: [ created ]
 

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - develop
-      - dependabot/*
+      - feature/*
+      - features/*
+      - fix/*
+      - issue-*
       - release/*
-  pull_request:
+      - doc/*
+      - dependabot/*
   release:
     types: [ created ]
 

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -4,11 +4,14 @@ on:
   merge_group:
   push:
     branches:
-      - main
       - develop
-      - dependabot/*
+      - feature/*
+      - features/*
+      - fix/*
+      - issue-*
       - release/*
-  pull_request:
+      - doc/*
+      - dependabot/*
   release:
     types: [ created ]
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -4,11 +4,14 @@ on:
   merge_group:
   push:
     branches:
-      - main
       - develop
-      - dependabot/*
+      - feature/*
+      - features/*
+      - fix/*
+      - issue-*
       - release/*
-  pull_request:
+      - doc/*
+      - dependabot/*
   release:
     types: [ created ]
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,11 +3,14 @@ name: SonarCloud
 on:
   push:
     branches:
-      - main
       - develop
+      - feature/*
+      - features/*
+      - fix/*
+      - issue-*
       - release/*
+      - doc/*
       - dependabot/*
-  pull_request:
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
to avoid to merge develop automatically:
Checking out the ref
  /usr/bin/git checkout --progress --force refs/remotes/pull/950/merge
  Note: switching to 'refs/remotes/pull/950/merge'.
  
  You are in 'detached HEAD' state. You can look around, make experimental
  changes and commit them, and you can discard any commits you make in this
  state without impacting any branches by switching back to a branch.
  
  If you want to create a new branch to retain commits you create, you may
  do so (now or later) by using -c with the switch command. Example:
  
    git switch -c <new-branch-name>
  
  Or undo this operation with:
  
    git switch -
  
  Turn off this advice by setting config variable advice.detachedHead to false
  
  HEAD is now at b59b11a Merge b234f61b8de8ed67aa3e5028d33c408fcd1af5c7 into c5dde687f9a1266ebd6391de64b2c7f2d3b9e781