### PR TITLE
Replace expansive regex with find

### DIFF
--- a/src/cpp/benders/benders_core/CriterionInputDataReader.cpp
+++ b/src/cpp/benders/benders_core/CriterionInputDataReader.cpp
@@ -13,14 +13,10 @@ using namespace Benders::Criterion;
 CriterionPattern::CriterionPattern(std::string prefix, std::string body)
     : prefix_(std::move(prefix)), body_(std::move(body)) {}
 
-/**
- * just do
- * just cat ;)
- */
-std::regex CriterionPattern::MakeRegex() const {
-  auto pattern = "(^" + prefix_ + "area<" + body_ + ">" + ")";
-  return std::regex(pattern);
+std::string CriterionPattern::Pattern() const {
+  return prefix_ + "area<" + body_ + ">";
 }
+
 const std::string &CriterionPattern::GetPrefix() const { return prefix_; }
 void CriterionPattern::SetPrefix(const std::string &prefix) {
   prefix_ = prefix;

--- a/src/cpp/benders/benders_core/VariablesGroup.cpp
+++ b/src/cpp/benders/benders_core/VariablesGroup.cpp
@@ -25,15 +25,16 @@ std::vector<std::vector<int>> VariablesGroup::Indices() const {
 
 void VariablesGroup::Search() {
   indices_.assign(criterion_single_input_data_.size(), {});
-  int var_index(0);
-  for (const auto& variable : all_variables_) {
-    int pattern_index(0);
-    for (const auto& single_input_data : criterion_single_input_data_) {
-      if (std::regex_search(variable, single_input_data.Pattern().MakeRegex())) {
+  int pattern_index(0);
+  for (const auto& single_input_data : criterion_single_input_data_) {
+    auto pattern = single_input_data.Pattern().GetPrefix() + "area<" + single_input_data.Pattern().GetBody() + ">";
+    int var_index(0);
+    for (const auto& variable : all_variables_) {
+      if (variable.find(single_input_data.Pattern().GetPrefix()) != std::string::npos) {
         indices_[pattern_index].push_back(var_index);
       }
-      ++pattern_index;
+      var_index++;
     }
-    ++var_index;
+    ++pattern_index;
   }
 }

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/CriterionInputDataReader.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/CriterionInputDataReader.h
@@ -45,7 +45,7 @@ class CriterionPattern {
  public:
   explicit CriterionPattern(std::string prefix, std::string body);
   CriterionPattern() = default;
-  [[nodiscard]] std::regex MakeRegex() const;
+  [[nodiscard]] std::string Pattern() const;
   [[nodiscard]] const std::string &GetPrefix() const;
   void SetPrefix(const std::string &prefix);
   [[nodiscard]] const std::string &GetBody() const;
@@ -54,7 +54,6 @@ class CriterionPattern {
  private:
   std::string prefix_;
   std::string body_;
-
 };
 
 /// @brief holds the pattern and the criterion

--- a/tests/cpp/outer_loop/outer_loop_test.cpp
+++ b/tests/cpp/outer_loop/outer_loop_test.cpp
@@ -181,17 +181,17 @@ TEST_F(OuterLoopPatternTest, RegexGivenPrefixAndBody) {
   const std::string body = "body";
   CriterionPattern o(prefix, body);
 
-  auto ret_regex = o.MakeRegex();
+  auto ret_regex = o.Pattern();
 
-  ASSERT_EQ(std::regex_search(prefix + body, ret_regex), false);
-  ASSERT_EQ(std::regex_search(prefix + "::" + body + "::suffix", ret_regex),
+  ASSERT_EQ((prefix + body).find(ret_regex) != std::string::npos, false);
+  ASSERT_EQ((prefix + "::" + body + "::suffix").find(ret_regex) != std::string::npos,
             false);
-  ASSERT_EQ(std::regex_search(body + prefix, ret_regex), false);
-  ASSERT_EQ(std::regex_search(prefix + "::", ret_regex), false);
-  ASSERT_EQ(std::regex_search(body, ret_regex), false);
-  ASSERT_EQ(std::regex_search(prefix + "area<" + body + ">", ret_regex), true);
-  ASSERT_EQ(std::regex_search(prefix + "area<" + body + ">::suffix", ret_regex), true);
-  ASSERT_EQ(std::regex_search(prefix + "area<" + body + "_other_area>::suffix", ret_regex), false);
+  ASSERT_EQ((body + prefix).find(ret_regex) != std::string::npos , false);
+  ASSERT_EQ((prefix + "::").find(ret_regex) != std::string::npos, false);
+  ASSERT_EQ((body).find(ret_regex) != std::string::npos, false);
+  ASSERT_EQ((prefix + "area<" + body + ">").find(ret_regex) != std::string::npos, true);
+  ASSERT_EQ((prefix + "area<" + body + ">::suffix").find(ret_regex) != std::string::npos, true); //Match
+  ASSERT_EQ((prefix + "area<" + body + "_other_area>::suffix").find(ret_regex) != std::string::npos, false);
 }
 
 class OuterLoopInputFromYamlTest : public ::testing::Test {};


### PR DESCRIPTION
std::regex is atrociously slow. We could replace it with another lib but in this case we don't really require the power of regex expressions and just need a regular string equality match.

Performance wise :
For 66 criterions and 247320 variables
Using regex, variablesGroups::search takes 74s out of 90 (82%)
Using find it takes 0.5s out of 20 (2,5%)