### PR TITLE
Weights not correctly read for subproblems

### DIFF
--- a/src/cpp/benders/benders_core/Worker.cpp
+++ b/src/cpp/benders/benders_core/Worker.cpp
@@ -49,7 +49,7 @@ void Worker::init(const std::string &solver_name, int log_level,
   }
 
   read_prob(_solver.get(), _path_to_mps);
-  // Always set solver parameters after reading problems, as restore also comes with parameters of the solver and we do not want them to override our preferences
+  // Always set solver parameters after reading problems, as restore (used by Xpress writing .svf files) also comes with parameters of the solver and we do not want them to override our preferences
   _solver->set_threads(1);
   _solver->set_output_log_level(log_level);
 

--- a/src/cpp/benders/benders_core/Worker.cpp
+++ b/src/cpp/benders/benders_core/Worker.cpp
@@ -48,9 +48,10 @@ void Worker::init(const std::string &solver_name, int log_level,
                                     solver_log_manager);
   }
 
+  read_prob(_solver.get(), _path_to_mps);
+  // Always set solver parameters after reading problems, as restore also comes with parameters of the solver and we do not want them to override our preferences
   _solver->set_threads(1);
   _solver->set_output_log_level(log_level);
-  read_prob(_solver.get(), _path_to_mps);
 
   for (auto const &kvp : _name_to_id) {
     _id_to_name[kvp.second] = kvp.first;

--- a/src/cpp/lpnamer/input_reader/MpsTxtWriter.cpp
+++ b/src/cpp/lpnamer/input_reader/MpsTxtWriter.cpp
@@ -26,6 +26,7 @@ auto FileWithExtension(std::string_view ext,
 
 void FilesMapper::FillMapFiles() {
   year_week_and_files_dict_.clear();
+  // For now, Antares can only write .mps files
   FillMapWithMpsFiles(FileWithExtension(".mps"s, simulation_dir_));
   std::vector<std::filesystem::path> variables_files;
   std::vector<std::filesystem::path> constraints_files;
@@ -57,6 +58,7 @@ void FilesMapper::FillMapZip() {
   zip_reader.Open();
   zip_reader.LoadEntriesPath();
   year_week_and_files_dict_.clear();
+  // For now, Antares can only write .mps files
   FillMapWithMpsFiles(zip_reader.GetEntriesPathWithExtension(".mps"s));
   std::vector<std::filesystem::path> variables_files;
   std::vector<std::filesystem::path> constraints_files;

--- a/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
+++ b/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
@@ -1,5 +1,7 @@
 #include "antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h"
 
+#include <antares-xpansion/multisolver_interface/SolverConfig.h>
+
 #include <fstream>
 #include <numeric>
 #include <ranges>
@@ -11,34 +13,35 @@ YearlyWeightsWriter::YearlyWeightsWriter(
     const std::filesystem::path& xpansion_output_dir,
     const std::vector<double>& weights_vector,
     const std::filesystem::path& output_file,
-    const std::vector<int>& active_years)
+    const std::vector<int>& active_years, const std::string& solver_name)
     : xpansion_output_dir_(xpansion_output_dir),
       weights_vector_(weights_vector),
       output_file_(output_file),
-      active_years_(active_years) {
+      active_years_(active_years),
+      solver_name_(solver_name) {
   xpansion_lp_dir_ = xpansion_output_dir / LP_DIR;
   if (!std::filesystem::is_directory(xpansion_lp_dir_)) {
     std::filesystem::create_directory(xpansion_lp_dir_);
   }
 }
 
-void YearlyWeightsWriter::CreateWeightFile() {
-  FillMpsWeightsMap();
+void YearlyWeightsWriter::CreateWeightFile(
+    const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
+        problems_and_data) {
+  FillMpsWeightsMap(problems_and_data);
   DumpMpsWeightsToFile();
 }
 
-void YearlyWeightsWriter::FillMpsWeightsMap() {
+void YearlyWeightsWriter::FillMpsWeightsMap(
+    const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
+        problems_and_data) {
   mps_weights_.clear();
-  auto it = std::filesystem::directory_iterator(xpansion_lp_dir_);
-  auto mps_list = it | std::views::filter([](const auto& p) {
-                    return p.path().extension() == ".mps";
-                  });
-  for (auto& mps_file : mps_list ) {
-    auto year = GetYearFromMpsName(mps_file.path().filename().string());
-    auto year_index =
-        std::find(active_years_.begin(), active_years_.end(), year) -
-        active_years_.begin();
-    mps_weights_[mps_file.path().filename()] = weights_vector_[year_index];
+
+  for (const auto& [problem, data] : problems_and_data) {
+    auto year_index = std::find(active_years_.begin(), active_years_.end(),
+                                problem->mc_year) -
+                      active_years_.begin();
+    mps_weights_[data._problem_mps] = weights_vector_[year_index];
   }
 }
 
@@ -54,7 +57,10 @@ void YearlyWeightsWriter::DumpMpsWeightsToFile() const {
   mps_weights_file.open(file);
 
   for (const auto& [mps_name, weight] : mps_weights_) {
-    mps_weights_file << mps_name.string() << " " << weight << std::endl;
+    mps_weights_file << SolverConfig::FileName(
+                            mps_name, SolverConfig(std::move(solver_name_)))
+                            .string()
+                     << " " << weight << std::endl;
   }
   mps_weights_file << "WEIGHT_SUM "
                    << std::reduce(weights_vector_.begin(),

--- a/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
+++ b/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
@@ -39,17 +39,13 @@ void YearlyWeightsWriter::FillMpsWeightsMap(
   problem_filename_to_weight_.clear();
 
   for (const auto& [problem, data] : problems_and_data) {
-    if (std::find(active_years_.begin(), active_years_.end(),
-                  problem->mc_year) != active_years_.end()) {
-      auto year_index = std::find(active_years_.begin(), active_years_.end(),
-                                  problem->mc_year) -
-                        active_years_.begin();
-      problem_filename_to_weight_[data._problem_filename] =
-          weights_vector_[year_index];
+    auto it = std::find(active_years_.begin(), active_years_.end(), problem->mc_year);
+    if (it != active_years_.end()) {
+      auto year_index = std::distance(active_years_.begin(), it);
+      problem_filename_to_weight_[data._problem_filename] = weights_vector_[year_index];
     } else {
       std::ostringstream msg;
-      msg << "Mc year" << problem->mc_year
-        << " not found in the list of active years." << std::endl;
+      msg << "Mc year " << problem->mc_year << " not found in the list of active years." << std::endl;
       (*logger_)(LogUtils::LOGLEVEL::FATAL) << LOGLOCATION << msg.str();
       throw McYearNotInActiveYearsListError(msg.str(), LOGLOCATION);
     }

--- a/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
+++ b/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
@@ -35,13 +35,14 @@ void YearlyWeightsWriter::CreateWeightFile(
 void YearlyWeightsWriter::FillMpsWeightsMap(
     const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
         problems_and_data) {
-  mps_weights_.clear();
+  problem_filename_to_weight_.clear();
 
   for (const auto& [problem, data] : problems_and_data) {
     auto year_index = std::find(active_years_.begin(), active_years_.end(),
                                 problem->mc_year) -
                       active_years_.begin();
-    mps_weights_[data._problem_mps] = weights_vector_[year_index];
+    problem_filename_to_weight_[data._problem_filename] =
+        weights_vector_[year_index];
   }
 }
 
@@ -56,10 +57,8 @@ void YearlyWeightsWriter::DumpMpsWeightsToFile() const {
   std::ofstream mps_weights_file;
   mps_weights_file.open(file);
 
-  for (const auto& [mps_name, weight] : mps_weights_) {
-    mps_weights_file << SolverConfig::FileName(
-                            mps_name, SolverConfig(std::move(solver_name_)))
-                            .string()
+  for (const auto& [mps_name, weight] : problem_filename_to_weight_) {
+    mps_weights_file << SolverConfig(solver_name_).FileName(mps_name).string()
                      << " " << weight << std::endl;
   }
   mps_weights_file << "WEIGHT_SUM "

--- a/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
+++ b/src/cpp/lpnamer/input_reader/WeightsFileWriter.cpp
@@ -13,12 +13,13 @@ YearlyWeightsWriter::YearlyWeightsWriter(
     const std::filesystem::path& xpansion_output_dir,
     const std::vector<double>& weights_vector,
     const std::filesystem::path& output_file,
-    const std::vector<int>& active_years, const std::string& solver_name)
+    const std::vector<int>& active_years, const std::string& solver_name, std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger> logger)
     : xpansion_output_dir_(xpansion_output_dir),
       weights_vector_(weights_vector),
       output_file_(output_file),
       active_years_(active_years),
-      solver_name_(solver_name) {
+      solver_name_(solver_name),
+      logger_(logger) {
   xpansion_lp_dir_ = xpansion_output_dir / LP_DIR;
   if (!std::filesystem::is_directory(xpansion_lp_dir_)) {
     std::filesystem::create_directory(xpansion_lp_dir_);
@@ -38,11 +39,20 @@ void YearlyWeightsWriter::FillMpsWeightsMap(
   problem_filename_to_weight_.clear();
 
   for (const auto& [problem, data] : problems_and_data) {
-    auto year_index = std::find(active_years_.begin(), active_years_.end(),
-                                problem->mc_year) -
-                      active_years_.begin();
-    problem_filename_to_weight_[data._problem_filename] =
-        weights_vector_[year_index];
+    if (std::find(active_years_.begin(), active_years_.end(),
+                  problem->mc_year) != active_years_.end()) {
+      auto year_index = std::find(active_years_.begin(), active_years_.end(),
+                                  problem->mc_year) -
+                        active_years_.begin();
+      problem_filename_to_weight_[data._problem_filename] =
+          weights_vector_[year_index];
+    } else {
+      std::ostringstream msg;
+      msg << "Mc year" << problem->mc_year
+        << " not found in the list of active years." << std::endl;
+      (*logger_)(LogUtils::LOGLEVEL::FATAL) << LOGLOCATION << msg.str();
+      throw McYearNotInActiveYearsListError(msg.str(), LOGLOCATION);
+    }
   }
 }
 

--- a/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/MpsTxtWriter.h
+++ b/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/MpsTxtWriter.h
@@ -20,9 +20,9 @@ using MpsVariableConstraintsFiles =
 using YearWeekAndFilesDict = std::map<YearAndWeek, MpsVariableConstraintsFiles>;
 
 struct ProblemData {
-  ProblemData(const std::string& problem_mps, const std::string& variables_txt)
-      : _problem_mps(problem_mps), _variables_txt(variables_txt) {}
-  std::string _problem_mps;
+  ProblemData(const std::string& problem_filename, const std::string& variables_txt)
+      : _problem_filename(problem_filename), _variables_txt(variables_txt) {}
+  std::string _problem_filename;
   std::string _variables_txt;
 };
 

--- a/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h
+++ b/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h
@@ -1,17 +1,24 @@
 #ifndef SRC_CPP_LPNAMER_INPUTREADER_YEARLYWEIGHTSWRITER_H
 #define SRC_CPP_LPNAMER_INPUTREADER_YEARLYWEIGHTSWRITER_H
+#include <antares-xpansion/lpnamer/model/Problem.h>
+
 #include <filesystem>
 #include <map>
 #include <vector>
+
+#include "MpsTxtWriter.h"
 
 class YearlyWeightsWriter {
  public:
   explicit YearlyWeightsWriter(const std::filesystem::path& xpansion_output_dir,
                                const std::vector<double>& weights_vector,
                                const std::filesystem::path& output_file,
-                               const std::vector<int>& active_years);
+                               const std::vector<int>& active_years,
+                               const std::string& solver_name);
 
-  void CreateWeightFile();
+  void CreateWeightFile(
+      const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
+          problems_and_data);
 
  private:
   std::filesystem::path xpansion_output_dir_;
@@ -22,7 +29,10 @@ class YearlyWeightsWriter {
   std::vector<double> weights_vector_;
   std::filesystem::path output_file_;
   std::vector<int> active_years_;
-  void FillMpsWeightsMap();
+  std::string solver_name_;
+  void FillMpsWeightsMap(
+      const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
+          problems_and_data);
   int GetYearFromMpsName(const std::string& file_name) const;
   void DumpMpsWeightsToFile() const;
 };

--- a/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h
+++ b/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h
@@ -25,7 +25,7 @@ class YearlyWeightsWriter {
   std::filesystem::path xpansion_lp_dir_ = "";
   std::filesystem::path antares_archive_path_;
   const std::string LP_DIR = "lp";
-  std::map<std::filesystem::path, double> mps_weights_ = {};
+  std::map<std::filesystem::path, double> problem_filename_to_weight_ = {};
   std::vector<double> weights_vector_;
   std::filesystem::path output_file_;
   std::vector<int> active_years_;

--- a/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h
+++ b/src/cpp/lpnamer/input_reader/include/antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h
@@ -7,18 +7,24 @@
 #include <vector>
 
 #include "MpsTxtWriter.h"
+#include "antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h"
 
 class YearlyWeightsWriter {
  public:
-  explicit YearlyWeightsWriter(const std::filesystem::path& xpansion_output_dir,
-                               const std::vector<double>& weights_vector,
-                               const std::filesystem::path& output_file,
-                               const std::vector<int>& active_years,
-                               const std::string& solver_name);
+  explicit YearlyWeightsWriter(
+      const std::filesystem::path& xpansion_output_dir,
+      const std::vector<double>& weights_vector,
+      const std::filesystem::path& output_file,
+      const std::vector<int>& active_years, const std::string& solver_name,
+      std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger> logger);
 
   void CreateWeightFile(
       const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
           problems_and_data);
+  class McYearNotInActiveYearsListError
+      : public LogUtils::XpansionError<std::runtime_error> {
+    using LogUtils::XpansionError<std::runtime_error>::XpansionError;
+  };
 
  private:
   std::filesystem::path xpansion_output_dir_;
@@ -30,6 +36,7 @@ class YearlyWeightsWriter {
   std::filesystem::path output_file_;
   std::vector<int> active_years_;
   std::string solver_name_;
+  std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger> logger_;
   void FillMpsWeightsMap(
       const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
           problems_and_data);

--- a/src/cpp/lpnamer/main/ProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/ProblemGeneration.cpp
@@ -261,7 +261,7 @@ std::vector<std::shared_ptr<Problem>> ProblemGeneration::getXpansionProblems(
   std::vector<std::string> problem_names;
   std::transform(mpsList.begin(), mpsList.end(),
                  std::back_inserter(problem_names),
-                 [](ProblemData const& data) { return data._problem_mps; });
+                 [](ProblemData const& data) { return data._problem_filename; });
   switch (mode_.value()) {
     case SimulationInputMode::FILE: {
       FileProblemsProviderAdapter adapter(lpDir_, problem_names);
@@ -342,7 +342,7 @@ void ProblemGeneration::RunProblemGeneration(
       ProblemData data{xpansion_problems.at(i)->_name, {}};
       problems_and_data.emplace_back(xpansion_problems.at(i), data);
     } else {
-      xpansion_problems.at(i)->_name = mpsList.at(i)._problem_mps;
+      xpansion_problems.at(i)->_name = mpsList.at(i)._problem_filename;
       problems_and_data.emplace_back(xpansion_problems.at(i), mpsList.at(i));
     }
   }
@@ -376,7 +376,7 @@ void ProblemGeneration::RunProblemGeneration(
             (*logger)(LogUtils::LOGLEVEL::ERR) << "Undefined mode";
             break;
         }
-        linkProblemsGenerator.treat(data._problem_mps, couplings, problem.get(),
+        linkProblemsGenerator.treat(data._problem_filename, couplings, problem.get(),
                                     variables_provider.get(),
                                     mps_file_writer.get());
       });

--- a/src/cpp/lpnamer/main/ProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/ProblemGeneration.cpp
@@ -197,9 +197,9 @@ void ProblemGeneration::ProcessWeights(
                                         logger);
   weights_file_reader.CheckWeightsFile();
   auto weights_vector = weights_file_reader.WeightsList();
-  auto yearly_weight_writer =
-      YearlyWeightsWriter(xpansion_output_dir, weights_vector,
-                          weights_file.filename(), active_years, solver_name);
+  auto yearly_weight_writer = YearlyWeightsWriter(
+      xpansion_output_dir, weights_vector, weights_file.filename(),
+      active_years, solver_name, logger);
   yearly_weight_writer.CreateWeightFile(problems_and_data);
 }
 
@@ -259,9 +259,9 @@ std::vector<std::shared_ptr<Problem>> ProblemGeneration::getXpansionProblems(
     std::shared_ptr<ArchiveReader> reader,
     const Antares::Solver::LpsFromAntares& lps = {}) {
   std::vector<std::string> problem_names;
-  std::transform(mpsList.begin(), mpsList.end(),
-                 std::back_inserter(problem_names),
-                 [](ProblemData const& data) { return data._problem_filename; });
+  std::transform(
+      mpsList.begin(), mpsList.end(), std::back_inserter(problem_names),
+      [](ProblemData const& data) { return data._problem_filename; });
   switch (mode_.value()) {
     case SimulationInputMode::FILE: {
       FileProblemsProviderAdapter adapter(lpDir_, problem_names);
@@ -376,8 +376,8 @@ void ProblemGeneration::RunProblemGeneration(
             (*logger)(LogUtils::LOGLEVEL::ERR) << "Undefined mode";
             break;
         }
-        linkProblemsGenerator.treat(data._problem_filename, couplings, problem.get(),
-                                    variables_provider.get(),
+        linkProblemsGenerator.treat(data._problem_filename, couplings,
+                                    problem.get(), variables_provider.get(),
                                     mps_file_writer.get());
       });
 

--- a/src/cpp/lpnamer/main/ProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/ProblemGeneration.cpp
@@ -20,9 +20,9 @@
 #include "antares-xpansion/lpnamer/model/ActiveLinks.h"
 #include "antares-xpansion/lpnamer/problem_modifier/AdditionalConstraints.h"
 #include "antares-xpansion/lpnamer/problem_modifier/FileProblemsProviderAdapter.h"
+#include "antares-xpansion/lpnamer/problem_modifier/FileWriter.h"
 #include "antares-xpansion/lpnamer/problem_modifier/LauncherHelpers.h"
 #include "antares-xpansion/lpnamer/problem_modifier/LinkProblemsGenerator.h"
-#include "antares-xpansion/lpnamer/problem_modifier/FileWriter.h"
 #include "antares-xpansion/lpnamer/problem_modifier/MasterGeneration.h"
 #include "antares-xpansion/lpnamer/problem_modifier/MasterProblemBuilder.h"
 #include "antares-xpansion/lpnamer/problem_modifier/ProblemVariablesFileAdapter.h"
@@ -62,10 +62,10 @@ ProblemGeneration::ProblemGeneration(ProblemGenerationOptions& options)
 }
 
 namespace {
-  bool islower(std::string_view str) {
-    return std::ranges::all_of(str, [](char c) { return std::islower(c); });
-  }
+bool islower(std::string_view str) {
+  return std::ranges::all_of(str, [](char c) { return std::islower(c); });
 }
+}  // namespace
 static std::string solverXpansionToSimulator(const SolverConfig& in) {
   // in could be Cbc or CBC depending on whether it is defined or not in the
   // settings file
@@ -132,9 +132,9 @@ std::filesystem::path ProblemGeneration::updateProblems() {
     study_dir =
         std::filesystem::absolute(archive_path).parent_path().parent_path();
     // Assume study/output/archive.zip
-    //If doesn't work
-    //study_dir = xpansion_output_dir.parent_path().parent_path(); //Assume study/output/archive.zip
-
+    // If doesn't work
+    // study_dir = xpansion_output_dir.parent_path().parent_path(); //Assume
+    // study/output/archive.zip
   }
 
   if (mode_ == SimulationInputMode::ANTARES_API) {
@@ -184,8 +184,10 @@ std::filesystem::path ProblemGeneration::updateProblems() {
 std::shared_ptr<ArchiveReader> InstantiateZipReader(
     const std::filesystem::path& antares_archive_path);
 void ProblemGeneration::ProcessWeights(
+    const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
+        problems_and_data,
     const std::filesystem::path& xpansion_output_dir,
-    const std::filesystem::path& weights_file,
+    const std::filesystem::path& weights_file, const std::string& solver_name,
     std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger> logger) {
   const auto settings_dir = xpansion_output_dir / ".." / ".." / "settings";
   const auto general_data_file = settings_dir / "generaldata.ini";
@@ -197,8 +199,8 @@ void ProblemGeneration::ProcessWeights(
   auto weights_vector = weights_file_reader.WeightsList();
   auto yearly_weight_writer =
       YearlyWeightsWriter(xpansion_output_dir, weights_vector,
-                          weights_file.filename(), active_years);
-  yearly_weight_writer.CreateWeightFile();
+                          weights_file.filename(), active_years, solver_name);
+  yearly_weight_writer.CreateWeightFile(problems_and_data);
 }
 
 void ProblemGeneration::ExtractUtilsFiles(
@@ -227,7 +229,8 @@ std::vector<ActiveLink> getLinks(
  */
 void validateMasterFormulation(
     const std::string& master_formulation,
-    const std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger> logger) {
+    const std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger>
+        logger) {
   if ((master_formulation != "relaxed") && (master_formulation != "integer")) {
     (*logger)(LogUtils::LOGLEVEL::FATAL)
         << LOGLOCATION
@@ -320,11 +323,13 @@ void ProblemGeneration::RunProblemGeneration(
 
   auto solver_log_manager = SolverLogManager(log_file_path);
   Couplings couplings;
-  LinkProblemsGenerator linkProblemsGenerator(
-      lpDir_, links, solver_config_, logger, solver_log_manager, rename_problems);
+  LinkProblemsGenerator linkProblemsGenerator(lpDir_, links, solver_config_,
+                                              logger, solver_log_manager,
+                                              rename_problems);
   std::shared_ptr<ArchiveReader> reader =
-      mode_ == SimulationInputMode::ARCHIVE ? InstantiateZipReader(antares_archive_path)
-                                   : std::make_shared<ArchiveReader>();
+      mode_ == SimulationInputMode::ARCHIVE
+          ? InstantiateZipReader(antares_archive_path)
+          : std::make_shared<ArchiveReader>();
 
   /* Main stuff */
   std::vector<std::shared_ptr<Problem>> xpansion_problems = getXpansionProblems(
@@ -377,7 +382,8 @@ void ProblemGeneration::RunProblemGeneration(
       });
 
   if (!weights_file.empty()) {
-    ProcessWeights(xpansion_output_dir, weights_file, logger);
+    ProcessWeights(problems_and_data, xpansion_output_dir, weights_file,
+                   solver_config_.Name(), logger);
   }
 
   if (mode_ == SimulationInputMode::ARCHIVE) {

--- a/src/cpp/lpnamer/main/include/antares-xpansion/lpnamer/main/ProblemGeneration.h
+++ b/src/cpp/lpnamer/main/include/antares-xpansion/lpnamer/main/ProblemGeneration.h
@@ -40,8 +40,10 @@ class ProblemGeneration {
       const std::filesystem::path& weights_file, bool unnamed_problems);
 
   void ProcessWeights(
+      const std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>&
+          problems_and_data,
       const std::filesystem::path& xpansion_output_dir,
-      const std::filesystem::path& weights_file,
+      const std::filesystem::path& weights_file, const std::string& solver_name,
       std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger> logger);
   void ExtractUtilsFiles(
       const std::filesystem::path& antares_archive_path,

--- a/src/cpp/lpnamer/problem_modifier/LinkProblemsGenerator.cpp
+++ b/src/cpp/lpnamer/problem_modifier/LinkProblemsGenerator.cpp
@@ -74,7 +74,7 @@ void LinkProblemsGenerator::treatloop(const std::filesystem::path &root,
       std::execution::par, mps_list.begin(), mps_list.end(),
       [&](const auto &mps) {
         auto adapter = std::make_unique<MPSFileProblemProviderAdapter>(
-            root, mps._problem_mps);
+            root, mps._problem_filename);
         auto problem =
             adapter->provide_problem(solver_config_.Name(), solver_log_manager_);
         std::unique_ptr<IProblemVariablesProviderPort> variables_provider;
@@ -87,7 +87,7 @@ void LinkProblemsGenerator::treatloop(const std::filesystem::path &root,
                   problem, _links, logger_);
         }
 
-        treat(mps._problem_mps, couplings, problem.get(),
+        treat(mps._problem_filename, couplings, problem.get(),
               variables_provider.get(), writer);
       });
 }

--- a/src/cpp/lpnamer/problem_modifier/MasterGeneration.cpp
+++ b/src/cpp/lpnamer/problem_modifier/MasterGeneration.cpp
@@ -57,7 +57,7 @@ void MasterGeneration::write_master_mps(
 std::filesystem::path FileNameForStructureFile(const std::string& problemName,
                                              std::string solverName) {
   if (problemName == "master") return {"master"};
-  return SolverConfig::FileName(problemName, SolverConfig(std::move(solverName)));
+  return SolverConfig(std::move(solverName)).FileName(problemName);
 }
 
 void MasterGeneration::write_structure_file(

--- a/src/cpp/multisolver_interface/SolverConfig.cpp
+++ b/src/cpp/multisolver_interface/SolverConfig.cpp
@@ -31,12 +31,11 @@ void SolverConfig::init(std::string solver_name) {
   use_save_restore = save_restore_supported;
 }
 
-std::filesystem::path SolverConfig::FileName(const std::string& problemName,
-                                             const SolverConfig& solverName) {
+std::filesystem::path SolverConfig::FileName(const std::string& problemName) {
   const std::string save_ext = ".svf";
   const std::string default_ext = ".mps";
   std::filesystem::path path{problemName};
-  if (solverName.use_save_restore) {
+  if (use_save_restore) {
     path.replace_extension(save_ext);
   } else {
     path.replace_extension(default_ext);

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverConfig.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverConfig.h
@@ -25,6 +25,5 @@ class SolverConfig {
   ~SolverConfig() = default;
   bool operator==(const std::string& rhs) const;
   SolverConfig& operator=(const std::string& rhs);
-  static std::filesystem::path FileName(const std::string& problemName,
-                                        const SolverConfig& solverName);
+  std::filesystem::path FileName(const std::string& problemName);
 };

--- a/src/cpp/sensitivity/SensitivityInputReader.cpp
+++ b/src/cpp/sensitivity/SensitivityInputReader.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<SolverAbstract> SensitivityInputReader::get_last_master() const 
       throw std::runtime_error(fmt::format("{}: unsupported format : {}",
                                            LOGLOCATION, format));
   }
-  // Always set solver parameters after reading problems, as restore also comes with parameters of the solver and we do not want them to override our preferences
+  // Always set solver parameters after reading problems, as restore (used by Xpress writing .svf files) also comes with parameters of the solver and we do not want them to override our preferences
   last_master->set_threads(1);
   last_master->set_output_log_level(
       _benders_data[Output::OPTIONS_C]["LOG_LEVEL"].asInt());

--- a/src/cpp/sensitivity/SensitivityInputReader.cpp
+++ b/src/cpp/sensitivity/SensitivityInputReader.cpp
@@ -58,9 +58,7 @@ std::shared_ptr<SolverAbstract> SensitivityInputReader::get_last_master() const 
     last_master = factory.create_solver(
         _benders_data[Output::OPTIONS_C]["SOLVER_NAME"].asString());
   }
-  last_master->set_threads(1);
-  last_master->set_output_log_level(
-      _benders_data[Output::OPTIONS_C]["LOG_LEVEL"].asInt());
+  
   auto problem_format = _benders_data[Output::OPTIONS_C][Output::PROBLEM_FORMAT_C].asString();
   auto format = problem_format.empty() ? ProblemsFormat::MPS_FILE : problemsFormatFromString(problem_format);
   switch (format) {
@@ -74,6 +72,10 @@ std::shared_ptr<SolverAbstract> SensitivityInputReader::get_last_master() const 
       throw std::runtime_error(fmt::format("{}: unsupported format : {}",
                                            LOGLOCATION, format));
   }
+  // Always set solver parameters after reading problems, as restore also comes with parameters of the solver and we do not want them to override our preferences
+  last_master->set_threads(1);
+  last_master->set_output_log_level(
+      _benders_data[Output::OPTIONS_C]["LOG_LEVEL"].asInt());
   return last_master;
 }
 

--- a/src/python/antares_xpansion/problem_generator_driver.py
+++ b/src/python/antares_xpansion/problem_generator_driver.py
@@ -130,7 +130,7 @@ class ProblemGeneratorDriver:
     def lp_namer_options(self):
         is_relaxed = 'relaxed' if self.is_relaxed else 'integer'
         if self.memory:
-            ret = ["--study", str(os.path.normpath(self.study_path)), "-f", is_relaxed]  # study/output/xpansion_output_dir
+            ret = ["--study", str(os.path.normpath(self.study_path)), "-f", is_relaxed]  # study path
         else:
             ret = ["-a", str(self.output_path), "-f", is_relaxed]
         if self.weight_file_name_for_lp:

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -90,12 +90,6 @@ class MockProblem : public Problem {
   }
 };
 
-// class MockProblemData : public ProblemData {
-//  public:
-//   MockProblemData(const std::string &mps) : ProblemData(mps, "variables.txt")
-//   {}
-// };
-
 void RunWeightsFileWriterTest(const std::string &solver_name,
                               const std::string &expected) {
   auto tempDir = std::filesystem::temp_directory_path() / "lp";
@@ -103,9 +97,13 @@ void RunWeightsFileWriterTest(const std::string &solver_name,
     std::filesystem::create_directory(tempDir);
   }
 
+  auto logger =
+      std::make_shared<ProblemGenerationLog::ProblemGenerationLogger>(
+          LogUtils::LOGLEVEL::NONE);
+
   auto yearly_weight_writer =
       YearlyWeightsWriter(std::filesystem::temp_directory_path(), {3, 5, 7},
-                          "weights_123.txt", {1, 2, 3}, solver_name);
+                          "weights_123.txt", {1, 2, 3}, solver_name, logger);
 
   std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>
       problems_and_data = {

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -85,24 +85,27 @@ class MockSolverAbstract : public SolverAbstract {
 
 class MockProblem : public Problem {
  public:
-  MockProblem(int year)
-      : Problem(std::make_shared<MockSolverAbstract>()), mc_year(year) {}
-  int mc_year;
+  MockProblem(int year) : Problem(std::make_shared<MockSolverAbstract>()) {
+    Problem::mc_year = year;
+  }
 };
 
 // class MockProblemData : public ProblemData {
 //  public:
-//   MockProblemData(const std::string &mps) : ProblemData(mps, "variables.txt") {}
+//   MockProblemData(const std::string &mps) : ProblemData(mps, "variables.txt")
+//   {}
 // };
 
-void RunWeightsFileWriterTest(const std::string& solver_name, const std::string& expected) {
+void RunWeightsFileWriterTest(const std::string &solver_name,
+                              const std::string &expected) {
   auto tempDir = std::filesystem::temp_directory_path() / "lp";
   if (!std::filesystem::is_directory(tempDir)) {
     std::filesystem::create_directory(tempDir);
   }
 
-  auto yearly_weight_writer = YearlyWeightsWriter(
-      tempDir, {3, 5, 7}, "weights_123.txt", {1, 2, 3}, solver_name);
+  auto yearly_weight_writer =
+      YearlyWeightsWriter(std::filesystem::temp_directory_path(), {3, 5, 7},
+                          "weights_123.txt", {1, 2, 3}, solver_name);
 
   std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>
       problems_and_data = {
@@ -130,18 +133,6 @@ void RunWeightsFileWriterTest(const std::string& solver_name, const std::string&
 
   // Clean up
   std::filesystem::remove(tempDir / "weights_123.txt");
-}
-
-TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithMockSolver) {
-  std::string expected = R"xxx(problem-1-1--optim-nb-1.mps 3
-problem-1-50--optim-nb-1.mps 3
-problem-2-10--optim-nb-1.mps 5
-problem-2-11--optim-nb-1.mps 5
-problem-2-30--optim-nb-1.mps 5
-problem-3-20--optim-nb-1.mps 7
-WEIGHT_SUM 15
-)xxx";
-  RunWeightsFileWriterTest("MockSolver", expected);
 }
 
 TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithXpress) {

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -120,7 +120,7 @@ class WeightsFileWriterTest : public ::testing::Test {
   void RunWeightsFileWriterTest(const std::string &solver_name,
                                 const std::string &expected) {
     auto yearly_weight_writer = YearlyWeightsWriter(
-        tempDir, {3, 5, 7}, "weights_123.txt", {1, 2, 3}, solver_name, logger);
+        std::filesystem::temp_directory_path(), {3, 5, 7}, "weights_123.txt", {1, 2, 3}, solver_name, logger);
 
     yearly_weight_writer.CreateWeightFile(problems_and_data);
 

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -90,50 +90,57 @@ class MockProblem : public Problem {
   }
 };
 
-void RunWeightsFileWriterTest(const std::string &solver_name,
-                              const std::string &expected) {
-  auto tempDir = std::filesystem::temp_directory_path() / "lp";
-  if (!std::filesystem::is_directory(tempDir)) {
-    std::filesystem::create_directory(tempDir);
+class WeightsFileWriterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    tempDir = std::filesystem::temp_directory_path() / "lp";
+    if (!std::filesystem::is_directory(tempDir)) {
+      std::filesystem::create_directory(tempDir);
+    }
+
+    logger = std::make_shared<ProblemGenerationLog::ProblemGenerationLogger>(
+        LogUtils::LOGLEVEL::NONE);
+
+    problems_and_data = {
+        {std::make_shared<MockProblem>(1),
+         ProblemData("problem-1-1--optim-nb-1.mps", "variables.txt")},
+        {std::make_shared<MockProblem>(1),
+         ProblemData("problem-1-50--optim-nb-1.mps", "variables.txt")},
+        {std::make_shared<MockProblem>(2),
+         ProblemData("problem-2-10--optim-nb-1.mps", "variables.txt")},
+        {std::make_shared<MockProblem>(2),
+         ProblemData("problem-2-11--optim-nb-1.mps", "variables.txt")},
+        {std::make_shared<MockProblem>(2),
+         ProblemData("problem-2-30--optim-nb-1.mps", "variables.txt")},
+        {std::make_shared<MockProblem>(3),
+         ProblemData("problem-3-20--optim-nb-1.mps", "variables.txt")},
+    };
   }
 
-  auto logger =
-      std::make_shared<ProblemGenerationLog::ProblemGenerationLogger>(
-          LogUtils::LOGLEVEL::NONE);
+  void RunWeightsFileWriterTest(const std::string &solver_name,
+                                const std::string &expected) {
+    auto yearly_weight_writer = YearlyWeightsWriter(
+        tempDir, {3, 5, 7}, "weights_123.txt", {1, 2, 3}, solver_name, logger);
 
-  auto yearly_weight_writer =
-      YearlyWeightsWriter(std::filesystem::temp_directory_path(), {3, 5, 7},
-                          "weights_123.txt", {1, 2, 3}, solver_name, logger);
+    yearly_weight_writer.CreateWeightFile(problems_and_data);
 
+    std::ifstream reader(tempDir / "weights_123.txt");
+    std::string actual((std::istreambuf_iterator<char>(reader)),
+                       std::istreambuf_iterator<char>());
+
+    EXPECT_EQ(expected, actual);
+
+    // Clean up
+    std::filesystem::remove(tempDir / "weights_123.txt");
+  }
+
+  std::filesystem::path tempDir;
+  std::shared_ptr<ProblemGenerationLog::ProblemGenerationLogger> logger;
   std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>
-      problems_and_data = {
-          {std::make_shared<MockProblem>(1),
-           ProblemData("problem-1-1--optim-nb-1.mps", "variables.txt")},
-          {std::make_shared<MockProblem>(1),
-           ProblemData("problem-1-50--optim-nb-1.mps", "variables.txt")},
-          {std::make_shared<MockProblem>(2),
-           ProblemData("problem-2-10--optim-nb-1.mps", "variables.txt")},
-          {std::make_shared<MockProblem>(2),
-           ProblemData("problem-2-11--optim-nb-1.mps", "variables.txt")},
-          {std::make_shared<MockProblem>(2),
-           ProblemData("problem-2-30--optim-nb-1.mps", "variables.txt")},
-          {std::make_shared<MockProblem>(3),
-           ProblemData("problem-3-20--optim-nb-1.mps", "variables.txt")},
-      };
+      problems_and_data;
+};
 
-  yearly_weight_writer.CreateWeightFile(problems_and_data);
-
-  std::ifstream reader(tempDir / "weights_123.txt");
-  std::string actual((std::istreambuf_iterator<char>(reader)),
-                     std::istreambuf_iterator<char>());
-
-  EXPECT_EQ(expected, actual);
-
-  // Clean up
-  std::filesystem::remove(tempDir / "weights_123.txt");
-}
-
-TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithXpress) {
+TEST_F(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithXpress) {
   std::string expected = R"xxx(problem-1-1--optim-nb-1.svf 3
 problem-1-50--optim-nb-1.svf 3
 problem-2-10--optim-nb-1.svf 5
@@ -145,7 +152,7 @@ WEIGHT_SUM 15
   RunWeightsFileWriterTest("xpress", expected);
 }
 
-TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithCoin) {
+TEST_F(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithCoin) {
   std::string expected = R"xxx(problem-1-1--optim-nb-1.mps 3
 problem-1-50--optim-nb-1.mps 3
 problem-2-10--optim-nb-1.mps 5

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -1,37 +1,138 @@
 #include <fstream>
+#include <memory>
 
 #include "antares-xpansion/lpnamer/input_reader/WeightsFileWriter.h"
 #include "gtest/gtest.h"
 
-void writeDummyFileInTempLpDir(std::string name) {
-  auto tmp_path = std::filesystem::temp_directory_path() / "lp" / name;
-  std::ofstream writer;
-  writer.open(tmp_path);
-  writer << std::endl;
-  writer.close();
-}
+class MockSolverAbstract : public SolverAbstract {
+ public:
+  int get_number_of_instances() override { return 1; }
+  std::string get_solver_name() const override { return "MockSolver"; }
+  void init() override {}
+  void free() override {}
+  void write_prob_mps(const std::filesystem::path &filename) override {}
+  void write_prob_lp(const std::filesystem::path &filename) override {}
+  void read_prob_mps(const std::filesystem::path &filename) override {}
+  void read_prob_lp(const std::filesystem::path &filename) override {}
+  void copy_prob(Ptr fictif_solv) override {}
+  int get_ncols() const override { return 0; }
+  int get_nrows() const override { return 0; }
+  int get_nelems() const override { return 0; }
+  int get_n_integer_vars() const override { return 0; }
+  void get_obj(double *obj, int first, int last) const override {}
+  void set_obj_to_zero() override {}
+  void set_obj(const double *obj, int first, int last) override {}
+  void get_rows(int *mstart, int *mclind, double *dmatval, int size, int *nels,
+                int first, int last) const override {}
+  void get_row_type(char *qrtype, int first, int last) const override {}
+  void get_rhs(double *rhs, int first, int last) const override {}
+  void get_rhs_range(double *range, int first, int last) const override {}
+  void get_col_type(char *coltype, int first, int last) const override {}
+  void get_lb(double *lb, int first, int last) const override {}
+  void get_ub(double *ub, int first, int last) const override {}
+  int get_row_index(const std::string &name) override { return 0; }
+  int get_col_index(const std::string &name) override { return 0; }
+  std::vector<std::string> get_row_names(int first, int last) override {
+    return {};
+  }
+  std::vector<std::string> get_row_names() override { return {}; }
+  std::vector<std::string> get_col_names(int first, int last) override {
+    return {};
+  }
+  std::vector<std::string> get_col_names() override { return {}; }
+  void del_rows(int first, int last) override {}
+  void add_rows(int newrows, int newnz, const char *qrtype, const double *rhs,
+                const double *range, const int *mstart, const int *mclind,
+                const double *dmatval,
+                const std::vector<std::string> &names = {}) override {}
+  void add_cols(int newcol, int newnz, const double *objx, const int *mstart,
+                const int *mrwind, const double *dmatval, const double *bdl,
+                const double *bdu) override {}
+  void add_name(int type, const char *cnames, int indice) override {}
+  void add_names(int type, const std::vector<std::string> &cnames, int first,
+                 int end) override {}
+  void chg_obj(const std::vector<int> &mindex,
+               const std::vector<double> &obj) override {}
+  void chg_obj_direction(const bool minimize) override {}
+  void chg_bounds(const std::vector<int> &mindex,
+                  const std::vector<char> &qbtype,
+                  const std::vector<double> &bnd) override {}
+  void chg_col_type(const std::vector<int> &mindex,
+                    const std::vector<char> &qctype) override {}
+  void chg_rhs(int id_row, double val) override {}
+  void chg_coef(int id_row, int id_col, double val) override {}
+  void chg_row_name(int id_row, const std::string &name) override {}
+  void chg_col_name(int id_col, const std::string &name) override {}
+  int solve_lp() override { return 0; }
+  int solve_mip() override { return 0; }
+  void get_basis(int *rstatus, int *cstatus) const override {}
+  double get_mip_value() const override { return 0.0; }
+  double get_lp_value() const override { return 0.0; }
+  int get_splex_num_of_ite_last() const override { return 0; }
+  void get_lp_sol(double *primals, double *duals,
+                  double *reduced_costs) override {}
+  void get_mip_sol(double *primals) override {}
+  void set_output_log_level(int loglevel) override {}
+  void set_algorithm(const std::string &algo) override {}
+  void set_threads(int n_threads) override {}
+  void set_optimality_gap(double gap) override {}
+  void set_simplex_iter(int iter) override {}
+  void write_basis(const std::filesystem::path &filename) override {}
+  void read_basis(const std::filesystem::path &filename) override {}
+  void save_prob(const std::filesystem::path &filename) override {}
+  void restore_prob(const std::filesystem::path &filename) override {}
+};
 
-TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFile) {
+class MockProblem : public Problem {
+ public:
+  MockProblem(int year)
+      : Problem(std::make_shared<MockSolverAbstract>()), mc_year(year) {}
+  int mc_year;
+};
+
+// class MockProblemData : public ProblemData {
+//  public:
+//   MockProblemData(const std::string &mps) : ProblemData(mps, "variables.txt") {}
+// };
+
+void RunWeightsFileWriterTest(const std::string& solver_name, const std::string& expected) {
   auto tempDir = std::filesystem::temp_directory_path() / "lp";
   if (!std::filesystem::is_directory(tempDir)) {
     std::filesystem::create_directory(tempDir);
   }
-  writeDummyFileInTempLpDir("problem-1-1--optim-nb-1.mps");
-  writeDummyFileInTempLpDir("problem-1-50--optim-nb-1.mps");
-  writeDummyFileInTempLpDir("problem-2-10--optim-nb-1.mps");
-  writeDummyFileInTempLpDir("problem-2-11--optim-nb-1.mps");
-  writeDummyFileInTempLpDir("problem-2-30--optim-nb-1.mps");
-  writeDummyFileInTempLpDir("problem-3-20--optim-nb-1.mps");
-  writeDummyFileInTempLpDir("problem-3-30--optim-nb-1.txt");
 
-  auto yearly_weight_writer =
-      YearlyWeightsWriter(std::filesystem::temp_directory_path(), {3, 5, 7},
-                          "weights_123.txt", {1, 2, 3});
-  yearly_weight_writer.CreateWeightFile();
+  auto yearly_weight_writer = YearlyWeightsWriter(
+      tempDir, {3, 5, 7}, "weights_123.txt", {1, 2, 3}, solver_name);
+
+  std::vector<std::pair<std::shared_ptr<Problem>, ProblemData>>
+      problems_and_data = {
+          {std::make_shared<MockProblem>(1),
+           ProblemData("problem-1-1--optim-nb-1.mps", "variables.txt")},
+          {std::make_shared<MockProblem>(1),
+           ProblemData("problem-1-50--optim-nb-1.mps", "variables.txt")},
+          {std::make_shared<MockProblem>(2),
+           ProblemData("problem-2-10--optim-nb-1.mps", "variables.txt")},
+          {std::make_shared<MockProblem>(2),
+           ProblemData("problem-2-11--optim-nb-1.mps", "variables.txt")},
+          {std::make_shared<MockProblem>(2),
+           ProblemData("problem-2-30--optim-nb-1.mps", "variables.txt")},
+          {std::make_shared<MockProblem>(3),
+           ProblemData("problem-3-20--optim-nb-1.mps", "variables.txt")},
+      };
+
+  yearly_weight_writer.CreateWeightFile(problems_and_data);
 
   std::ifstream reader(tempDir / "weights_123.txt");
   std::string actual((std::istreambuf_iterator<char>(reader)),
                      std::istreambuf_iterator<char>());
+
+  EXPECT_EQ(expected, actual);
+
+  // Clean up
+  std::filesystem::remove(tempDir / "weights_123.txt");
+}
+
+TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithMockSolver) {
   std::string expected = R"xxx(problem-1-1--optim-nb-1.mps 3
 problem-1-50--optim-nb-1.mps 3
 problem-2-10--optim-nb-1.mps 5
@@ -40,6 +141,29 @@ problem-2-30--optim-nb-1.mps 5
 problem-3-20--optim-nb-1.mps 7
 WEIGHT_SUM 15
 )xxx";
+  RunWeightsFileWriterTest("MockSolver", expected);
+}
 
-  EXPECT_EQ(expected, actual);
+TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithXpress) {
+  std::string expected = R"xxx(problem-1-1--optim-nb-1.svf 3
+problem-1-50--optim-nb-1.svf 3
+problem-2-10--optim-nb-1.svf 5
+problem-2-11--optim-nb-1.svf 5
+problem-2-30--optim-nb-1.svf 5
+problem-3-20--optim-nb-1.svf 7
+WEIGHT_SUM 15
+)xxx";
+  RunWeightsFileWriterTest("xpress", expected);
+}
+
+TEST(WeightsFileWriterTest, CorrectlyWriteWeightsFileWithCoin) {
+  std::string expected = R"xxx(problem-1-1--optim-nb-1.mps 3
+problem-1-50--optim-nb-1.mps 3
+problem-2-10--optim-nb-1.mps 5
+problem-2-11--optim-nb-1.mps 5
+problem-2-30--optim-nb-1.mps 5
+problem-3-20--optim-nb-1.mps 7
+WEIGHT_SUM 15
+)xxx";
+  RunWeightsFileWriterTest("coin", expected);
 }


### PR DESCRIPTION
In problem generation, a file `weights.txt` is generated to map problem names to their corresponding weights. Initially, this mapping was constructed by fetching all mps files in the directory after the antares step and extracting the year number from the file name.

In memory mode, Antares does not write mps file anymore. The weights file generation is now based on the `problems_and_data` structure in memory that gathers the problems and their year number. Moreover, depending on the solver name, the filename written in the `weights.txt` is now correct (.svf or .mps) depending on the context.