### PR TITLE
Remove Antares mps file after read in problem generation

### DIFF
--- a/src/cpp/lpnamer/problem_modifier/FileProblemProviderAdapter.cpp
+++ b/src/cpp/lpnamer/problem_modifier/FileProblemProviderAdapter.cpp
@@ -14,7 +14,10 @@ std::shared_ptr<Problem> FileProblemProviderAdapter::provide_problem(
   auto in_prblm = std::make_shared<Problem>(
       factory.create_solver(solver_name, solver_log_manager));
 
-  in_prblm->read_prob_mps(lp_dir_.parent_path() / problem_name_);
+  const std::filesystem::path problem_path =
+      lp_dir_.parent_path() / problem_name_;
+  in_prblm->read_prob_mps(problem_path);
+  std::remove(problem_path.c_str());
   return in_prblm;
 }
 FileProblemProviderAdapter::FileProblemProviderAdapter(

--- a/src/cpp/lpnamer/problem_modifier/FileProblemProviderAdapter.cpp
+++ b/src/cpp/lpnamer/problem_modifier/FileProblemProviderAdapter.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<Problem> FileProblemProviderAdapter::provide_problem(
   const std::filesystem::path problem_path =
       lp_dir_.parent_path() / problem_name_;
   in_prblm->read_prob_mps(problem_path);
-  std::remove(problem_path.c_str());
+  std::filesystem::remove(problem_path);
   return in_prblm;
 }
 FileProblemProviderAdapter::FileProblemProviderAdapter(

--- a/src/cpp/lpnamer/problem_modifier/ZipProblemProviderAdapter.cpp
+++ b/src/cpp/lpnamer/problem_modifier/ZipProblemProviderAdapter.cpp
@@ -6,9 +6,9 @@
 
 #include <utility>
 
+#include "antares-xpansion/helpers/solver_utils.h"
 #include "antares-xpansion/lpnamer/problem_modifier/LinkProblemsGenerator.h"
 #include "antares-xpansion/xpansion_interfaces/StringManip.h"
-#include "antares-xpansion/helpers/solver_utils.h"
 void ZipProblemProviderAdapter::reader_extract_file(
     const std::string& problem_name, ArchiveReader& reader,
     const std::filesystem::path& lpDir) const {
@@ -26,6 +26,7 @@ std::shared_ptr<Problem> ZipProblemProviderAdapter::provide_problem(
       factory.create_solver(solver_name, solver_log_manager));
 
   in_prblm->read_prob_mps(lp_mps_name);
+  std::remove(lp_mps_name.c_str());
   return in_prblm;
 }
 

--- a/src/cpp/lpnamer/problem_modifier/ZipProblemProviderAdapter.cpp
+++ b/src/cpp/lpnamer/problem_modifier/ZipProblemProviderAdapter.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<Problem> ZipProblemProviderAdapter::provide_problem(
       factory.create_solver(solver_name, solver_log_manager));
 
   in_prblm->read_prob_mps(lp_mps_name);
-  std::remove(lp_mps_name.c_str());
+  std::filesystem::remove(lp_mps_name);
   return in_prblm;
 }
 


### PR DESCRIPTION
Antares files are read in problem generation and are then useless, they should be removed to improve disk usage