### PR TITLE
[ANT-2202] Vectorize row and col names change (only available with Xpress) in solver to accelerate problem generation

### DIFF
--- a/src/cpp/helpers/solver_utils.cc
+++ b/src/cpp/helpers/solver_utils.cc
@@ -34,7 +34,7 @@ void solver_addcols(SolverAbstract &solver_p, std::vector<double> const &objx_p,
     int newnnz = static_cast<int>(dmatval_p.size());
 
     solver_p.add_cols(newCols, newnnz, objx_p.data(), mstart_p.data(),
-                      mrwind_p.data(), dmatval_p.data(), bdl_p.data(), bdu_p.data());
+                      mrwind_p.data(), dmatval_p.data(), bdl_p.data(), bdu_p.data(), {});
 
     std::vector<int> newIndex(newCols);
     for (int i = 0; i < newCols; i++)

--- a/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
+++ b/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
@@ -116,14 +116,14 @@ class Problem : public SolverAbstract {
   void add_rows(int newrows, int newnz, const char *qrtype, const double *rhs,
                 const double *range, const int *mstart, const int *mclind,
                 const double *dmatval,
-                const std::vector<std::string> &names = {}) override {
+                const std::vector<std::string> &names) override {
     solver_abstract_->add_rows(newrows, newnz, qrtype, rhs, range, mstart,
                                mclind, dmatval, names);
   }
   void add_cols(int newcol, int newnz, const double *objx, const int *mstart,
                 const int *mrwind, const double *dmatval, const double *bdl,
                 const double *bdu,
-                const std::vector<std::string> &names = {}) override {
+                const std::vector<std::string> &names) override {
     solver_abstract_->add_cols(newcol, newnz, objx, mstart, mrwind, dmatval,
                                bdl, bdu, names);
   }

--- a/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
+++ b/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
@@ -122,9 +122,10 @@ class Problem : public SolverAbstract {
   }
   void add_cols(int newcol, int newnz, const double *objx, const int *mstart,
                 const int *mrwind, const double *dmatval, const double *bdl,
-                const double *bdu) override {
+                const double *bdu,
+                const std::vector<std::string> &names = {}) override {
     solver_abstract_->add_cols(newcol, newnz, objx, mstart, mrwind, dmatval,
-                               bdl, bdu);
+                               bdl, bdu, names);
   }
   void add_name(int type, const char *cnames, int indice) override {
     solver_abstract_->add_name(type, cnames, indice);

--- a/src/cpp/lpnamer/problem_modifier/AntaresProblemToXpansionProblemTranslator.cpp
+++ b/src/cpp/lpnamer/problem_modifier/AntaresProblemToXpansionProblemTranslator.cpp
@@ -7,8 +7,8 @@
 #include <algorithm>
 #include <cmath>
 
-#include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 #include "antares-xpansion/multisolver_interface/SolverFactory.h"
+#include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
 /**
  *
@@ -17,8 +17,9 @@
  */
 std::shared_ptr<Problem>
 AntaresProblemToXpansionProblemTranslator::translateToXpansionProblem(
-    const Antares::Solver::LpsFromAntares& lps, unsigned int year, unsigned int week,
-    const std::string& solver_name, SolverLogManager& solver_log_manager) {
+    const Antares::Solver::LpsFromAntares& lps, unsigned int year,
+    unsigned int week, const std::string& solver_name,
+    SolverLogManager& solver_log_manager) {
   SolverFactory factory;
   auto problem = std::make_shared<Problem>(
       factory.create_solver(solver_name, solver_log_manager));
@@ -32,21 +33,16 @@ AntaresProblemToXpansionProblemTranslator::translateToXpansionProblem(
   std::vector<char> coltypes(constant.VariablesCount, 'C');
 
   problem->add_cols(constant.VariablesCount, 0, hebdo.LinearCost.data(),
-                    tmp.data(), {}, {}, hebdo.Xmin.data(), hebdo.Xmax.data());
+                    tmp.data(), {}, {}, hebdo.Xmin.data(), hebdo.Xmax.data(),
+                    hebdo.variables);
 
   std::span<char> signs(hebdo.Direction.data(), hebdo.Direction.size());
   auto LEG_vector = convertSignToLEG(signs);
-  problem->add_rows(
-      constant.ConstraintesCount, constant.CoeffCount,
-      convertSignToLEG(signs).data(), hebdo.RHS.data(),
-      nullptr, reinterpret_cast<const int *>(constant.Mdeb.data()), reinterpret_cast<const int *>(constant.ColumnIndexes.data()),
-      constant.ConstraintsMatrixCoeff.data(), {});
-  for (int i = 0; i < constant.VariablesCount; ++i) {
-    problem->chg_col_name(i, hebdo.variables[i]);
-  }
-  for (int i = 0; i < constant.ConstraintesCount; ++i) {
-    problem->chg_row_name(i, hebdo.constraints[i]);
-  }
+  problem->add_rows(constant.ConstraintesCount, constant.CoeffCount,
+                    convertSignToLEG(signs).data(), hebdo.RHS.data(), nullptr,
+                    reinterpret_cast<const int*>(constant.Mdeb.data()),
+                    reinterpret_cast<const int*>(constant.ColumnIndexes.data()),
+                    constant.ConstraintsMatrixCoeff.data(), hebdo.constraints);
   // On peut ajouter la partie qui renomme les variables ici si on stocke les
   // données du type de variables dans ConstantDataFromAntares, i.e. en
   // définissant une autre implémentation de IProblemVariablesProviderPort
@@ -56,7 +52,7 @@ AntaresProblemToXpansionProblemTranslator::translateToXpansionProblem(
 std::vector<char> AntaresProblemToXpansionProblemTranslator::convertSignToLEG(
     std::span<char> data) {
   std::vector<char> LEG_vector;
-  //Exclude final '\0' character
+  // Exclude final '\0' character
   std::ranges::transform(data, std::back_inserter(LEG_vector), [](char c) {
     if ('=' == c) {
       return 'E';

--- a/src/cpp/lpnamer/problem_modifier/LauncherHelpers.cpp
+++ b/src/cpp/lpnamer/problem_modifier/LauncherHelpers.cpp
@@ -4,10 +4,10 @@
 
 #include <filesystem>
 
-#include "antares-xpansion/lpnamer/model/Candidate.h"
 #include "antares-xpansion/lpnamer/input_reader/CandidatesINIReader.h"
-#include "antares-xpansion/lpnamer/problem_modifier/LinkProblemsGenerator.h"
 #include "antares-xpansion/lpnamer/input_reader/LinkProfileReader.h"
+#include "antares-xpansion/lpnamer/model/Candidate.h"
+#include "antares-xpansion/lpnamer/problem_modifier/LinkProblemsGenerator.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
 void treatAdditionalConstraints(
@@ -75,7 +75,7 @@ void addAdditionalConstraint(
   }
 
   master_p->add_rows(1, newnz, rtype.data(), rhs.data(), nullptr,
-                     matstart.data(), mindex.data(), matval.data());
+                     matstart.data(), mindex.data(), matval.data(), {});
 }
 
 void addBinaryVariables(
@@ -95,7 +95,8 @@ void addBinaryVariables(
     master_p->add_cols(
         1, 0, std::vector<double>(1, 0.0).data(), std::vector<int>(2, 0).data(),
         std::vector<int>(0).data(), std::vector<double>(0).data(),
-        std::vector<double>(1, 0).data(), std::vector<double>(1, 1e20).data());
+        std::vector<double>(1, 0).data(), std::vector<double>(1, 1e20).data(),
+        {});
 
     // Changing column type to binary
     master_p->chg_col_type(std::vector<int>(1, master_p->get_ncols() - 1),
@@ -122,7 +123,7 @@ void addBinaryVariables(
 
     master_p->add_rows(1, 2, std::vector<char>(1, 'L').data(),
                        std::vector<double>(1, 0.0).data(), nullptr,
-                       matstart.data(), matind.data(), matval.data());
+                       matstart.data(), matind.data(), matval.data(), {});
     master_p->chg_row_name(
         master_p->get_nrows() - 1,
         "link_" + pairOldNewVarnames.first + "_" + pairOldNewVarnames.second);

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -429,15 +429,23 @@ void SolverCbc::add_rows(int newrows, int newnz, const char *qrtype,
 void SolverCbc::add_cols(int newcol, int newnz, const double *objx,
                          const int *mstart, const int *mrwind,
                          const double *dmatval, const double *bdl,
-                         const double *bdu) {
+                         const double *bdu,
+                         const std::vector<std::string> &col_names) {
   std::vector<int> colStart(newcol + 1);
   for (int i(0); i < newcol; i++) {
     colStart[i] = mstart[i];
   }
   colStart[newcol] = newnz;
+  int ncolInit = get_ncols();
 
   _clp_inner_solver.addCols(newcol, colStart.data(), mrwind, dmatval, bdl, bdu,
                             objx);
+  if (col_names.size() > 0) {
+    int ncolFinal = get_ncols();
+    for (int i = ncolInit; i < ncolFinal; i++) {
+      chg_col_name(i, col_names[i - ncolInit]);
+    }
+  }
 }
 
 void SolverCbc::add_name(int type, const char *cnames, int indice) {

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -93,7 +93,8 @@ void SolverClp::read_prob_mps(const std::filesystem::path &filename) {
     filename_to_use.replace_extension(".mps");
   }
   int status = _clp.readMps(filename_to_use.string().c_str(), true, false);
-  zero_status_check(status, " Clp readMps "s + filename_to_use.string(), LOGLOCATION);
+  zero_status_check(status, " Clp readMps "s + filename_to_use.string(),
+                    LOGLOCATION);
 }
 
 void SolverClp::read_prob_lp(const std::filesystem::path &filename) {
@@ -302,14 +303,22 @@ void SolverClp::add_rows(int newrows, int newnz, const char *qrtype,
 void SolverClp::add_cols(int newcol, int newnz, const double *objx,
                          const int *mstart, const int *mrwind,
                          const double *dmatval, const double *bdl,
-                         const double *bdu) {
+                         const double *bdu,
+                         const std::vector<std::string> &col_names) {
   std::vector<int> colStart(newcol + 1);
   for (int i(0); i < newcol; i++) {
     colStart[i] = mstart[i];
   }
   colStart[newcol] = newnz;
+  int ncolInit = get_ncols();
 
   _clp.addColumns(newcol, bdl, bdu, objx, colStart.data(), mrwind, dmatval);
+  if (col_names.size() > 0) {
+    int ncolFinal = get_ncols();
+    for (int i = ncolInit; i < ncolFinal; i++) {
+      chg_col_name(i, col_names[i - ncolInit]);
+    }
+  }
 }
 
 void SolverClp::add_name(int type, const char *cnames, int indice) {

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -379,10 +379,16 @@ void SolverXpress::add_rows(int newrows, int newnz, const char *qrtype,
 void SolverXpress::add_cols(int newcol, int newnz, const double *objx,
                             const int *mstart, const int *mrwind,
                             const double *dmatval, const double *bdl,
-                            const double *bdu) {
+                            const double *bdu,
+                            const std::vector<std::string> &col_names) {
+  int ncolInit = get_ncols();
   int status = XPRSaddcols(_xprs, newcol, newnz, objx, mstart, mrwind, dmatval,
                            bdl, bdu);
   zero_status_check(status, "add columns", LOGLOCATION);
+  if (col_names.size() > 0) {
+    int ncolFinal = get_ncols();
+    add_names(2, col_names, ncolInit, ncolFinal - 1);
+  }
 }
 
 void SolverXpress::add_name(int type, const char *cnames, int indice) {
@@ -392,12 +398,12 @@ void SolverXpress::add_name(int type, const char *cnames, int indice) {
 
 void SolverXpress::add_names(int type, const std::vector<std::string> &cnames,
                              int first, int end) {
-  std::vector<char> row_names_charp;
+  std::vector<char> names_charp;
   for (auto name : cnames) {
     name += '\0';
-    row_names_charp.insert(row_names_charp.end(), name.begin(), name.end());
+    names_charp.insert(names_charp.end(), name.begin(), name.end());
   }
-  int status = XPRSaddnames(_xprs, type, row_names_charp.data(), first, end);
+  int status = XPRSaddnames(_xprs, type, names_charp.data(), first, end);
   zero_status_check(status, "add names", LOGLOCATION);
 }
 
@@ -608,13 +614,13 @@ void SolverXpress::save_prob(const std::filesystem::path &filename) {
   filename_to_use.replace_extension(".svf");
   int status = XPRSsaveas(_xprs, filename_to_use.string().c_str());
   char errmsg[512];
-  XPRSgetlasterror(_xprs,errmsg);
+  XPRSgetlasterror(_xprs, errmsg);
   std::cerr << errmsg << std::endl;
   zero_status_check(status, "save problem", LOGLOCATION);
 }
 void SolverXpress::restore_prob(const std::filesystem::path &filename) {
-    int status = XPRSrestore(_xprs, filename.string().c_str(), "");
-    zero_status_check(status, "restore problem", LOGLOCATION);
+  int status = XPRSrestore(_xprs, filename.string().c_str(), "");
+  zero_status_check(status, "restore problem", LOGLOCATION);
 }
 
 void XPRS_CC optimizermsg(XPRSprob prob, void *strPtr, const char *sMsg,

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -546,7 +546,7 @@ class SolverAbstract {
                         const double *rhs, const double *range,
                         const int *mstart, const int *mclind,
                         const double *dmatval,
-                        const std::vector<std::string> &row_names = {}) = 0;
+                        const std::vector<std::string> &row_names) = 0;
 
   /**
   * @brief Adds new columns to the problem
@@ -572,7 +572,7 @@ class SolverAbstract {
                         const int *mstart, const int *mrwind,
                         const double *dmatval, const double *bdl,
                         const double *bdu,
-                        const std::vector<std::string> &col_names = {}) = 0;
+                        const std::vector<std::string> &col_names) = 0;
 
   /**
    * @brief Adds a name to a row or a column

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -190,7 +190,7 @@ class SolverAbstract {
   /**
    * @brief constructor of SolverAbstract class : does nothing
    */
-  SolverAbstract(){};
+  SolverAbstract() {};
 
   /**
    * @brief Copy constructor, copy the problem "toCopy" in memory and name it
@@ -200,12 +200,12 @@ class SolverAbstract {
    * @param toCopy : Pointer to an AbstractSolver object, containing a solver
    * object to copy
    */
-  SolverAbstract(const std::string &name, const SolverAbstract::Ptr toCopy){};
+  SolverAbstract(const std::string &name, const SolverAbstract::Ptr toCopy) {};
 
   /**
    * @brief destructor of SolverAbstract class : does nothing
    */
-  virtual ~SolverAbstract(){};
+  virtual ~SolverAbstract() {};
 
   /**
    * @brief Returns number of instances of solver currently in memory
@@ -539,12 +539,14 @@ class SolverAbstract {
   (contiguous) column indices for the elements in each row.
   * @param dmatval    : Double array of length newnz containing the (contiguous)
   element values.
+  * @param row_names  : String vector of length newrow containing the names of
+  the rows.
   */
   virtual void add_rows(int newrows, int newnz, const char *qrtype,
                         const double *rhs, const double *range,
                         const int *mstart, const int *mclind,
                         const double *dmatval,
-                        const std::vector<std::string> &names = {}) = 0;
+                        const std::vector<std::string> &row_names = {}) = 0;
 
   /**
   * @brief Adds new columns to the problem
@@ -563,11 +565,14 @@ class SolverAbstract {
   bounds on the added columns.
   * @param bdu        : Double array of length newcol containing the upper
   bounds on the added columns.
+  * @param col_names  : String vector of length newcol containing the names of
+  the columns.
   */
   virtual void add_cols(int newcol, int newnz, const double *objx,
                         const int *mstart, const int *mrwind,
                         const double *dmatval, const double *bdl,
-                        const double *bdu) = 0;
+                        const double *bdu,
+                        const std::vector<std::string> &col_names = {}) = 0;
 
   /**
    * @brief Adds a name to a row or a column

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -127,16 +127,16 @@ class SolverCbc : public SolverAbstract {
   *************************************************************************************************/
  public:
   virtual void del_rows(int first, int last) override;
-  virtual void add_rows(
-      int newrows, int newnz, const char *qrtype, const double *rhs,
-      const double *range, const int *mstart, const int *mclind,
-      const double *dmatval,
-      const std::vector<std::string> &row_names = {}) override;
-  virtual void add_cols(
-      int newcol, int newnz, const double *objx, const int *mstart,
-      const int *mrwind, const double *dmatval, const double *bdl,
-      const double *bdu,
-      const std::vector<std::string> &col_names = {}) override;
+  virtual void add_rows(int newrows, int newnz, const char *qrtype,
+                        const double *rhs, const double *range,
+                        const int *mstart, const int *mclind,
+                        const double *dmatval,
+                        const std::vector<std::string> &row_names) override;
+  virtual void add_cols(int newcol, int newnz, const double *objx,
+                        const int *mstart, const int *mrwind,
+                        const double *dmatval, const double *bdl,
+                        const double *bdu,
+                        const std::vector<std::string> &col_names) override;
   virtual void add_name(int type, const char *cnames, int indice) override;
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override;

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -39,7 +39,7 @@ class SolverCbc : public SolverAbstract {
    * @brief Default constructor of a CBC solver
    */
   SolverCbc();
-  explicit SolverCbc(SolverLogManager&log_manager);
+  explicit SolverCbc(SolverLogManager &log_manager);
 
   /**
    * @brief Copy constructor of solver, copy the problem toCopy in memory and
@@ -127,15 +127,16 @@ class SolverCbc : public SolverAbstract {
   *************************************************************************************************/
  public:
   virtual void del_rows(int first, int last) override;
-  virtual void add_rows(int newrows, int newnz, const char *qrtype,
-                        const double *rhs, const double *range,
-                        const int *mstart, const int *mclind,
-                        const double *dmatval,
-                        const std::vector<std::string> &names = {}) override;
-  virtual void add_cols(int newcol, int newnz, const double *objx,
-                        const int *mstart, const int *mrwind,
-                        const double *dmatval, const double *bdl,
-                        const double *bdu) override;
+  virtual void add_rows(
+      int newrows, int newnz, const char *qrtype, const double *rhs,
+      const double *range, const int *mstart, const int *mclind,
+      const double *dmatval,
+      const std::vector<std::string> &row_names = {}) override;
+  virtual void add_cols(
+      int newcol, int newnz, const double *objx, const int *mstart,
+      const int *mrwind, const double *dmatval, const double *bdl,
+      const double *bdu,
+      const std::vector<std::string> &col_names = {}) override;
   virtual void add_name(int type, const char *cnames, int indice) override;
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override;

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -124,16 +124,16 @@ class SolverClp : public SolverAbstract {
   *************************************************************************************************/
  public:
   virtual void del_rows(int first, int last) override;
-  virtual void add_rows(
-      int newrows, int newnz, const char *qrtype, const double *rhs,
-      const double *range, const int *mstart, const int *mclind,
-      const double *dmatval,
-      const std::vector<std::string> &row_names = {}) override;
-  virtual void add_cols(
-      int newcol, int newnz, const double *objx, const int *mstart,
-      const int *mrwind, const double *dmatval, const double *bdl,
-      const double *bdu,
-      const std::vector<std::string> &col_names = {}) override;
+  virtual void add_rows(int newrows, int newnz, const char *qrtype,
+                        const double *rhs, const double *range,
+                        const int *mstart, const int *mclind,
+                        const double *dmatval,
+                        const std::vector<std::string> &row_names) override;
+  virtual void add_cols(int newcol, int newnz, const double *objx,
+                        const int *mstart, const int *mrwind,
+                        const double *dmatval, const double *bdl,
+                        const double *bdu,
+                        const std::vector<std::string> &col_names) override;
   virtual void add_name(int type, const char *cnames, int indice) override;
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override;

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -124,15 +124,16 @@ class SolverClp : public SolverAbstract {
   *************************************************************************************************/
  public:
   virtual void del_rows(int first, int last) override;
-  virtual void add_rows(int newrows, int newnz, const char *qrtype,
-                        const double *rhs, const double *range,
-                        const int *mstart, const int *mclind,
-                        const double *dmatval,
-                        const std::vector<std::string> &names = {}) override;
-  virtual void add_cols(int newcol, int newnz, const double *objx,
-                        const int *mstart, const int *mrwind,
-                        const double *dmatval, const double *bdl,
-                        const double *bdu) override;
+  virtual void add_rows(
+      int newrows, int newnz, const char *qrtype, const double *rhs,
+      const double *range, const int *mstart, const int *mclind,
+      const double *dmatval,
+      const std::vector<std::string> &row_names = {}) override;
+  virtual void add_cols(
+      int newcol, int newnz, const double *objx, const int *mstart,
+      const int *mrwind, const double *dmatval, const double *bdl,
+      const double *bdu,
+      const std::vector<std::string> &col_names = {}) override;
   virtual void add_name(int type, const char *cnames, int indice) override;
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override;

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -121,15 +121,16 @@ class SolverXpress : public SolverAbstract {
   *************************************************************************************************/
  public:
   virtual void del_rows(int first, int last) override;
-  virtual void add_rows(int newrows, int newnz, const char *qrtype,
-                        const double *rhs, const double *range,
-                        const int *mstart, const int *mclind,
-                        const double *dmatval,
-                        const std::vector<std::string> &names = {}) override;
-  virtual void add_cols(int newcol, int newnz, const double *objx,
-                        const int *mstart, const int *mrwind,
-                        const double *dmatval, const double *bdl,
-                        const double *bdu) override;
+  virtual void add_rows(
+      int newrows, int newnz, const char *qrtype, const double *rhs,
+      const double *range, const int *mstart, const int *mclind,
+      const double *dmatval,
+      const std::vector<std::string> &row_names = {}) override;
+  virtual void add_cols(
+      int newcol, int newnz, const double *objx, const int *mstart,
+      const int *mrwind, const double *dmatval, const double *bdl,
+      const double *bdu,
+      const std::vector<std::string> &col_names = {}) override;
   virtual void add_name(int type, const char *cnames, int indice) override;
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override;

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -121,16 +121,16 @@ class SolverXpress : public SolverAbstract {
   *************************************************************************************************/
  public:
   virtual void del_rows(int first, int last) override;
-  virtual void add_rows(
-      int newrows, int newnz, const char *qrtype, const double *rhs,
-      const double *range, const int *mstart, const int *mclind,
-      const double *dmatval,
-      const std::vector<std::string> &row_names = {}) override;
-  virtual void add_cols(
-      int newcol, int newnz, const double *objx, const int *mstart,
-      const int *mrwind, const double *dmatval, const double *bdl,
-      const double *bdu,
-      const std::vector<std::string> &col_names = {}) override;
+  virtual void add_rows(int newrows, int newnz, const char *qrtype,
+                        const double *rhs, const double *range,
+                        const int *mstart, const int *mclind,
+                        const double *dmatval,
+                        const std::vector<std::string> &row_names) override;
+  virtual void add_cols(int newcol, int newnz, const double *objx,
+                        const int *mstart, const int *mrwind,
+                        const double *dmatval, const double *bdl,
+                        const double *bdu,
+                        const std::vector<std::string> &col_names) override;
   virtual void add_name(int type, const char *cnames, int indice) override;
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override;

--- a/tests/cpp/lp_namer/NOOPSolver.h
+++ b/tests/cpp/lp_namer/NOOPSolver.h
@@ -50,16 +50,16 @@ class NOOPSolver : public SolverAbstract {
     return std::vector<std::string>();
   }
   virtual void del_rows(int first, int last) override {}
-  virtual void add_rows(
-      int newrows, int newnz, const char *qrtype, const double *rhs,
-      const double *range, const int *mstart, const int *mclind,
-      const double *dmatval,
-      const std::vector<std::string> &row_names = {}) override {}
-  virtual void add_cols(
-      int newcol, int newnz, const double *objx, const int *mstart,
-      const int *mrwind, const double *dmatval, const double *bdl,
-      const double *bdu,
-      const std::vector<std::string> &col_names = {}) override {}
+  virtual void add_rows(int newrows, int newnz, const char *qrtype,
+                        const double *rhs, const double *range,
+                        const int *mstart, const int *mclind,
+                        const double *dmatval,
+                        const std::vector<std::string> &row_names) override {}
+  virtual void add_cols(int newcol, int newnz, const double *objx,
+                        const int *mstart, const int *mrwind,
+                        const double *dmatval, const double *bdl,
+                        const double *bdu,
+                        const std::vector<std::string> &col_names) override {}
   virtual void add_name(int type, const char *cnames, int indice) override {}
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override {}

--- a/tests/cpp/lp_namer/NOOPSolver.h
+++ b/tests/cpp/lp_namer/NOOPSolver.h
@@ -6,7 +6,7 @@
 #define ANTARESXPANSION_TESTS_CPP_LP_NAMER_NOOPSOLVER_H_
 
 #include "antares-xpansion/multisolver_interface/SolverAbstract.h"
-class NOOPSolver: public SolverAbstract {
+class NOOPSolver : public SolverAbstract {
  public:
   virtual int get_number_of_instances() override { return 0; }
   virtual std::string get_solver_name() const override { return std::string(); }
@@ -50,15 +50,16 @@ class NOOPSolver: public SolverAbstract {
     return std::vector<std::string>();
   }
   virtual void del_rows(int first, int last) override {}
-  virtual void add_rows(int newrows, int newnz, const char *qrtype,
-                        const double *rhs, const double *range,
-                        const int *mstart, const int *mclind,
-                        const double *dmatval,
-                        const std::vector<std::string> &names = {}) override {}
-  virtual void add_cols(int newcol, int newnz, const double *objx,
-                        const int *mstart, const int *mrwind,
-                        const double *dmatval, const double *bdl,
-                        const double *bdu) override {}
+  virtual void add_rows(
+      int newrows, int newnz, const char *qrtype, const double *rhs,
+      const double *range, const int *mstart, const int *mclind,
+      const double *dmatval,
+      const std::vector<std::string> &row_names = {}) override {}
+  virtual void add_cols(
+      int newcol, int newnz, const double *objx, const int *mstart,
+      const int *mrwind, const double *dmatval, const double *bdl,
+      const double *bdu,
+      const std::vector<std::string> &col_names = {}) override {}
   virtual void add_name(int type, const char *cnames, int indice) override {}
   virtual void add_names(int type, const std::vector<std::string> &cnames,
                          int first, int end) override {}

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -44,10 +44,11 @@ class MockSolverAbstract : public SolverAbstract {
   void add_rows(int newrows, int newnz, const char *qrtype, const double *rhs,
                 const double *range, const int *mstart, const int *mclind,
                 const double *dmatval,
-                const std::vector<std::string> &names = {}) override {}
+                const std::vector<std::string> &row_names = {}) override {}
   void add_cols(int newcol, int newnz, const double *objx, const int *mstart,
                 const int *mrwind, const double *dmatval, const double *bdl,
-                const double *bdu) override {}
+                const double *bdu,
+                const std::vector<std::string> &col_names = {}) override {}
   void add_name(int type, const char *cnames, int indice) override {}
   void add_names(int type, const std::vector<std::string> &cnames, int first,
                  int end) override {}

--- a/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
+++ b/tests/cpp/lp_namer/WeightsFileWriterTest.cpp
@@ -44,11 +44,11 @@ class MockSolverAbstract : public SolverAbstract {
   void add_rows(int newrows, int newnz, const char *qrtype, const double *rhs,
                 const double *range, const int *mstart, const int *mclind,
                 const double *dmatval,
-                const std::vector<std::string> &row_names = {}) override {}
+                const std::vector<std::string> &row_names) override {}
   void add_cols(int newcol, int newnz, const double *objx, const int *mstart,
                 const int *mrwind, const double *dmatval, const double *bdl,
                 const double *bdu,
-                const std::vector<std::string> &col_names = {}) override {}
+                const std::vector<std::string> &col_names) override {}
   void add_name(int type, const char *cnames, int indice) override {}
   void add_names(int type, const std::vector<std::string> &cnames, int first,
                  int end) override {}

--- a/tests/cpp/solvers_interface/test_exceptions.cpp
+++ b/tests/cpp/solvers_interface/test_exceptions.cpp
@@ -1,6 +1,6 @@
+#include "antares-xpansion/multisolver_interface/Solver.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 #include "catch2.hpp"
-#include "antares-xpansion/multisolver_interface/Solver.h"
 
 TEST_CASE("InvalidStatusException", "[exceptions][invalid_status]") {
   SolverFactory factory;
@@ -61,7 +61,7 @@ SolverAbstract::Ptr createSimpleProblem(const std::string& solver_name) {
   std::vector<double> lb = std::vector<double>(2, 0.0);
   std::vector<double> ub = std::vector<double>(2, 100.0);
   solver->add_cols(2, 0, obj.data(), matstart.data(), matind.data(),
-                   matval.data(), lb.data(), ub.data());
+                   matval.data(), lb.data(), ub.data(), {});
   //========================================================================================
   // Add a row to problem : creating row structure
   int newRows = 2;
@@ -74,7 +74,7 @@ SolverAbstract::Ptr createSimpleProblem(const std::string& solver_name) {
   //========================================================================================
   // Add rows to solver
   solver->add_rows(newRows, newElems, ntype.data(), rhs.data(), NULL,
-                   mstart.data(), mind.data(), matvalRow.data());
+                   mstart.data(), mind.data(), matvalRow.data(), {});
 
   return solver;
 }

--- a/tests/cpp/solvers_interface/test_modifying_problem.cpp
+++ b/tests/cpp/solvers_interface/test_modifying_problem.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 
+#include "antares-xpansion/multisolver_interface/Solver.h"
 #include "catch2.hpp"
 #include "define_datas.hpp"
-#include "antares-xpansion/multisolver_interface/Solver.h"
 
 TEST_CASE("Modification: deleting rows", "[modif][del-rows]") {
   AllDatas datas;
@@ -79,7 +79,7 @@ TEST_CASE("Modification: add rows", "[modif][add-rows]") {
         //========================================================================================
         // Add the row to solver
         solver->add_rows(newRows, newElems, ntype.data(), rhs.data(), NULL,
-                         mstart.data(), mind.data(), matval.data());
+                         mstart.data(), mind.data(), matval.data(), {});
 
         //========================================================================================
         // Check new constraint matrix
@@ -307,7 +307,8 @@ TEST_CASE("Modification: add columns", "[modif][add-cols]") {
         std::vector<double> ubs(newcol, 6.0);
 
         solver->add_cols(newcol, nnz, newobj.data(), nmstart.data(),
-                         nmind.data(), nmatval.data(), lbs.data(), ubs.data());
+                         nmind.data(), nmatval.data(), lbs.data(), ubs.data(),
+                         {});
 
         //========================================================================================
         // Check objective and rows
@@ -457,7 +458,7 @@ TEST_CASE("Modification: add cols and a row associated to those columns",
       std::vector<double> lb(1, 0.0);
       std::vector<double> ub(1, 100.0);
       solver->add_cols(1, 0, obj.data(), matstart.data(), matind.data(),
-                       matval.data(), lb.data(), ub.data());
+                       matval.data(), lb.data(), ub.data(), {});
 
       // 3 Colunms with no obj
       matstart.resize(3);
@@ -469,7 +470,7 @@ TEST_CASE("Modification: add cols and a row associated to those columns",
       ub.resize(3);
       ub = std::vector<double>(3, 100.0);
       solver->add_cols(3, 0, obj.data(), matstart.data(), matind.data(),
-                       matval.data(), lb.data(), ub.data());
+                       matval.data(), lb.data(), ub.data(), {});
 
       REQUIRE(solver->get_ncols() == datas[inst]._ncols + 4);
       REQUIRE(solver->get_nrows() == datas[inst]._nrows);
@@ -494,7 +495,8 @@ TEST_CASE("Modification: add cols and a row associated to those columns",
       rowmatval[0] = 1.0;
 
       solver->add_rows(newrows, newnz, rowType.data(), rhs.data(), NULL,
-                       rowmatstart.data(), rowmatind.data(), rowmatval.data());
+                       rowmatstart.data(), rowmatind.data(), rowmatval.data(),
+                       {});
 
       REQUIRE(solver->get_nrows() == datas[inst]._nrows + newrows);
       REQUIRE(solver->get_nelems() == datas[inst]._nelems + newnz);


### PR DESCRIPTION
In problem generation, when reading the problem in memory from the Antares data structure, row and column names were added one by one to the `Problem` object. This is very inefficient, and is a major bottleneck in problem generation time (verified with vtune).

Solver Xpress provides a method to vectorize changes in row and column names. This PR exploits this vectorization to accelerate problem generation (when Xpress is used). As this feature is not provided by other solvers, no change in performance can be expected, we simply update the solver interfaces accordingly.