### PR TITLE
Disable deprecated 9.2 options for simulator

### DIFF
--- a/src/python/antares_xpansion/general_data_processor.py
+++ b/src/python/antares_xpansion/general_data_processor.py
@@ -102,6 +102,11 @@ class GeneralDataProcessor:
             (general_section, "year-by-year"): "false",
             (output_section, "synthesis"): "false",
             ("input", "import"): "",
+            # the following parameters are deprecated in Simulator 9.2
+            # we disable them manually to avoid simulation failure
+            ("adequacy patch", "enable-first-step"): "",
+            ("adequacy patch", "set-to-null-ntc-between-physical-out-for-first-step"): "",
+            ("other preferences", "initial-reservoir-levels"): ""
         }
 
     def backup_data(self):


### PR DESCRIPTION
This pull request includes an update to the `src/python/antares_xpansion/general_data_processor.py` file. The change involves disabling deprecated parameters in the Simulator 9.2 to prevent simulation failures.

Key change:

* [`src/python/antares_xpansion/general_data_processor.py`](diffhunk://#diff-96aa49295acb725fef9a0ef455881034cd283167f9d8a7126f75f3a33aaaee55R105-R109): Added code to disable the deprecated parameters `("adequacy patch", "enable-first-step")`, `("adequacy patch", "set-to-null-ntc-between-physical-out-for-first-step")`, and `("other preferences", "initial-reservoir-levels")` in the `_get_values_to_change_general_data_file` method.