### PR TITLE
Test merge_mps

### DIFF
--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -75,9 +75,6 @@ jobs:
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
-          ls $XPRESS_DIR
-          echo ---
-          ls $XPRESS_DIR/lib/
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Update alternatives

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -75,6 +75,9 @@ jobs:
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
+          ls $XPRESS_DIR
+          echo ---
+          ls $XPRESS_DIR/lib/
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Update alternatives

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,7 +3,6 @@ name: SonarCloud
 on:
   push:
     branches:
-      - branch-coverage
       - develop
       - feature/*
       - features/*
@@ -12,7 +11,6 @@ on:
       - release/*
       - doc/*
       - dependabot/*
-  pull_request:
 
 jobs:
   sonarcloud:
@@ -158,6 +156,14 @@ jobs:
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
           cd $GITHUB_WORKSPACE/_build
           ctest -C Release --output-on-failure
+
+      - name: Run long test on develop
+        continue-on-error: true
+        if: github.branch == 'develop'
+        run: |
+          export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
+          cd $GITHUB_WORKSPACE/_build
+          ctest -C Release --output-on-failure -L "long | medium"
 
       - name: Compile coverage reports
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,8 +1,6 @@
 name: SonarCloud
 
 on:
-  schedule:
-    - cron: '0 0 * * *' # minuit for long tests
   push:
     branches:
       - branch-coverage
@@ -159,15 +157,7 @@ jobs:
         run: |
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
           cd $GITHUB_WORKSPACE/_build
-          ctest -C Release --output-on-failure -L "unit|short|bdd"
-
-      - name: Run long test on schedule
-        continue-on-error: true
-        if: github.event_name == 'schedule'
-        run: |
-          export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
-          cd $GITHUB_WORKSPACE/_build
-          ctest -C Release --output-on-failure -L "long | medium"
+          ctest -C Release --output-on-failure
 
       - name: Compile coverage reports
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,6 +3,7 @@ name: SonarCloud
 on:
   push:
     branches:
+      - branch-coverage
       - develop
       - feature/*
       - features/*

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,6 +1,8 @@
 name: SonarCloud
 
 on:
+  schedule:
+    - cron: '0 0 * * *' # minuit for long tests
   push:
     branches:
       - branch-coverage
@@ -158,6 +160,14 @@ jobs:
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
           cd $GITHUB_WORKSPACE/_build
           ctest -C Release --output-on-failure -L "unit|short|bdd"
+
+      - name: Run long test on schedule
+        continue-on-error: true
+        if: github.event_name == 'schedule'
+        run: |
+          export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
+          cd $GITHUB_WORKSPACE/_build
+          ctest -C Release --output-on-failure -L "long | medium"
 
       - name: Compile coverage reports
         run: |

--- a/src/cpp/benders/benders_core/CouplingMapGenerator.cpp
+++ b/src/cpp/benders/benders_core/CouplingMapGenerator.cpp
@@ -1,8 +1,7 @@
 #include <antares-xpansion/benders/benders_core/CouplingMapGenerator.h>
 #include <antares-xpansion/xpansion_interfaces/LoggerUtils.h>
 
-struct InvalidStructureFile: LogUtils::XpansionError<std::runtime_error>
-{
+struct InvalidStructureFile : LogUtils::XpansionError<std::runtime_error> {
     using LogUtils::XpansionError<std::runtime_error>::XpansionError;
 };
 
@@ -21,14 +20,12 @@ struct InvalidStructureFile: LogUtils::XpansionError<std::runtime_error>
  *  \note The id in the coupling_map is that of the variable in the solver
  *responsible for the creation of the structure file.
  */
-CouplingMap CouplingMapGenerator::BuildInput(const std::filesystem::path& structure_path,
-                                             std::shared_ptr<ILoggerXpansion> logger,
-                                             const std::string& context)
-{
+CouplingMap CouplingMapGenerator::BuildInput(const std::filesystem::path &structure_path,
+                                             ILoggerXpansion *logger,
+                                             const std::string &context) {
     CouplingMap coupling_map;
     std::ifstream summary(structure_path, std::ios::in);
-    if (!summary)
-    {
+    if (!summary) {
         auto log_location = LOGLOCATION;
         std::ostringstream msg;
         msg << "Cannot open structure file " << structure_path << std::endl;
@@ -39,8 +36,7 @@ CouplingMap CouplingMapGenerator::BuildInput(const std::filesystem::path& struct
     }
     std::string line;
 
-    while (std::getline(summary, line))
-    {
+    while (std::getline(summary, line)) {
         std::stringstream buffer(line);
         std::string problem_name;
         std::string variable_name;

--- a/src/cpp/benders/benders_core/CouplingMapGenerator.cpp
+++ b/src/cpp/benders/benders_core/CouplingMapGenerator.cpp
@@ -1,7 +1,8 @@
 #include <antares-xpansion/benders/benders_core/CouplingMapGenerator.h>
 #include <antares-xpansion/xpansion_interfaces/LoggerUtils.h>
 
-struct InvalidStructureFile : LogUtils::XpansionError<std::runtime_error> {
+struct InvalidStructureFile: LogUtils::XpansionError<std::runtime_error>
+{
     using LogUtils::XpansionError<std::runtime_error>::XpansionError;
 };
 
@@ -20,12 +21,14 @@ struct InvalidStructureFile : LogUtils::XpansionError<std::runtime_error> {
  *  \note The id in the coupling_map is that of the variable in the solver
  *responsible for the creation of the structure file.
  */
-CouplingMap CouplingMapGenerator::BuildInput(const std::filesystem::path &structure_path,
-                                             ILoggerXpansion *logger,
-                                             const std::string &context) {
+CouplingMap CouplingMapGenerator::BuildInput(const std::filesystem::path& structure_path,
+                                             ILoggerXpansion* logger,
+                                             const std::string& context)
+{
     CouplingMap coupling_map;
     std::ifstream summary(structure_path, std::ios::in);
-    if (!summary) {
+    if (!summary)
+    {
         auto log_location = LOGLOCATION;
         std::ostringstream msg;
         msg << "Cannot open structure file " << structure_path << std::endl;
@@ -36,7 +39,8 @@ CouplingMap CouplingMapGenerator::BuildInput(const std::filesystem::path &struct
     }
     std::string line;
 
-    while (std::getline(summary, line)) {
+    while (std::getline(summary, line))
+    {
         std::stringstream buffer(line);
         std::string problem_name;
         std::string variable_name;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/CouplingMapGenerator.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/CouplingMapGenerator.h
@@ -6,6 +6,6 @@ class CouplingMapGenerator
 {
 public:
     static CouplingMap BuildInput(const std::filesystem::path& structure_path,
-                                  std::shared_ptr<ILoggerXpansion> logger,
+                                  ILoggerXpansion *logger,
                                   const std::string& context = "Benders");
 };

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/CouplingMapGenerator.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/CouplingMapGenerator.h
@@ -6,6 +6,6 @@ class CouplingMapGenerator
 {
 public:
     static CouplingMap BuildInput(const std::filesystem::path& structure_path,
-                                  ILoggerXpansion *logger,
+                                  ILoggerXpansion* logger,
                                   const std::string& context = "Benders");
 };

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -24,12 +24,14 @@
 
 #include "ProblemFormat.h"
 
-enum class MasterFormulation {
+enum class MasterFormulation
+{
     INTEGER,
     RELAXED
 };
 
-enum class SOLVER {
+enum class SOLVER
+{
     BENDERS,
     OUTER_LOOP,
     MERGE_MPS
@@ -59,56 +61,72 @@ using ActiveCutStorage = std::vector<ActiveCut>;
 using mps_coupling = std::pair<std::string, std::string>;
 using mps_coupling_list = std::list<mps_coupling>;
 
-enum class BENDERSMETHOD {
+enum class BENDERSMETHOD
+{
     BENDERS,
     BENDERS_BY_BATCH,
     BENDERS_OUTERLOOP,
     BENDERS_BY_BATCH_OUTERLOOP
 };
 
-inline std::string bendersmethod_to_string(BENDERSMETHOD method) {
-    switch (method) {
-        case BENDERSMETHOD::BENDERS:
-            return "Benders";
-        case BENDERSMETHOD::BENDERS_BY_BATCH:
-            return "Benders by batch";
-        case BENDERSMETHOD::BENDERS_OUTERLOOP:
-            return "Outerloop around Benders";
-        case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
-            return "Outerloop around Benders by batch";
-        default:
-            return "Unknown";
+inline std::string bendersmethod_to_string(BENDERSMETHOD method)
+{
+    switch (method)
+    {
+    case BENDERSMETHOD::BENDERS:
+        return "Benders";
+    case BENDERSMETHOD::BENDERS_BY_BATCH:
+        return "Benders by batch";
+    case BENDERSMETHOD::BENDERS_OUTERLOOP:
+        return "Outerloop around Benders";
+    case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
+        return "Outerloop around Benders by batch";
+    default:
+        return "Unknown";
     }
 }
 
-struct Predicate {
-    bool operator()(const PointPtr &lhs, const PointPtr &rhs) const {
+struct Predicate
+{
+    bool operator()(const PointPtr& lhs, const PointPtr& rhs) const
+    {
         return *lhs < *rhs;
     }
 
-    bool operator()(const Point &lhs, const Point &rhs) const {
+    bool operator()(const Point& lhs, const Point& rhs) const
+    {
         Point::const_iterator it1(lhs.begin());
         Point::const_iterator it2(rhs.begin());
 
         Point::const_iterator end1(lhs.end());
         Point::const_iterator end2(rhs.end());
 
-        while (it1 != end1 && it2 != end2) {
-            if (it1->first != it2->first) {
+        while (it1 != end1 && it2 != end2)
+        {
+            if (it1->first != it2->first)
+            {
                 return it1->first < it2->first;
-            } else {
-                if (std::fabs(it1->second - it2->second) < EPSILON_PREDICATE) {
+            }
+            else
+            {
+                if (std::fabs(it1->second - it2->second) < EPSILON_PREDICATE)
+                {
                     ++it1;
                     ++it2;
-                } else {
+                }
+                else
+                {
                     return it1->second < it2->second;
                 }
             }
         }
 
-        if (it1 == end1 && it2 == end2) {
+        if (it1 == end1 && it2 == end2)
+        {
             return false;
-        } else {
+        }
+        else
+        {
             return (it1 == end1);
         }
     }
@@ -121,18 +139,26 @@ struct Predicate {
  *
  *  \param rhs : point
  */
-inline std::ostream &operator<<(std::ostream &stream, const Point &rhs) {
-    for (const auto &kvp: rhs) {
-        if (kvp.second > 0) {
-            if (kvp.second == 1) {
+inline std::ostream& operator<<(std::ostream& stream, const Point& rhs)
+{
+    for (const auto& kvp: rhs)
+    {
+        if (kvp.second > 0)
+        {
+            if (kvp.second == 1)
+            {
                 stream << "+";
                 stream << kvp.first;
-            } else {
+            }
+            else
+            {
                 stream << "+";
                 stream << kvp.second;
                 stream << kvp.first;
             }
-        } else if (kvp.second < 0) {
+        }
+        else if (kvp.second < 0)
+        {
             stream << kvp.second;
             stream << kvp.first;
         }
@@ -140,9 +166,9 @@ inline std::ostream &operator<<(std::ostream &stream, const Point &rhs) {
     return stream;
 }
 
-double norm_point(const Point &x0, const Point &x1);
+double norm_point(const Point& x0, const Point& x1);
 
-std::ostream &operator<<(std::ostream &stream, const std::vector<IntVector> &rhs);
+std::ostream& operator<<(std::ostream& stream, const std::vector<IntVector>& rhs);
 
 const std::string SUBPROBLEM_WEIGHT_CST_STR("CONSTANT");
 const std::string SUBPROBLEM_WEIGHT_UNIFORM_CST_STR("UNIFORM");
@@ -150,7 +176,8 @@ const std::string WEIGHT_SUM_CST_STR("WEIGHT_SUM");
 const std::string MPS_SUFFIX = ".mps";
 const std::string SAVE_SUFFIX = ".svf";
 
-struct BaseOptions {
+struct BaseOptions
+{
     std::string OUTPUTROOT;
     std::string INPUTROOT;
     std::string STRUCTURE_FILE;
@@ -171,13 +198,17 @@ struct BaseOptions {
 
 typedef BaseOptions MergeMPSOptions;
 
-struct ExternalLoopOptions {
+struct ExternalLoopOptions
+{
     bool DO_OUTER_LOOP = false;
     std::string OUTER_LOOP_OPTION_FILE;
 };
 
-struct BendersBaseOptions : public BaseOptions {
-    explicit BendersBaseOptions(const BaseOptions &base_to_copy): BaseOptions(base_to_copy) {
+struct BendersBaseOptions: public BaseOptions
+{
+    explicit BendersBaseOptions(const BaseOptions& base_to_copy):
+        BaseOptions(base_to_copy)
+    {
     }
 
     int MAX_ITERATIONS = -1;
@@ -204,4 +235,4 @@ struct BendersBaseOptions : public BaseOptions {
 
 void usage(int argc);
 
-Json::Value get_json_file_content(const std::filesystem::path &json_file);
+Json::Value get_json_file_content(const std::filesystem::path& json_file);

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -24,13 +24,12 @@
 
 #include "ProblemFormat.h"
 
-enum class MasterFormulation
-{
+enum class MasterFormulation {
     INTEGER,
     RELAXED
 };
-enum class SOLVER
-{
+
+enum class SOLVER {
     BENDERS,
     OUTER_LOOP,
     MERGE_MPS
@@ -43,89 +42,73 @@ typedef std::shared_ptr<Point> PointPtr;
 
 const double EPSILON_PREDICATE = 1e-8;
 
-typedef std::set<std::string> problem_names;
-typedef std::map<std::string, int> VariableMap;
-typedef std::map<int, std::string> Int2Str;
-typedef std::map<std::string, double> Str2Dbl;
-typedef std::vector<int> IntVector;
-typedef std::vector<char> CharVector;
-typedef std::vector<double> DblVector;
-typedef std::vector<std::string> StrVector;
-typedef std::map<std::string, VariableMap> CouplingMap;
+using problem_names = std::set<std::string>;
+using VariableMap = std::map<std::string, int>;
+using Int2Str = std::map<int, std::string>;
+using Str2Dbl = std::map<std::string, double>;
+using IntVector = std::vector<int>;
+using CharVector = std::vector<char>;
+using DblVector = std::vector<double>;
+using StrVector = std::vector<std::string>;
+using CouplingMap = std::map<std::string, VariableMap>;
 
-typedef std::map<std::string, IntVector> SlaveCutId;
-typedef std::tuple<int, std::string, int, bool> ActiveCut;
-typedef std::vector<ActiveCut> ActiveCutStorage;
+using SlaveCutId = std::map<std::string, IntVector>;
+using ActiveCut = std::tuple<int, std::string, int, bool>;
+using ActiveCutStorage = std::vector<ActiveCut>;
 
-typedef std::pair<std::string, std::string> mps_coupling;
-typedef std::list<mps_coupling> mps_coupling_list;
+using mps_coupling = std::pair<std::string, std::string>;
+using mps_coupling_list = std::list<mps_coupling>;
 
-enum class BENDERSMETHOD
-{
+enum class BENDERSMETHOD {
     BENDERS,
     BENDERS_BY_BATCH,
     BENDERS_OUTERLOOP,
     BENDERS_BY_BATCH_OUTERLOOP
 };
 
-inline std::string bendersmethod_to_string(BENDERSMETHOD method)
-{
-    switch (method)
-    {
-    case BENDERSMETHOD::BENDERS:
-        return "Benders";
-    case BENDERSMETHOD::BENDERS_BY_BATCH:
-        return "Benders by batch";
-    case BENDERSMETHOD::BENDERS_OUTERLOOP:
-        return "Outerloop around Benders";
-    case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
-        return "Outerloop around Benders by batch";
-    default:
-        return "Unknown";
+inline std::string bendersmethod_to_string(BENDERSMETHOD method) {
+    switch (method) {
+        case BENDERSMETHOD::BENDERS:
+            return "Benders";
+        case BENDERSMETHOD::BENDERS_BY_BATCH:
+            return "Benders by batch";
+        case BENDERSMETHOD::BENDERS_OUTERLOOP:
+            return "Outerloop around Benders";
+        case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
+            return "Outerloop around Benders by batch";
+        default:
+            return "Unknown";
     }
 }
 
-struct Predicate
-{
-    bool operator()(const PointPtr& lhs, const PointPtr& rhs) const
-    {
+struct Predicate {
+    bool operator()(const PointPtr &lhs, const PointPtr &rhs) const {
         return *lhs < *rhs;
     }
 
-    bool operator()(const Point& lhs, const Point& rhs) const
-    {
+    bool operator()(const Point &lhs, const Point &rhs) const {
         Point::const_iterator it1(lhs.begin());
         Point::const_iterator it2(rhs.begin());
 
         Point::const_iterator end1(lhs.end());
         Point::const_iterator end2(rhs.end());
 
-        while (it1 != end1 && it2 != end2)
-        {
-            if (it1->first != it2->first)
-            {
+        while (it1 != end1 && it2 != end2) {
+            if (it1->first != it2->first) {
                 return it1->first < it2->first;
-            }
-            else
-            {
-                if (std::fabs(it1->second - it2->second) < EPSILON_PREDICATE)
-                {
+            } else {
+                if (std::fabs(it1->second - it2->second) < EPSILON_PREDICATE) {
                     ++it1;
                     ++it2;
-                }
-                else
-                {
+                } else {
                     return it1->second < it2->second;
                 }
             }
         }
 
-        if (it1 == end1 && it2 == end2)
-        {
+        if (it1 == end1 && it2 == end2) {
             return false;
-        }
-        else
-        {
+        } else {
             return (it1 == end1);
         }
     }
@@ -138,26 +121,18 @@ struct Predicate
  *
  *  \param rhs : point
  */
-inline std::ostream& operator<<(std::ostream& stream, const Point& rhs)
-{
-    for (const auto& kvp: rhs)
-    {
-        if (kvp.second > 0)
-        {
-            if (kvp.second == 1)
-            {
+inline std::ostream &operator<<(std::ostream &stream, const Point &rhs) {
+    for (const auto &kvp: rhs) {
+        if (kvp.second > 0) {
+            if (kvp.second == 1) {
                 stream << "+";
                 stream << kvp.first;
-            }
-            else
-            {
+            } else {
                 stream << "+";
                 stream << kvp.second;
                 stream << kvp.first;
             }
-        }
-        else if (kvp.second < 0)
-        {
+        } else if (kvp.second < 0) {
             stream << kvp.second;
             stream << kvp.first;
         }
@@ -165,9 +140,9 @@ inline std::ostream& operator<<(std::ostream& stream, const Point& rhs)
     return stream;
 }
 
-double norm_point(const Point& x0, const Point& x1);
+double norm_point(const Point &x0, const Point &x1);
 
-std::ostream& operator<<(std::ostream& stream, const std::vector<IntVector>& rhs);
+std::ostream &operator<<(std::ostream &stream, const std::vector<IntVector> &rhs);
 
 const std::string SUBPROBLEM_WEIGHT_CST_STR("CONSTANT");
 const std::string SUBPROBLEM_WEIGHT_UNIFORM_CST_STR("UNIFORM");
@@ -175,8 +150,7 @@ const std::string WEIGHT_SUM_CST_STR("WEIGHT_SUM");
 const std::string MPS_SUFFIX = ".mps";
 const std::string SAVE_SUFFIX = ".svf";
 
-struct BaseOptions
-{
+struct BaseOptions {
     std::string OUTPUTROOT;
     std::string INPUTROOT;
     std::string STRUCTURE_FILE;
@@ -197,17 +171,13 @@ struct BaseOptions
 
 typedef BaseOptions MergeMPSOptions;
 
-struct ExternalLoopOptions
-{
+struct ExternalLoopOptions {
     bool DO_OUTER_LOOP = false;
     std::string OUTER_LOOP_OPTION_FILE;
 };
 
-struct BendersBaseOptions: public BaseOptions
-{
-    explicit BendersBaseOptions(const BaseOptions& base_to_copy):
-        BaseOptions(base_to_copy)
-    {
+struct BendersBaseOptions : public BaseOptions {
+    explicit BendersBaseOptions(const BaseOptions &base_to_copy): BaseOptions(base_to_copy) {
     }
 
     int MAX_ITERATIONS = -1;
@@ -233,4 +203,5 @@ struct BendersBaseOptions: public BaseOptions
 };
 
 void usage(int argc);
-Json::Value get_json_file_content(const std::filesystem::path& json_file);
+
+Json::Value get_json_file_content(const std::filesystem::path &json_file);

--- a/src/cpp/benders/factories/BendersFactory.cpp
+++ b/src/cpp/benders/factories/BendersFactory.cpp
@@ -17,42 +17,30 @@
 #include "antares-xpansion/helpers/Timer.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
-BENDERSMETHOD DeduceBendersMethod(size_t coupling_map_size, size_t batch_size, bool outer_loop)
-{
-    if (batch_size == 0 || batch_size == coupling_map_size - 1)
-    {
-        if (outer_loop)
-        {
+BENDERSMETHOD DeduceBendersMethod(size_t coupling_map_size, size_t batch_size, bool outer_loop) {
+    if (batch_size == 0 || batch_size == coupling_map_size - 1) {
+        if (outer_loop) {
             return BENDERSMETHOD::BENDERS_OUTERLOOP;
-        }
-        else
-        {
+        } else {
             return BENDERSMETHOD::BENDERS;
         }
-    }
-    else
-    {
-        if (outer_loop)
-        {
+    } else {
+        if (outer_loop) {
             return BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP;
-        }
-        else
-        {
+        } else {
             return BENDERSMETHOD::BENDERS_BY_BATCH;
         }
     }
 }
 
-void BendersMainFactory::PrepareForExecution(bool outer_loop)
-{
+void BendersMainFactory::PrepareForExecution(bool outer_loop) {
     BendersBaseOptions benders_options(options_.get_benders_options());
     benders_options.EXTERNAL_LOOP_OPTIONS.DO_OUTER_LOOP = outer_loop;
 
     SetupLoggerAndOutputWriter(benders_options);
 
     const auto coupling_map = CouplingMapGenerator::BuildInput(benders_options.STRUCTURE_FILE,
-                                                               std::make_shared<BendersLoggerBase>(
-                                                                 benders_loggers_),
+                                                               &benders_loggers_,
                                                                "Benders");
 
     method_ = DeduceBendersMethod(coupling_map.size(), options_.BATCH_SIZE, outer_loop);
@@ -60,15 +48,12 @@ void BendersMainFactory::PrepareForExecution(bool outer_loop)
 
     criterion_input_holder_ = ProcessCriterionInput();
 
-    if (pworld_->rank() == 0)
-    {
+    if (pworld_->rank() == 0) {
         if (Benders::StartUp startup;
-            startup.StudyAlreadyAchievedCriterion(options_, writer_.get(), logger_))
-        {
+            startup.StudyAlreadyAchievedCriterion(options_, writer_.get(), logger_)) {
             return;
         }
-        if (!isCriterionListEmpty())
-        {
+        if (!isCriterionListEmpty()) {
             AddCriterionOutputs();
         }
     }
@@ -77,10 +62,8 @@ void BendersMainFactory::PrepareForExecution(bool outer_loop)
     ConfigureSolverLog();
 }
 
-void BendersMainFactory::ConfigureSolverLog()
-{
-    if (options_.LOG_LEVEL > 1)
-    {
+void BendersMainFactory::ConfigureSolverLog() {
+    if (options_.LOG_LEVEL > 1) {
         auto solver_log = std::filesystem::path(options_.OUTPUTROOT)
                           / (std::string("solver_log_proc_") + std::to_string(pworld_->rank())
                              + ".txt");
@@ -89,57 +72,50 @@ void BendersMainFactory::ConfigureSolverLog()
     }
 }
 
-void BendersMainFactory::ConfigureBenders(const BendersBaseOptions& benders_options,
-                                          const CouplingMap& coupling_map)
-{
-    switch (method_)
-    {
-    case BENDERSMETHOD::BENDERS:
-        benders_ = std::make_shared<BendersMpi>(benders_options,
-                                                logger_,
-                                                writer_,
-                                                *penv_,
-                                                *pworld_,
-                                                math_log_driver_);
-        break;
-    case BENDERSMETHOD::BENDERS_OUTERLOOP:
-        benders_ = std::make_shared<Outerloop::BendersMpiOuterLoop>(benders_options,
-                                                                    logger_,
-                                                                    writer_,
-                                                                    *penv_,
-                                                                    *pworld_,
-                                                                    math_log_driver_);
-        break;
-    case BENDERSMETHOD::BENDERS_BY_BATCH:
-    case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
-        benders_ = std::make_shared<BendersByBatch>(benders_options,
+void BendersMainFactory::ConfigureBenders(const BendersBaseOptions &benders_options,
+                                          const CouplingMap &coupling_map) {
+    switch (method_) {
+        case BENDERSMETHOD::BENDERS:
+            benders_ = std::make_shared<BendersMpi>(benders_options,
                                                     logger_,
                                                     writer_,
                                                     *penv_,
                                                     *pworld_,
                                                     math_log_driver_);
-        break;
+            break;
+        case BENDERSMETHOD::BENDERS_OUTERLOOP:
+            benders_ = std::make_shared<Outerloop::BendersMpiOuterLoop>(benders_options,
+                                                                        logger_,
+                                                                        writer_,
+                                                                        *penv_,
+                                                                        *pworld_,
+                                                                        math_log_driver_);
+            break;
+        case BENDERSMETHOD::BENDERS_BY_BATCH:
+        case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
+            benders_ = std::make_shared<BendersByBatch>(benders_options,
+                                                        logger_,
+                                                        writer_,
+                                                        *penv_,
+                                                        *pworld_,
+                                                        math_log_driver_);
+            break;
     }
 
     benders_->set_input_map(coupling_map);
     benders_->setCriterionComputationInputs(
-      std::visit([](auto&& the_variant)
-                 { return static_cast<Benders::Criterion::CriterionInputData>(the_variant); },
-                 criterion_input_holder_));
+        std::visit([](auto &&the_variant) { return static_cast<Benders::Criterion::CriterionInputData>(the_variant); },
+                   criterion_input_holder_));
 }
 
-void BendersMainFactory::SetupLoggerAndOutputWriter(const BendersBaseOptions& benders_options)
-{
+void BendersMainFactory::SetupLoggerAndOutputWriter(const BendersBaseOptions &benders_options) {
     auto benders_log_console = benders_options.LOG_LEVEL > 0;
-    if (pworld_->rank() == 0)
-    {
+    if (pworld_->rank() == 0) {
         auto logger_factory = FileAndStdoutLoggerFactory(LogReportsName(), benders_log_console);
         logger_ = logger_factory.get_logger();
         math_log_driver_ = BuildMathLogger(benders_log_console);
         writer_ = build_json_writer(options_.JSON_FILE, options_.RESUME);
-    }
-    else
-    {
+    } else {
         logger_ = build_void_logger();
         writer_ = build_void_writer();
         math_log_driver_ = MathLoggerFactory::get_void_logger();
@@ -152,15 +128,13 @@ void BendersMainFactory::SetupLoggerAndOutputWriter(const BendersBaseOptions& be
     writer_->WriteProblemFormat(fmt::format("{}", options_.PROBLEMS_FORMAT));
 }
 
-bool BendersMainFactory::isCriterionListEmpty() const
-{
-    return std::visit([](auto&& the_variant) { return the_variant.Criteria().empty(); },
+bool BendersMainFactory::isCriterionListEmpty() const {
+    return std::visit([](auto &&the_variant) { return the_variant.Criteria().empty(); },
                       criterion_input_holder_);
 }
 
 std::shared_ptr<MathLoggerDriver> BendersMainFactory::BuildMathLogger(
-  bool benders_log_console) const
-{
+    bool benders_log_console) const {
     const std::filesystem::path output_root(options_.OUTPUTROOT);
     auto math_logs_file = output_root / "benders_solver.log";
 
@@ -171,45 +145,37 @@ std::shared_ptr<MathLoggerDriver> BendersMainFactory::BuildMathLogger(
     return math_log_driver;
 }
 
-void BendersMainFactory::AddCriterionOutputs()
-{
+void BendersMainFactory::AddCriterionOutputs() {
     const std::filesystem::path output_root(options_.OUTPUTROOT);
 
-    const auto& headers = std::visit([](auto&& the_variant) { return the_variant.PatternBodies(); },
+    const auto &headers = std::visit([](auto &&the_variant) { return the_variant.PatternBodies(); },
                                      criterion_input_holder_);
     math_log_driver_->add_logger(output_root / LOLD_FILE,
                                  headers,
                                  &CriteriaCurrentIterationData::criteria);
 
-    positive_unsupplied_file_ = std::visit([](auto&& the_variant)
-                                           { return the_variant.PatternsPrefix() + ".txt"; },
+    positive_unsupplied_file_ = std::visit([](auto &&the_variant) { return the_variant.PatternsPrefix() + ".txt"; },
                                            criterion_input_holder_);
     math_log_driver_->add_logger(output_root / positive_unsupplied_file_,
                                  headers,
                                  &CriteriaCurrentIterationData::patterns_values);
 }
 
-int BendersMainFactory::RunBenders()
-{
-    try
-    {
+int BendersMainFactory::RunBenders() {
+    try {
         PrepareForExecution(false);
-        if (benders_)
-        {
+        if (benders_) {
             StartMessage();
             benders_->launch();
             EndMessage(benders_->execution_time());
         }
-    }
-    catch (std::exception& e)
-    {
+    } catch (std::exception &e) {
         std::ostringstream msg;
         msg << "error: " << e.what() << std::endl;
         benders_loggers_.display_message(msg.str());
         mpi::environment::abort(1);
     }
-    catch (...)
-    {
+    catch (...) {
         std::ostringstream msg;
         msg << "Exception of unknown type!" << std::endl;
         benders_loggers_.display_message(msg.str());
@@ -218,8 +184,7 @@ int BendersMainFactory::RunBenders()
     return 0;
 }
 
-void BendersMainFactory::StartMessage()
-{
+void BendersMainFactory::StartMessage() {
     std::ostringstream oss_l;
     oss_l << "Starting " << context_ << std::endl;
     options_.print(oss_l);
@@ -227,8 +192,7 @@ void BendersMainFactory::StartMessage()
     benders_loggers_.display_message(oss_l.str());
 }
 
-void BendersMainFactory::EndMessage(const double execution_time)
-{
+void BendersMainFactory::EndMessage(const double execution_time) {
     std::ostringstream str;
     str << "Optimization results available in : " << options_.JSON_FILE << std::endl;
     benders_loggers_.display_message(str.str(), LogUtils::LOGLEVEL::INFO, context_);
@@ -240,51 +204,44 @@ void BendersMainFactory::EndMessage(const double execution_time)
 }
 
 std::variant<Benders::Criterion::CriterionInputData,
-             Benders::Criterion::OuterLoopCriterionInputData>
-BendersMainFactory::ProcessCriterionInput()
-{
+    Benders::Criterion::OuterLoopCriterionInputData>
+BendersMainFactory::ProcessCriterionInput() {
     const auto fpath = std::filesystem::path(options_.INPUTROOT) / options_.OUTER_LOOP_OPTION_FILE;
     // if adequacy_criterion.yml is provided read it
     if ((method_ == BENDERSMETHOD::BENDERS_OUTERLOOP
          || method_ == BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP)
-        && std::filesystem::exists(fpath))
-    {
+        && std::filesystem::exists(fpath)) {
         return Benders::Criterion::CriterionInputFromYaml().Read(fpath);
     }
     // else compute criterion for all areas!
-    else
-    {
+    else {
         return BuildPatternsUsingAreaFile();
     }
 }
 
-Benders::Criterion::CriterionInputData BendersMainFactory::BuildPatternsUsingAreaFile()
-{
+Benders::Criterion::CriterionInputData BendersMainFactory::BuildPatternsUsingAreaFile() {
     std::set<std::string> unique_areas = ReadAreaFile();
     Benders::Criterion::CriterionInputData ret;
     ret.SetCriterionCountThreshold(1);
 
-    for (const auto& area: unique_areas)
-    {
+    for (const auto &area: unique_areas) {
         Benders::Criterion::CriterionSingleInputData
-          singleInputData(Benders::Criterion::PositiveUnsuppliedEnergy, area, 1);
+                singleInputData(Benders::Criterion::PositiveUnsuppliedEnergy, area, 1);
         ret.AddSingleData(singleInputData);
     }
 
     return ret;
 }
 
-std::set<std::string> BendersMainFactory::ReadAreaFile()
-{
+std::set<std::string> BendersMainFactory::ReadAreaFile() {
     std::set<std::string> unique_areas;
     const auto area_file = std::filesystem::path(options_.INPUTROOT) / options_.AREA_FILE;
     const auto area_file_data = AreaParser::ReadAreaFile(area_file);
-    if (const auto& msg = area_file_data.error_message; !msg.empty())
-    {
+    if (const auto &msg = area_file_data.error_message; !msg.empty()) {
         benders_loggers_.display_message(msg, LogUtils::LOGLEVEL::WARNING, context_);
         std::ostringstream ms;
         ms << " Consequently, " << LOLD_FILE
-           << " and other criterion based files will not be produced!";
+                << " and other criterion based files will not be produced!";
 
         benders_loggers_.display_message(ms.str(), LogUtils::LOGLEVEL::WARNING, context_);
         return {};
@@ -292,18 +249,16 @@ std::set<std::string> BendersMainFactory::ReadAreaFile()
     return {area_file_data.areas.begin(), area_file_data.areas.end()};
 }
 
-int BendersMainFactory::RunExternalLoop()
-{
-    try
-    {
+int BendersMainFactory::RunExternalLoop() {
+    try {
         PrepareForExecution(true);
         double tau = 0.5;
-        const auto& outer_loop_inputs = std::get<Benders::Criterion::OuterLoopCriterionInputData>(
-          criterion_input_holder_);
+        const auto &outer_loop_inputs = std::get<Benders::Criterion::OuterLoopCriterionInputData>(
+            criterion_input_holder_);
         std::shared_ptr<Outerloop::IMasterUpdate> master_updater = std::make_shared<
-          Outerloop::MasterUpdateBase>(benders_, tau, outer_loop_inputs.StoppingThreshold());
+            Outerloop::MasterUpdateBase>(benders_, tau, outer_loop_inputs.StoppingThreshold());
         std::shared_ptr<Outerloop::ICutsManager>
-          cuts_manager = std::make_shared<Outerloop::CutsManagerRunTime>();
+                cuts_manager = std::make_shared<Outerloop::CutsManagerRunTime>();
 
         Outerloop::OuterLoopBenders ext_loop(outer_loop_inputs.Criteria(),
                                              master_updater,
@@ -313,16 +268,13 @@ int BendersMainFactory::RunExternalLoop()
         StartMessage();
         ext_loop.Run();
         EndMessage(ext_loop.Runtime());
-    }
-    catch (std::exception& e)
-    {
+    } catch (std::exception &e) {
         std::ostringstream msg;
         msg << "error: " << e.what() << std::endl;
         benders_loggers_.display_message(msg.str());
         mpi::environment::abort(1);
     }
-    catch (...)
-    {
+    catch (...) {
         std::ostringstream msg;
         msg << "Exception of unknown type!" << std::endl;
         benders_loggers_.display_message(msg.str());
@@ -332,18 +284,15 @@ int BendersMainFactory::RunExternalLoop()
 }
 
 BendersMainFactory::BendersMainFactory(int argc,
-                                       char** argv,
-                                       mpi::environment& env,
-                                       mpi::communicator& world,
-                                       const SOLVER& solver):
-    argv_(argv),
-    penv_(&env),
-    pworld_(&world),
-    solver_(solver)
-{
+                                       char **argv,
+                                       mpi::environment &env,
+                                       mpi::communicator &world,
+                                       const SOLVER &solver): argv_(argv),
+                                                              penv_(&env),
+                                                              pworld_(&world),
+                                                              solver_(solver) {
     // First check usage (options are given)
-    if (world.rank() == 0)
-    {
+    if (world.rank() == 0) {
         usage(argc);
     }
 
@@ -351,37 +300,29 @@ BendersMainFactory::BendersMainFactory(int argc,
 }
 
 BendersMainFactory::BendersMainFactory(int argc,
-                                       char** argv,
-                                       const std::filesystem::path& options_file,
-                                       mpi::environment& env,
-                                       mpi::communicator& world,
-                                       const SOLVER& solver):
-    argv_(argv),
-    penv_(&env),
-    pworld_(&world),
-    solver_(solver),
-    options_(options_file)
-{
+                                       char **argv,
+                                       const std::filesystem::path &options_file,
+                                       mpi::environment &env,
+                                       mpi::communicator &world,
+                                       const SOLVER &solver): argv_(argv),
+                                                              penv_(&env),
+                                                              pworld_(&world),
+                                                              solver_(solver),
+                                                              options_(options_file) {
     // First check usage (options are given)
-    if (world.rank() == 0)
-    {
+    if (world.rank() == 0) {
         usage(argc);
     }
 }
 
-std::filesystem::path BendersMainFactory::LogReportsName() const
-{
+std::filesystem::path BendersMainFactory::LogReportsName() const {
     return std::filesystem::path(options_.OUTPUTROOT) / "reportbenders.txt";
 }
 
-int BendersMainFactory::Run()
-{
-    if (solver_ == SOLVER::BENDERS)
-    {
+int BendersMainFactory::Run() {
+    if (solver_ == SOLVER::BENDERS) {
         return RunBenders();
-    }
-    else
-    {
+    } else {
         return RunExternalLoop();
     }
 }

--- a/src/cpp/benders/factories/BendersFactory.cpp
+++ b/src/cpp/benders/factories/BendersFactory.cpp
@@ -17,23 +17,34 @@
 #include "antares-xpansion/helpers/Timer.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
-BENDERSMETHOD DeduceBendersMethod(size_t coupling_map_size, size_t batch_size, bool outer_loop) {
-    if (batch_size == 0 || batch_size == coupling_map_size - 1) {
-        if (outer_loop) {
+BENDERSMETHOD DeduceBendersMethod(size_t coupling_map_size, size_t batch_size, bool outer_loop)
+{
+    if (batch_size == 0 || batch_size == coupling_map_size - 1)
+    {
+        if (outer_loop)
+        {
             return BENDERSMETHOD::BENDERS_OUTERLOOP;
-        } else {
+        }
+        else
+        {
             return BENDERSMETHOD::BENDERS;
         }
-    } else {
-        if (outer_loop) {
+    }
+    else
+    {
+        if (outer_loop)
+        {
             return BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP;
-        } else {
+        }
+        else
+        {
             return BENDERSMETHOD::BENDERS_BY_BATCH;
         }
     }
 }
 
-void BendersMainFactory::PrepareForExecution(bool outer_loop) {
+void BendersMainFactory::PrepareForExecution(bool outer_loop)
+{
     BendersBaseOptions benders_options(options_.get_benders_options());
     benders_options.EXTERNAL_LOOP_OPTIONS.DO_OUTER_LOOP = outer_loop;
 
@@ -48,12 +59,15 @@ void BendersMainFactory::PrepareForExecution(bool outer_loop) {
 
     criterion_input_holder_ = ProcessCriterionInput();
 
-    if (pworld_->rank() == 0) {
+    if (pworld_->rank() == 0)
+    {
         if (Benders::StartUp startup;
-            startup.StudyAlreadyAchievedCriterion(options_, writer_.get(), logger_)) {
+            startup.StudyAlreadyAchievedCriterion(options_, writer_.get(), logger_))
+        {
             return;
         }
-        if (!isCriterionListEmpty()) {
+        if (!isCriterionListEmpty())
+        {
             AddCriterionOutputs();
         }
     }
@@ -62,8 +76,10 @@ void BendersMainFactory::PrepareForExecution(bool outer_loop) {
     ConfigureSolverLog();
 }
 
-void BendersMainFactory::ConfigureSolverLog() {
-    if (options_.LOG_LEVEL > 1) {
+void BendersMainFactory::ConfigureSolverLog()
+{
+    if (options_.LOG_LEVEL > 1)
+    {
         auto solver_log = std::filesystem::path(options_.OUTPUTROOT)
                           / (std::string("solver_log_proc_") + std::to_string(pworld_->rank())
                              + ".txt");
@@ -72,50 +88,57 @@ void BendersMainFactory::ConfigureSolverLog() {
     }
 }
 
-void BendersMainFactory::ConfigureBenders(const BendersBaseOptions &benders_options,
-                                          const CouplingMap &coupling_map) {
-    switch (method_) {
-        case BENDERSMETHOD::BENDERS:
-            benders_ = std::make_shared<BendersMpi>(benders_options,
+void BendersMainFactory::ConfigureBenders(const BendersBaseOptions& benders_options,
+                                          const CouplingMap& coupling_map)
+{
+    switch (method_)
+    {
+    case BENDERSMETHOD::BENDERS:
+        benders_ = std::make_shared<BendersMpi>(benders_options,
+                                                logger_,
+                                                writer_,
+                                                *penv_,
+                                                *pworld_,
+                                                math_log_driver_);
+        break;
+    case BENDERSMETHOD::BENDERS_OUTERLOOP:
+        benders_ = std::make_shared<Outerloop::BendersMpiOuterLoop>(benders_options,
+                                                                    logger_,
+                                                                    writer_,
+                                                                    *penv_,
+                                                                    *pworld_,
+                                                                    math_log_driver_);
+        break;
+    case BENDERSMETHOD::BENDERS_BY_BATCH:
+    case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
+        benders_ = std::make_shared<BendersByBatch>(benders_options,
                                                     logger_,
                                                     writer_,
                                                     *penv_,
                                                     *pworld_,
                                                     math_log_driver_);
-            break;
-        case BENDERSMETHOD::BENDERS_OUTERLOOP:
-            benders_ = std::make_shared<Outerloop::BendersMpiOuterLoop>(benders_options,
-                                                                        logger_,
-                                                                        writer_,
-                                                                        *penv_,
-                                                                        *pworld_,
-                                                                        math_log_driver_);
-            break;
-        case BENDERSMETHOD::BENDERS_BY_BATCH:
-        case BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP:
-            benders_ = std::make_shared<BendersByBatch>(benders_options,
-                                                        logger_,
-                                                        writer_,
-                                                        *penv_,
-                                                        *pworld_,
-                                                        math_log_driver_);
-            break;
+        break;
     }
 
     benders_->set_input_map(coupling_map);
     benders_->setCriterionComputationInputs(
-        std::visit([](auto &&the_variant) { return static_cast<Benders::Criterion::CriterionInputData>(the_variant); },
-                   criterion_input_holder_));
+      std::visit([](auto&& the_variant)
+                 { return static_cast<Benders::Criterion::CriterionInputData>(the_variant); },
+                 criterion_input_holder_));
 }
 
-void BendersMainFactory::SetupLoggerAndOutputWriter(const BendersBaseOptions &benders_options) {
+void BendersMainFactory::SetupLoggerAndOutputWriter(const BendersBaseOptions& benders_options)
+{
     auto benders_log_console = benders_options.LOG_LEVEL > 0;
-    if (pworld_->rank() == 0) {
+    if (pworld_->rank() == 0)
+    {
         auto logger_factory = FileAndStdoutLoggerFactory(LogReportsName(), benders_log_console);
         logger_ = logger_factory.get_logger();
         math_log_driver_ = BuildMathLogger(benders_log_console);
         writer_ = build_json_writer(options_.JSON_FILE, options_.RESUME);
-    } else {
+    }
+    else
+    {
         logger_ = build_void_logger();
         writer_ = build_void_writer();
         math_log_driver_ = MathLoggerFactory::get_void_logger();
@@ -128,13 +151,15 @@ void BendersMainFactory::SetupLoggerAndOutputWriter(const BendersBaseOptions &be
     writer_->WriteProblemFormat(fmt::format("{}", options_.PROBLEMS_FORMAT));
 }
 
-bool BendersMainFactory::isCriterionListEmpty() const {
-    return std::visit([](auto &&the_variant) { return the_variant.Criteria().empty(); },
+bool BendersMainFactory::isCriterionListEmpty() const
+{
+    return std::visit([](auto&& the_variant) { return the_variant.Criteria().empty(); },
                       criterion_input_holder_);
 }
 
 std::shared_ptr<MathLoggerDriver> BendersMainFactory::BuildMathLogger(
-    bool benders_log_console) const {
+  bool benders_log_console) const
+{
     const std::filesystem::path output_root(options_.OUTPUTROOT);
     auto math_logs_file = output_root / "benders_solver.log";
 
@@ -145,37 +170,45 @@ std::shared_ptr<MathLoggerDriver> BendersMainFactory::BuildMathLogger(
     return math_log_driver;
 }
 
-void BendersMainFactory::AddCriterionOutputs() {
+void BendersMainFactory::AddCriterionOutputs()
+{
     const std::filesystem::path output_root(options_.OUTPUTROOT);
 
-    const auto &headers = std::visit([](auto &&the_variant) { return the_variant.PatternBodies(); },
+    const auto& headers = std::visit([](auto&& the_variant) { return the_variant.PatternBodies(); },
                                      criterion_input_holder_);
     math_log_driver_->add_logger(output_root / LOLD_FILE,
                                  headers,
                                  &CriteriaCurrentIterationData::criteria);
 
-    positive_unsupplied_file_ = std::visit([](auto &&the_variant) { return the_variant.PatternsPrefix() + ".txt"; },
+    positive_unsupplied_file_ = std::visit([](auto&& the_variant)
+                                           { return the_variant.PatternsPrefix() + ".txt"; },
                                            criterion_input_holder_);
     math_log_driver_->add_logger(output_root / positive_unsupplied_file_,
                                  headers,
                                  &CriteriaCurrentIterationData::patterns_values);
 }
 
-int BendersMainFactory::RunBenders() {
-    try {
+int BendersMainFactory::RunBenders()
+{
+    try
+    {
         PrepareForExecution(false);
-        if (benders_) {
+        if (benders_)
+        {
             StartMessage();
             benders_->launch();
             EndMessage(benders_->execution_time());
         }
-    } catch (std::exception &e) {
+    }
+    catch (std::exception& e)
+    {
         std::ostringstream msg;
         msg << "error: " << e.what() << std::endl;
         benders_loggers_.display_message(msg.str());
         mpi::environment::abort(1);
     }
-    catch (...) {
+    catch (...)
+    {
         std::ostringstream msg;
         msg << "Exception of unknown type!" << std::endl;
         benders_loggers_.display_message(msg.str());
@@ -184,7 +217,8 @@ int BendersMainFactory::RunBenders() {
     return 0;
 }
 
-void BendersMainFactory::StartMessage() {
+void BendersMainFactory::StartMessage()
+{
     std::ostringstream oss_l;
     oss_l << "Starting " << context_ << std::endl;
     options_.print(oss_l);
@@ -192,7 +226,8 @@ void BendersMainFactory::StartMessage() {
     benders_loggers_.display_message(oss_l.str());
 }
 
-void BendersMainFactory::EndMessage(const double execution_time) {
+void BendersMainFactory::EndMessage(const double execution_time)
+{
     std::ostringstream str;
     str << "Optimization results available in : " << options_.JSON_FILE << std::endl;
     benders_loggers_.display_message(str.str(), LogUtils::LOGLEVEL::INFO, context_);
@@ -204,44 +239,51 @@ void BendersMainFactory::EndMessage(const double execution_time) {
 }
 
 std::variant<Benders::Criterion::CriterionInputData,
-    Benders::Criterion::OuterLoopCriterionInputData>
-BendersMainFactory::ProcessCriterionInput() {
+             Benders::Criterion::OuterLoopCriterionInputData>
+BendersMainFactory::ProcessCriterionInput()
+{
     const auto fpath = std::filesystem::path(options_.INPUTROOT) / options_.OUTER_LOOP_OPTION_FILE;
     // if adequacy_criterion.yml is provided read it
     if ((method_ == BENDERSMETHOD::BENDERS_OUTERLOOP
          || method_ == BENDERSMETHOD::BENDERS_BY_BATCH_OUTERLOOP)
-        && std::filesystem::exists(fpath)) {
+        && std::filesystem::exists(fpath))
+    {
         return Benders::Criterion::CriterionInputFromYaml().Read(fpath);
     }
     // else compute criterion for all areas!
-    else {
+    else
+    {
         return BuildPatternsUsingAreaFile();
     }
 }
 
-Benders::Criterion::CriterionInputData BendersMainFactory::BuildPatternsUsingAreaFile() {
+Benders::Criterion::CriterionInputData BendersMainFactory::BuildPatternsUsingAreaFile()
+{
     std::set<std::string> unique_areas = ReadAreaFile();
     Benders::Criterion::CriterionInputData ret;
     ret.SetCriterionCountThreshold(1);
 
-    for (const auto &area: unique_areas) {
+    for (const auto& area: unique_areas)
+    {
         Benders::Criterion::CriterionSingleInputData
-                singleInputData(Benders::Criterion::PositiveUnsuppliedEnergy, area, 1);
+          singleInputData(Benders::Criterion::PositiveUnsuppliedEnergy, area, 1);
         ret.AddSingleData(singleInputData);
     }
 
     return ret;
 }
 
-std::set<std::string> BendersMainFactory::ReadAreaFile() {
+std::set<std::string> BendersMainFactory::ReadAreaFile()
+{
     std::set<std::string> unique_areas;
     const auto area_file = std::filesystem::path(options_.INPUTROOT) / options_.AREA_FILE;
     const auto area_file_data = AreaParser::ReadAreaFile(area_file);
-    if (const auto &msg = area_file_data.error_message; !msg.empty()) {
+    if (const auto& msg = area_file_data.error_message; !msg.empty())
+    {
         benders_loggers_.display_message(msg, LogUtils::LOGLEVEL::WARNING, context_);
         std::ostringstream ms;
         ms << " Consequently, " << LOLD_FILE
-                << " and other criterion based files will not be produced!";
+           << " and other criterion based files will not be produced!";
 
         benders_loggers_.display_message(ms.str(), LogUtils::LOGLEVEL::WARNING, context_);
         return {};
@@ -249,16 +291,18 @@ std::set<std::string> BendersMainFactory::ReadAreaFile() {
     return {area_file_data.areas.begin(), area_file_data.areas.end()};
 }
 
-int BendersMainFactory::RunExternalLoop() {
-    try {
+int BendersMainFactory::RunExternalLoop()
+{
+    try
+    {
         PrepareForExecution(true);
         double tau = 0.5;
-        const auto &outer_loop_inputs = std::get<Benders::Criterion::OuterLoopCriterionInputData>(
-            criterion_input_holder_);
+        const auto& outer_loop_inputs = std::get<Benders::Criterion::OuterLoopCriterionInputData>(
+          criterion_input_holder_);
         std::shared_ptr<Outerloop::IMasterUpdate> master_updater = std::make_shared<
-            Outerloop::MasterUpdateBase>(benders_, tau, outer_loop_inputs.StoppingThreshold());
+          Outerloop::MasterUpdateBase>(benders_, tau, outer_loop_inputs.StoppingThreshold());
         std::shared_ptr<Outerloop::ICutsManager>
-                cuts_manager = std::make_shared<Outerloop::CutsManagerRunTime>();
+          cuts_manager = std::make_shared<Outerloop::CutsManagerRunTime>();
 
         Outerloop::OuterLoopBenders ext_loop(outer_loop_inputs.Criteria(),
                                              master_updater,
@@ -268,13 +312,16 @@ int BendersMainFactory::RunExternalLoop() {
         StartMessage();
         ext_loop.Run();
         EndMessage(ext_loop.Runtime());
-    } catch (std::exception &e) {
+    }
+    catch (std::exception& e)
+    {
         std::ostringstream msg;
         msg << "error: " << e.what() << std::endl;
         benders_loggers_.display_message(msg.str());
         mpi::environment::abort(1);
     }
-    catch (...) {
+    catch (...)
+    {
         std::ostringstream msg;
         msg << "Exception of unknown type!" << std::endl;
         benders_loggers_.display_message(msg.str());
@@ -284,15 +331,18 @@ int BendersMainFactory::RunExternalLoop() {
 }
 
 BendersMainFactory::BendersMainFactory(int argc,
-                                       char **argv,
-                                       mpi::environment &env,
-                                       mpi::communicator &world,
-                                       const SOLVER &solver): argv_(argv),
-                                                              penv_(&env),
-                                                              pworld_(&world),
-                                                              solver_(solver) {
+                                       char** argv,
+                                       mpi::environment& env,
+                                       mpi::communicator& world,
+                                       const SOLVER& solver):
+    argv_(argv),
+    penv_(&env),
+    pworld_(&world),
+    solver_(solver)
+{
     // First check usage (options are given)
-    if (world.rank() == 0) {
+    if (world.rank() == 0)
+    {
         usage(argc);
     }
 
@@ -300,29 +350,37 @@ BendersMainFactory::BendersMainFactory(int argc,
 }
 
 BendersMainFactory::BendersMainFactory(int argc,
-                                       char **argv,
-                                       const std::filesystem::path &options_file,
-                                       mpi::environment &env,
-                                       mpi::communicator &world,
-                                       const SOLVER &solver): argv_(argv),
-                                                              penv_(&env),
-                                                              pworld_(&world),
-                                                              solver_(solver),
-                                                              options_(options_file) {
+                                       char** argv,
+                                       const std::filesystem::path& options_file,
+                                       mpi::environment& env,
+                                       mpi::communicator& world,
+                                       const SOLVER& solver):
+    argv_(argv),
+    penv_(&env),
+    pworld_(&world),
+    solver_(solver),
+    options_(options_file)
+{
     // First check usage (options are given)
-    if (world.rank() == 0) {
+    if (world.rank() == 0)
+    {
         usage(argc);
     }
 }
 
-std::filesystem::path BendersMainFactory::LogReportsName() const {
+std::filesystem::path BendersMainFactory::LogReportsName() const
+{
     return std::filesystem::path(options_.OUTPUTROOT) / "reportbenders.txt";
 }
 
-int BendersMainFactory::Run() {
-    if (solver_ == SOLVER::BENDERS) {
+int BendersMainFactory::Run()
+{
+    if (solver_ == SOLVER::BENDERS)
+    {
         return RunBenders();
-    } else {
+    }
+    else
+    {
         return RunExternalLoop();
     }
 }

--- a/src/cpp/benders/merge_mps/MergeMPS.cpp
+++ b/src/cpp/benders/merge_mps/MergeMPS.cpp
@@ -213,6 +213,11 @@ double MergeMPS::slave_weight(int nslaves, const std::string &name) const {
         const double weight(_options.SLAVE_WEIGHT_VALUE);
         return 1 / weight;
     } else {
+        if (_options.weights.find(name) == _options.weights.end()) {
+            _logger->display_message(
+                "No weight found for " + name + ". Problem will not contribute to objective function",
+                LogUtils::LOGLEVEL::WARNING, "MergeMPS");
+        }
         return _options.weights.find(name)->second;
     }
 }

--- a/src/cpp/benders/merge_mps/MergeMPS.cpp
+++ b/src/cpp/benders/merge_mps/MergeMPS.cpp
@@ -13,6 +13,9 @@ MergeMPS::MergeMPS(MergeMPSOptions options,
                                                                   _writer(std::move(writer)) {
 }
 
+/**
+ * Limitation: on windows may not support master problem with full path as name
+ */
 void MergeMPS::launch() {
     const auto inputRootDir = std::filesystem::path(_options.INPUTROOT);
     auto structure_path(inputRootDir / _options.STRUCTURE_FILE);

--- a/src/cpp/benders/merge_mps/MergeMPS.cpp
+++ b/src/cpp/benders/merge_mps/MergeMPS.cpp
@@ -1,24 +1,22 @@
 #include "antares-xpansion/benders/merge_mps/MergeMPS.h"
 
 #include <filesystem>
+#include <utility>
 
 #include "antares-xpansion/benders/benders_core/CouplingMapGenerator.h"
 #include "antares-xpansion/helpers/Timer.h"
 
-MergeMPS::MergeMPS(const MergeMPSOptions& options,
-                   Logger& logger,
-                   std::shared_ptr<Output::OutputWriter> writer):
-    _options(options),
-    _logger(logger),
-    _writer(writer)
-{
+MergeMPS::MergeMPS(MergeMPSOptions options,
+                   Logger logger,
+                   std::shared_ptr<Output::OutputWriter> writer): _options(std::move(options)),
+                                                                  _logger(std::move(logger)),
+                                                                  _writer(std::move(writer)) {
 }
 
-void MergeMPS::launch()
-{
+void MergeMPS::launch() {
     const auto inputRootDir = std::filesystem::path(_options.INPUTROOT);
     auto structure_path(inputRootDir / _options.STRUCTURE_FILE);
-    CouplingMap input = CouplingMapGenerator::BuildInput(structure_path, _logger, "Merge mps");
+    CouplingMap input = CouplingMapGenerator::BuildInput(structure_path, _logger.get(), "Merge mps");
 
     SolverFactory factory;
     std::string solver_to_use = (_options.SOLVER_NAME == "COIN") ? "CBC" : _options.SOLVER_NAME;
@@ -30,33 +28,27 @@ void MergeMPS::launch()
     int cntProblems_l(0);
 
     _logger->display_message("Merging problems...");
-    for (const auto& kvp: input)
-    {
+    for (const auto &kvp: input) {
         auto problem_name(inputRootDir / (kvp.first));
         SolverAbstract::Ptr solver_l = factory.create_solver(solver_to_use);
         solver_l->set_output_log_level(_options.LOG_LEVEL);
 
-        if (kvp.first != _options.MASTER_NAME)
-        {
+        if (kvp.first != _options.MASTER_NAME) {
             solver_l->read_prob_mps(problem_name);
             int mps_ncols(solver_l->get_ncols());
 
             DblVector o(mps_ncols);
             IntVector sequence(mps_ncols);
-            for (int i(0); i < mps_ncols; ++i)
-            {
+            for (int i(0); i < mps_ncols; ++i) {
                 sequence[i] = i;
             }
             solver_get_obj_func_coeffs(*solver_l, o, 0, mps_ncols - 1);
             const double weigth = slave_weight(nslaves, kvp.first);
-            for (auto& c: o)
-            {
+            for (auto &c: o) {
                 c *= weigth;
             }
             solver_l->chg_obj(sequence, o);
-        }
-        else
-        {
+        } else {
             solver_l->read_prob_mps(problem_name);
         }
         StandardLp lpData(*solver_l);
@@ -64,21 +56,17 @@ void MergeMPS::launch()
 
         lpData.append_in(mergedSolver_l, varPrefix_l);
 
-        for (const auto& x: kvp.second)
-        {
+        for (const auto &x: kvp.second) {
             int col_index = mergedSolver_l->get_col_index(varPrefix_l + x.first);
-            if (col_index == -1)
-            {
+            if (col_index == -1) {
                 std::cerr << LOGLOCATION << "missing variable " << x.first << " in " << kvp.first
-                          << " supposedly renamed to " << varPrefix_l + x.first << ".";
+                        << " supposedly renamed to " << varPrefix_l + x.first << ".";
                 mergedSolver_l->write_prob_lp(std::filesystem::path(_options.OUTPUTROOT)
                                               / "mergeError.lp");
                 mergedSolver_l->write_prob_mps(std::filesystem::path(_options.OUTPUTROOT)
                                                / ("mergeError" + MPS_SUFFIX));
                 std::exit(1);
-            }
-            else
-            {
+            } else {
                 x_mps_id[x.first][kvp.first] = col_index;
             }
         }
@@ -93,8 +81,7 @@ void MergeMPS::launch()
     int neles(0);
     size_t neles_reserve(0);
     size_t nrows_reserve(0);
-    for (const auto& kvp: x_mps_id)
-    {
+    for (const auto &kvp: x_mps_id) {
         neles_reserve += kvp.second.size() * (kvp.second.size() - 1);
         nrows_reserve += kvp.second.size() * (kvp.second.size() - 1) / 2;
     }
@@ -105,23 +92,18 @@ void MergeMPS::launch()
     mstart.reserve(nrows_reserve + 1);
 
     // adding coupling constraints
-    for (const auto& kvp: x_mps_id)
-    {
+    for (const auto &kvp: x_mps_id) {
         const std::string var_name(kvp.first);
         _logger->display_message(var_name);
         bool is_first(true);
         int id1(-1);
         std::string first_mps;
-        for (const auto& mps: kvp.second)
-        {
-            if (is_first)
-            {
+        for (const auto &mps: kvp.second) {
+            if (is_first) {
                 is_first = false;
                 first_mps = mps.first;
                 id1 = mps.second;
-            }
-            else
-            {
+            } else {
                 int id2 = mps.second;
                 mstart.push_back(neles);
                 cindex.push_back(id1);
@@ -153,12 +135,9 @@ void MergeMPS::launch()
     _logger->display_message("Solving...");
     Timer timer;
     int status_l = 0;
-    if (mergedSolver_l->get_n_integer_vars() > 0)
-    {
+    if (mergedSolver_l->get_n_integer_vars() > 0) {
         status_l = mergedSolver_l->solve_mip();
-    }
-    else
-    {
+    } else {
         status_l = mergedSolver_l->solve_lp();
     }
 
@@ -167,31 +146,24 @@ void MergeMPS::launch()
     Point x0;
     DblVector ptr(mergedSolver_l->get_ncols());
     double investCost_l(0);
-    if (mergedSolver_l->get_n_integer_vars() > 0)
-    {
+    if (mergedSolver_l->get_n_integer_vars() > 0) {
         mergedSolver_l->get_mip_sol(ptr.data());
-    }
-    else
-    {
+    } else {
         mergedSolver_l->get_lp_sol(ptr.data(), nullptr, nullptr);
     }
 
     std::vector<double> obj_coef(mergedSolver_l->get_ncols());
     mergedSolver_l->get_obj(obj_coef.data(), 0, mergedSolver_l->get_ncols() - 1);
-    for (const auto& pairNameId: input[_options.MASTER_NAME])
-    {
+    for (const auto &pairNameId: input[_options.MASTER_NAME]) {
         int varIndexInMerged_l = x_mps_id[pairNameId.first][_options.MASTER_NAME];
         x0[pairNameId.first] = ptr[varIndexInMerged_l];
         investCost_l += x0[pairNameId.first] * obj_coef[varIndexInMerged_l];
     }
 
     double overallCost_l;
-    if (mergedSolver_l->get_n_integer_vars() > 0)
-    {
+    if (mergedSolver_l->get_n_integer_vars() > 0) {
         overallCost_l = mergedSolver_l->get_mip_value();
-    }
-    else
-    {
+    } else {
         overallCost_l = mergedSolver_l->get_lp_value();
     }
     double operationalCost_l = overallCost_l - investCost_l;
@@ -208,8 +180,7 @@ void MergeMPS::launch()
     sol_infos.solution.overall_cost = overallCost_l;
 
     Output::CandidatesVec candidates_vec;
-    for (const auto& pairNameValue_l: x0)
-    {
+    for (const auto &pairNameValue_l: x0) {
         Output::CandidateData candidate_data;
         candidate_data.name = pairNameValue_l.first;
         candidate_data.invest = pairNameValue_l.second;
@@ -218,12 +189,9 @@ void MergeMPS::launch()
         candidates_vec.push_back(candidate_data);
     }
     sol_infos.solution.candidates = candidates_vec;
-    if (optimality_l)
-    {
+    if (optimality_l) {
         sol_infos.problem_status = "OPTIMAL";
-    }
-    else
-    {
+    } else {
         sol_infos.problem_status = "ERROR";
     }
 
@@ -238,19 +206,13 @@ void MergeMPS::launch()
  *
  *  \param name : slave name
  */
-double MergeMPS::slave_weight(int nslaves, const std::string& name) const
-{
-    if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_UNIFORM_CST_STR)
-    {
+double MergeMPS::slave_weight(int nslaves, const std::string &name) const {
+    if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_UNIFORM_CST_STR) {
         return 1 / static_cast<double>(nslaves);
-    }
-    else if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_CST_STR)
-    {
+    } else if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_CST_STR) {
         const double weight(_options.SLAVE_WEIGHT_VALUE);
         return 1 / weight;
-    }
-    else
-    {
+    } else {
         return _options.weights.find(name)->second;
     }
 }

--- a/src/cpp/benders/merge_mps/MergeMPS.cpp
+++ b/src/cpp/benders/merge_mps/MergeMPS.cpp
@@ -18,7 +18,8 @@ MergeMPS::MergeMPS(MergeMPSOptions options,
 /**
  * Limitation: on windows may not support master problem with full path as name
  */
-void MergeMPS::launch() {
+void MergeMPS::launch()
+{
     const auto inputRootDir = std::filesystem::path(_options.INPUTROOT);
     auto structure_path(inputRootDir / _options.STRUCTURE_FILE);
     CouplingMap input = CouplingMapGenerator::BuildInput(structure_path,

--- a/src/cpp/benders/merge_mps/MergeMPS.cpp
+++ b/src/cpp/benders/merge_mps/MergeMPS.cpp
@@ -8,15 +8,20 @@
 
 MergeMPS::MergeMPS(MergeMPSOptions options,
                    Logger logger,
-                   std::shared_ptr<Output::OutputWriter> writer): _options(std::move(options)),
-                                                                  _logger(std::move(logger)),
-                                                                  _writer(std::move(writer)) {
+                   std::shared_ptr<Output::OutputWriter> writer):
+    _options(std::move(options)),
+    _logger(std::move(logger)),
+    _writer(std::move(writer))
+{
 }
 
-void MergeMPS::launch() {
+void MergeMPS::launch()
+{
     const auto inputRootDir = std::filesystem::path(_options.INPUTROOT);
     auto structure_path(inputRootDir / _options.STRUCTURE_FILE);
-    CouplingMap input = CouplingMapGenerator::BuildInput(structure_path, _logger.get(), "Merge mps");
+    CouplingMap input = CouplingMapGenerator::BuildInput(structure_path,
+                                                         _logger.get(),
+                                                         "Merge mps");
 
     SolverFactory factory;
     std::string solver_to_use = (_options.SOLVER_NAME == "COIN") ? "CBC" : _options.SOLVER_NAME;
@@ -28,27 +33,33 @@ void MergeMPS::launch() {
     int cntProblems_l(0);
 
     _logger->display_message("Merging problems...");
-    for (const auto &kvp: input) {
+    for (const auto& kvp: input)
+    {
         auto problem_name(inputRootDir / (kvp.first));
         SolverAbstract::Ptr solver_l = factory.create_solver(solver_to_use);
         solver_l->set_output_log_level(_options.LOG_LEVEL);
 
-        if (kvp.first != _options.MASTER_NAME) {
+        if (kvp.first != _options.MASTER_NAME)
+        {
             solver_l->read_prob_mps(problem_name);
             int mps_ncols(solver_l->get_ncols());
 
             DblVector o(mps_ncols);
             IntVector sequence(mps_ncols);
-            for (int i(0); i < mps_ncols; ++i) {
+            for (int i(0); i < mps_ncols; ++i)
+            {
                 sequence[i] = i;
             }
             solver_get_obj_func_coeffs(*solver_l, o, 0, mps_ncols - 1);
             const double weigth = slave_weight(nslaves, kvp.first);
-            for (auto &c: o) {
+            for (auto& c: o)
+            {
                 c *= weigth;
             }
             solver_l->chg_obj(sequence, o);
-        } else {
+        }
+        else
+        {
             solver_l->read_prob_mps(problem_name);
         }
         StandardLp lpData(*solver_l);
@@ -56,17 +67,21 @@ void MergeMPS::launch() {
 
         lpData.append_in(mergedSolver_l, varPrefix_l);
 
-        for (const auto &x: kvp.second) {
+        for (const auto& x: kvp.second)
+        {
             int col_index = mergedSolver_l->get_col_index(varPrefix_l + x.first);
-            if (col_index == -1) {
+            if (col_index == -1)
+            {
                 std::cerr << LOGLOCATION << "missing variable " << x.first << " in " << kvp.first
-                        << " supposedly renamed to " << varPrefix_l + x.first << ".";
+                          << " supposedly renamed to " << varPrefix_l + x.first << ".";
                 mergedSolver_l->write_prob_lp(std::filesystem::path(_options.OUTPUTROOT)
                                               / "mergeError.lp");
                 mergedSolver_l->write_prob_mps(std::filesystem::path(_options.OUTPUTROOT)
                                                / ("mergeError" + MPS_SUFFIX));
                 std::exit(1);
-            } else {
+            }
+            else
+            {
                 x_mps_id[x.first][kvp.first] = col_index;
             }
         }
@@ -81,7 +96,8 @@ void MergeMPS::launch() {
     int neles(0);
     size_t neles_reserve(0);
     size_t nrows_reserve(0);
-    for (const auto &kvp: x_mps_id) {
+    for (const auto& kvp: x_mps_id)
+    {
         neles_reserve += kvp.second.size() * (kvp.second.size() - 1);
         nrows_reserve += kvp.second.size() * (kvp.second.size() - 1) / 2;
     }
@@ -92,18 +108,23 @@ void MergeMPS::launch() {
     mstart.reserve(nrows_reserve + 1);
 
     // adding coupling constraints
-    for (const auto &kvp: x_mps_id) {
+    for (const auto& kvp: x_mps_id)
+    {
         const std::string var_name(kvp.first);
         _logger->display_message(var_name);
         bool is_first(true);
         int id1(-1);
         std::string first_mps;
-        for (const auto &mps: kvp.second) {
-            if (is_first) {
+        for (const auto& mps: kvp.second)
+        {
+            if (is_first)
+            {
                 is_first = false;
                 first_mps = mps.first;
                 id1 = mps.second;
-            } else {
+            }
+            else
+            {
                 int id2 = mps.second;
                 mstart.push_back(neles);
                 cindex.push_back(id1);
@@ -135,9 +156,12 @@ void MergeMPS::launch() {
     _logger->display_message("Solving...");
     Timer timer;
     int status_l = 0;
-    if (mergedSolver_l->get_n_integer_vars() > 0) {
+    if (mergedSolver_l->get_n_integer_vars() > 0)
+    {
         status_l = mergedSolver_l->solve_mip();
-    } else {
+    }
+    else
+    {
         status_l = mergedSolver_l->solve_lp();
     }
 
@@ -146,24 +170,31 @@ void MergeMPS::launch() {
     Point x0;
     DblVector ptr(mergedSolver_l->get_ncols());
     double investCost_l(0);
-    if (mergedSolver_l->get_n_integer_vars() > 0) {
+    if (mergedSolver_l->get_n_integer_vars() > 0)
+    {
         mergedSolver_l->get_mip_sol(ptr.data());
-    } else {
+    }
+    else
+    {
         mergedSolver_l->get_lp_sol(ptr.data(), nullptr, nullptr);
     }
 
     std::vector<double> obj_coef(mergedSolver_l->get_ncols());
     mergedSolver_l->get_obj(obj_coef.data(), 0, mergedSolver_l->get_ncols() - 1);
-    for (const auto &pairNameId: input[_options.MASTER_NAME]) {
+    for (const auto& pairNameId: input[_options.MASTER_NAME])
+    {
         int varIndexInMerged_l = x_mps_id[pairNameId.first][_options.MASTER_NAME];
         x0[pairNameId.first] = ptr[varIndexInMerged_l];
         investCost_l += x0[pairNameId.first] * obj_coef[varIndexInMerged_l];
     }
 
     double overallCost_l;
-    if (mergedSolver_l->get_n_integer_vars() > 0) {
+    if (mergedSolver_l->get_n_integer_vars() > 0)
+    {
         overallCost_l = mergedSolver_l->get_mip_value();
-    } else {
+    }
+    else
+    {
         overallCost_l = mergedSolver_l->get_lp_value();
     }
     double operationalCost_l = overallCost_l - investCost_l;
@@ -180,7 +211,8 @@ void MergeMPS::launch() {
     sol_infos.solution.overall_cost = overallCost_l;
 
     Output::CandidatesVec candidates_vec;
-    for (const auto &pairNameValue_l: x0) {
+    for (const auto& pairNameValue_l: x0)
+    {
         Output::CandidateData candidate_data;
         candidate_data.name = pairNameValue_l.first;
         candidate_data.invest = pairNameValue_l.second;
@@ -189,9 +221,12 @@ void MergeMPS::launch() {
         candidates_vec.push_back(candidate_data);
     }
     sol_infos.solution.candidates = candidates_vec;
-    if (optimality_l) {
+    if (optimality_l)
+    {
         sol_infos.problem_status = "OPTIMAL";
-    } else {
+    }
+    else
+    {
         sol_infos.problem_status = "ERROR";
     }
 
@@ -206,17 +241,25 @@ void MergeMPS::launch() {
  *
  *  \param name : slave name
  */
-double MergeMPS::slave_weight(int nslaves, const std::string &name) const {
-    if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_UNIFORM_CST_STR) {
+double MergeMPS::slave_weight(int nslaves, const std::string& name) const
+{
+    if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_UNIFORM_CST_STR)
+    {
         return 1 / static_cast<double>(nslaves);
-    } else if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_CST_STR) {
+    }
+    else if (_options.SLAVE_WEIGHT == SUBPROBLEM_WEIGHT_CST_STR)
+    {
         const double weight(_options.SLAVE_WEIGHT_VALUE);
         return 1 / weight;
-    } else {
-        if (_options.weights.find(name) == _options.weights.end()) {
-            _logger->display_message(
-                "No weight found for " + name + ". Problem will not contribute to objective function",
-                LogUtils::LOGLEVEL::WARNING, "MergeMPS");
+    }
+    else
+    {
+        if (_options.weights.find(name) == _options.weights.end())
+        {
+            _logger->display_message("No weight found for " + name
+                                       + ". Problem will not contribute to objective function",
+                                     LogUtils::LOGLEVEL::WARNING,
+                                     "MergeMPS");
         }
         return _options.weights.find(name)->second;
     }

--- a/src/cpp/benders/merge_mps/include/antares-xpansion/benders/merge_mps/MergeMPS.h
+++ b/src/cpp/benders/merge_mps/include/antares-xpansion/benders/merge_mps/MergeMPS.h
@@ -2,11 +2,9 @@
 
 #include "antares-xpansion/benders/benders_core/common.h"
 #include "antares-xpansion/benders/factories/WriterFactories.h"
-#include "antares-xpansion/benders/logger/User.h"
 #include "antares-xpansion/helpers/solver_utils.h"
 
-enum Attribute
-{
+enum Attribute {
     INT_VALUE,
     INT_VECTOR,
     CHAR_VECTOR,
@@ -14,30 +12,26 @@ enum Attribute
     MAX_ATTRIBUTE
 };
 
-enum IntAttribute
-{
+enum IntAttribute {
     NROWS,
     NCOLS,
     NELES,
     MAX_INT_ATTRIBUTE
 };
 
-enum IntVectorAttribute
-{
+enum IntVectorAttribute {
     MSTART,
     MINDEX,
     MAX_INT_VECTOR_ATTRIBUTE,
 };
 
-enum CharVectorAttribute
-{
+enum CharVectorAttribute {
     ROWTYPE,
     COLTYPE,
     MAX_CHAR_VECTOR_ATTRIBUTE
 };
 
-enum DblVectorAttribute
-{
+enum DblVectorAttribute {
     MVALUE,
     RHS,
     RANGE,
@@ -47,12 +41,10 @@ enum DblVectorAttribute
     MAX_DBL_VECTOR_ATTRIBUTE
 };
 
-typedef std::
-  tuple<IntVector, std::vector<IntVector>, std::vector<CharVector>, std::vector<DblVector>>
-    raw_standard_lp_data;
+using raw_standard_lp_data = std::tuple<IntVector, std::vector<IntVector>, std::vector<CharVector>, std::vector<
+    DblVector> >;
 
-class StandardLp
-{
+class StandardLp {
 private:
     std::vector<std::string> _colNames;
 
@@ -62,16 +54,14 @@ public:
     static size_t appendCNT;
 
 public:
-    void init()
-    {
+    void init() {
         initialise_int_values_with_zeros();
         initialise_int_vectors();
         initialise_char_vectors();
         initialise_dbl_vectors();
     }
 
-    explicit StandardLp(SolverAbstract& solver_p)
-    {
+    explicit StandardLp(SolverAbstract &solver_p) {
         init();
 
         int ncols = solver_p.get_ncols();
@@ -145,33 +135,31 @@ public:
                                    std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS] - 1);
 
         assert(std::get<Attribute::INT_VECTOR>(_data)[IntVectorAttribute::MSTART].size()
-               == 1 + std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
+            == 1 + std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
 
         assert(std::get<Attribute::CHAR_VECTOR>(_data)[CharVectorAttribute::COLTYPE].size()
-               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
         assert(std::get<Attribute::CHAR_VECTOR>(_data)[CharVectorAttribute::ROWTYPE].size()
-               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
+            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
 
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::MVALUE].size()
-               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NELES]);
+            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NELES]);
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::RHS].size()
-               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
+            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
 
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::OBJ].size()
-               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::LB].size()
-               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::UB].size()
-               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
     }
 
-    int append_in(SolverAbstract::Ptr containingSolver_p, const std::string& prefix_p = "") const
-    {
+    int append_in(SolverAbstract::Ptr containingSolver_p, const std::string &prefix_p = "") const {
         // simply increment the columns indices
         IntVector newmindex(std::get<Attribute::INT_VECTOR>(_data)[IntVectorAttribute::MINDEX]);
         int nbExistingCols(containingSolver_p->get_ncols());
-        for (auto& i: newmindex)
-        {
+        for (auto &i: newmindex) {
             i += nbExistingCols;
         }
 
@@ -182,8 +170,7 @@ public:
         std::transform(_colNames.begin(),
                        _colNames.end(),
                        newNames.begin(),
-                       [&prefix_l](std::string varName_p) -> std::string
-                       { return prefix_l + varName_p; });
+                       [&prefix_l](std::string varName_p) -> std::string { return prefix_l + varName_p; });
 
         std::vector<int> mstart(std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS], 0);
         solver_addcols(*containingSolver_p,
@@ -210,38 +197,35 @@ public:
     }
 
 private:
-    void initialise_int_values_with_zeros()
-    {
+    void initialise_int_values_with_zeros() {
         std::get<Attribute::INT_VALUE>(_data).assign(IntAttribute::MAX_INT_ATTRIBUTE, 0);
     }
 
-    void initialise_int_vectors()
-    {
+    void initialise_int_vectors() {
         std::get<Attribute::INT_VECTOR>(_data).assign(IntVectorAttribute::MAX_INT_VECTOR_ATTRIBUTE,
                                                       IntVector());
     }
 
-    void initialise_char_vectors()
-    {
+    void initialise_char_vectors() {
         std::get<Attribute::CHAR_VECTOR>(_data)
-          .assign(CharVectorAttribute::MAX_CHAR_VECTOR_ATTRIBUTE, CharVector());
+                .assign(CharVectorAttribute::MAX_CHAR_VECTOR_ATTRIBUTE, CharVector());
     }
 
-    void initialise_dbl_vectors()
-    {
+    void initialise_dbl_vectors() {
         std::get<Attribute::DBL_VECTOR>(_data).assign(DblVectorAttribute::MAX_DBL_VECTOR_ATTRIBUTE,
                                                       DblVector());
     }
 };
 
-class MergeMPS
-{
+class MergeMPS {
 public:
-    MergeMPS(const MergeMPSOptions& options,
-             Logger& logger,
+    MergeMPS(MergeMPSOptions options,
+             Logger logger,
              std::shared_ptr<Output::OutputWriter> writer);
+
     void launch();
-    double slave_weight(int nslaves, const std::string& name) const;
+
+    double slave_weight(int nslaves, const std::string &name) const;
 
     MergeMPSOptions _options;
     Logger _logger;

--- a/src/cpp/benders/merge_mps/include/antares-xpansion/benders/merge_mps/MergeMPS.h
+++ b/src/cpp/benders/merge_mps/include/antares-xpansion/benders/merge_mps/MergeMPS.h
@@ -4,7 +4,8 @@
 #include "antares-xpansion/benders/factories/WriterFactories.h"
 #include "antares-xpansion/helpers/solver_utils.h"
 
-enum Attribute {
+enum Attribute
+{
     INT_VALUE,
     INT_VECTOR,
     CHAR_VECTOR,
@@ -12,26 +13,30 @@ enum Attribute {
     MAX_ATTRIBUTE
 };
 
-enum IntAttribute {
+enum IntAttribute
+{
     NROWS,
     NCOLS,
     NELES,
     MAX_INT_ATTRIBUTE
 };
 
-enum IntVectorAttribute {
+enum IntVectorAttribute
+{
     MSTART,
     MINDEX,
     MAX_INT_VECTOR_ATTRIBUTE,
 };
 
-enum CharVectorAttribute {
+enum CharVectorAttribute
+{
     ROWTYPE,
     COLTYPE,
     MAX_CHAR_VECTOR_ATTRIBUTE
 };
 
-enum DblVectorAttribute {
+enum DblVectorAttribute
+{
     MVALUE,
     RHS,
     RANGE,
@@ -41,10 +46,11 @@ enum DblVectorAttribute {
     MAX_DBL_VECTOR_ATTRIBUTE
 };
 
-using raw_standard_lp_data = std::tuple<IntVector, std::vector<IntVector>, std::vector<CharVector>, std::vector<
-    DblVector> >;
+using raw_standard_lp_data = std::
+  tuple<IntVector, std::vector<IntVector>, std::vector<CharVector>, std::vector<DblVector>>;
 
-class StandardLp {
+class StandardLp
+{
 private:
     std::vector<std::string> _colNames;
 
@@ -54,14 +60,16 @@ public:
     static size_t appendCNT;
 
 public:
-    void init() {
+    void init()
+    {
         initialise_int_values_with_zeros();
         initialise_int_vectors();
         initialise_char_vectors();
         initialise_dbl_vectors();
     }
 
-    explicit StandardLp(SolverAbstract &solver_p) {
+    explicit StandardLp(SolverAbstract& solver_p)
+    {
         init();
 
         int ncols = solver_p.get_ncols();
@@ -135,31 +143,33 @@ public:
                                    std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS] - 1);
 
         assert(std::get<Attribute::INT_VECTOR>(_data)[IntVectorAttribute::MSTART].size()
-            == 1 + std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
+               == 1 + std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
 
         assert(std::get<Attribute::CHAR_VECTOR>(_data)[CharVectorAttribute::COLTYPE].size()
-            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
         assert(std::get<Attribute::CHAR_VECTOR>(_data)[CharVectorAttribute::ROWTYPE].size()
-            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
+               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
 
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::MVALUE].size()
-            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NELES]);
+               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NELES]);
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::RHS].size()
-            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
+               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NROWS]);
 
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::OBJ].size()
-            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::LB].size()
-            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
         assert(std::get<Attribute::DBL_VECTOR>(_data)[DblVectorAttribute::UB].size()
-            == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
+               == std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS]);
     }
 
-    int append_in(SolverAbstract::Ptr containingSolver_p, const std::string &prefix_p = "") const {
+    int append_in(SolverAbstract::Ptr containingSolver_p, const std::string& prefix_p = "") const
+    {
         // simply increment the columns indices
         IntVector newmindex(std::get<Attribute::INT_VECTOR>(_data)[IntVectorAttribute::MINDEX]);
         int nbExistingCols(containingSolver_p->get_ncols());
-        for (auto &i: newmindex) {
+        for (auto& i: newmindex)
+        {
             i += nbExistingCols;
         }
 
@@ -170,7 +180,8 @@ public:
         std::transform(_colNames.begin(),
                        _colNames.end(),
                        newNames.begin(),
-                       [&prefix_l](std::string varName_p) -> std::string { return prefix_l + varName_p; });
+                       [&prefix_l](std::string varName_p) -> std::string
+                       { return prefix_l + varName_p; });
 
         std::vector<int> mstart(std::get<Attribute::INT_VALUE>(_data)[IntAttribute::NCOLS], 0);
         solver_addcols(*containingSolver_p,
@@ -197,35 +208,38 @@ public:
     }
 
 private:
-    void initialise_int_values_with_zeros() {
+    void initialise_int_values_with_zeros()
+    {
         std::get<Attribute::INT_VALUE>(_data).assign(IntAttribute::MAX_INT_ATTRIBUTE, 0);
     }
 
-    void initialise_int_vectors() {
+    void initialise_int_vectors()
+    {
         std::get<Attribute::INT_VECTOR>(_data).assign(IntVectorAttribute::MAX_INT_VECTOR_ATTRIBUTE,
                                                       IntVector());
     }
 
-    void initialise_char_vectors() {
+    void initialise_char_vectors()
+    {
         std::get<Attribute::CHAR_VECTOR>(_data)
-                .assign(CharVectorAttribute::MAX_CHAR_VECTOR_ATTRIBUTE, CharVector());
+          .assign(CharVectorAttribute::MAX_CHAR_VECTOR_ATTRIBUTE, CharVector());
     }
 
-    void initialise_dbl_vectors() {
+    void initialise_dbl_vectors()
+    {
         std::get<Attribute::DBL_VECTOR>(_data).assign(DblVectorAttribute::MAX_DBL_VECTOR_ATTRIBUTE,
                                                       DblVector());
     }
 };
 
-class MergeMPS {
+class MergeMPS
+{
 public:
-    MergeMPS(MergeMPSOptions options,
-             Logger logger,
-             std::shared_ptr<Output::OutputWriter> writer);
+    MergeMPS(MergeMPSOptions options, Logger logger, std::shared_ptr<Output::OutputWriter> writer);
 
     void launch();
 
-    double slave_weight(int nslaves, const std::string &name) const;
+    double slave_weight(int nslaves, const std::string& name) const;
 
     MergeMPSOptions _options;
     Logger _logger;

--- a/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
+++ b/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
@@ -301,7 +301,7 @@ public:
         return solver_abstract_->get_splex_num_of_ite_last();
     }
 
-    void get_lp_sol(double* primals, double* duals, double* reduced_costs) override
+    void get_lp_sol(double* primals, double* duals, double* reduced_costs) const override
     {
         solver_abstract_->get_lp_sol(primals, duals, reduced_costs);
     }

--- a/src/cpp/multisolver_interface/CMakeLists.txt
+++ b/src/cpp/multisolver_interface/CMakeLists.txt
@@ -14,6 +14,7 @@
 # Conditionnal settings of solver source files
 # ---------------------------------------------------------------------------
 list(APPEND Solver_sources
+        ${CMAKE_CURRENT_LIST_DIR}/SolverAbstract.cpp
         ${CMAKE_CURRENT_LIST_DIR}/SolverFactory.cpp
         ${CMAKE_CURRENT_LIST_DIR}/SolverConfig.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/multisolver_interface/Solver.h

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -1,0 +1,151 @@
+#include "antares-xpansion/multisolver_interface/SolverAbstract.h"
+
+namespace {
+    bool verifyProblemDimensions(const SolverAbstract *merged, const SolverAbstract *master) {
+        if (merged->get_ncols() != master->get_ncols())
+            return false;
+        if (merged->get_nrows() != master->get_nrows())
+            return false;
+        if (merged->get_nelems() != master->get_nelems())
+            return false;
+        return true;
+    }
+
+    bool verifyObjectiveFunction(const SolverAbstract *merged, const SolverAbstract *master) {
+        std::vector<double> obj_merged(merged->get_ncols());
+        std::vector<double> obj_master(master->get_ncols());
+        merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
+        master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
+
+        for (int i = 0; i < merged->get_ncols(); ++i) {
+            if (obj_merged[i] != obj_master[i])
+                return false;
+        }
+        return true;
+    }
+
+    bool verifySolution(const SolverAbstract *merged, const SolverAbstract *master) {
+        std::vector<double> sol_merged(merged->get_ncols());
+        std::vector<double> sol_master(master->get_ncols());
+        merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
+        master->get_lp_sol(sol_master.data(), nullptr, nullptr);
+
+        for (int i = 0; i < merged->get_ncols(); ++i) {
+            if (sol_merged[i] != sol_master[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template<typename T>
+
+    bool IsEqual(const T &lhs, const T &rhs, const T &epsilon = std::numeric_limits<T>::epsilon()) {
+        if constexpr (std::is_floating_point_v<T>) {
+            return std::abs(lhs - rhs) <= epsilon * std::max(std::abs(lhs), std::abs(rhs));
+        } else return (lhs == rhs);
+    }
+
+    bool verifyConstraints(const SolverAbstract *merged, const SolverAbstract *master) {
+        std::vector<int> mstart(merged->get_ncols() + 1);
+        std::vector<int> cindex(merged->get_nelems());
+        std::vector<double> matval_merged(merged->get_nelems());
+        int n_merged = 0;
+        merged->get_rows(mstart.data(), cindex.data(), matval_merged.data(), merged->get_nelems(), &n_merged, 0,
+                         merged->get_nrows() - 1);
+
+        std::vector<int> mstart_master(master->get_ncols() + 1);
+        std::vector<int> cindex_master(master->get_nelems());
+        std::vector<double> matval_master(master->get_nelems());
+        int n_master = 0;
+        master->get_rows(mstart_master.data(), cindex_master.data(), matval_master.data(), master->get_nelems(),
+                         &n_master,
+                         0,
+                         master->get_nrows() - 1);
+
+        if (n_merged != n_master) {
+            return false;
+        }
+        for (int i = 0; i < n_merged; ++i) {
+            if (mstart[i] != mstart_master[i]) {
+                return false;
+            }
+            if (cindex[i] != cindex_master[i]) {
+                return false;
+            }
+            if (!IsEqual(matval_merged[i], matval_master[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool verifyRHS(const SolverAbstract *merged, const SolverAbstract *master) {
+        std::vector<double> rhs_merged(merged->get_nrows());
+        std::vector<double> rhs_master(master->get_nrows());
+        merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
+        master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
+
+        for (int i = 0; i < merged->get_nrows(); ++i) {
+            if (!IsEqual(rhs_merged[i], rhs_master[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool verifyRowTypes(const SolverAbstract *merged, const SolverAbstract *master) {
+        std::vector<char> sense_merged(merged->get_nrows());
+        std::vector<char> sense_master(master->get_nrows());
+        merged->get_row_type(sense_merged.data(), 0, merged->get_nrows() - 1);
+        master->get_row_type(sense_master.data(), 0, master->get_nrows() - 1);
+
+        for (int i = 0; i < merged->get_nrows(); ++i) {
+            if (sense_merged[i] != sense_master[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool verifyBounds(const SolverAbstract *merged, const SolverAbstract *master) {
+        std::vector<double> lb_merged(merged->get_ncols());
+        std::vector<double> lb_master(master->get_ncols());
+        merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
+        master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
+
+        for (int i = 0; i < merged->get_ncols(); ++i) {
+            if (!IsEqual(lb_merged[i], lb_master[i])) {
+                return false;
+            }
+        }
+
+
+        std::vector<double> ub_merged(merged->get_ncols());
+        std::vector<double> ub_master(master->get_ncols());
+        merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
+        master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
+
+        for (int i = 0; i < merged->get_ncols(); ++i) {
+            if (!IsEqual(ub_merged[i], ub_master[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+bool SolverAbstract::operator==(const SolverAbstract &other) const {
+    if (this == &other) {
+        return true;
+    }
+    bool is_equal = true;
+    is_equal = is_equal && verifyProblemDimensions(this, &other);
+    is_equal = is_equal && verifyObjectiveFunction(this, &other);
+    is_equal = is_equal && verifySolution(this, &other);
+    is_equal = is_equal && verifyConstraints(this, &other);
+    is_equal = is_equal && verifyRHS(this, &other);
+    is_equal = is_equal && verifyRowTypes(this, &other);
+    is_equal = is_equal && verifyBounds(this, &other);
+    return is_equal;
+}

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -1,113 +1,133 @@
 #include "antares-xpansion/multisolver_interface/SolverAbstract.h"
 
-namespace {
-    bool verifyProblemDimensions(const SolverAbstract *merged, const SolverAbstract *master) {
-        return (merged->get_ncols() == master->get_ncols())
-               && (merged->get_nrows() == master->get_nrows())
-               && (merged->get_nelems() == master->get_nelems());
+namespace
+{
+bool verifyProblemDimensions(const SolverAbstract* merged, const SolverAbstract* master)
+{
+    return (merged->get_ncols() == master->get_ncols())
+           && (merged->get_nrows() == master->get_nrows())
+           && (merged->get_nelems() == master->get_nelems());
+}
+
+bool verifyObjectiveFunction(const SolverAbstract* merged, const SolverAbstract* master)
+{
+    std::vector<double> obj_merged(merged->get_ncols());
+    std::vector<double> obj_master(master->get_ncols());
+    merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
+
+    return std::ranges::equal(obj_merged, obj_master);
+}
+
+bool verifySolution(const SolverAbstract* merged, const SolverAbstract* master)
+{
+    std::vector<double> sol_merged(merged->get_ncols());
+    std::vector<double> sol_master(master->get_ncols());
+    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
+    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
+
+    return std::ranges::equal(sol_merged, sol_master);
+}
+
+template<typename T>
+
+bool IsEqual(const T& lhs, const T& rhs, const T& epsilon = std::numeric_limits<T>::epsilon())
+{
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        return std::abs(lhs - rhs) <= epsilon * std::max(std::abs(lhs), std::abs(rhs));
     }
-
-    bool verifyObjectiveFunction(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<double> obj_merged(merged->get_ncols());
-        std::vector<double> obj_master(master->get_ncols());
-        merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
-        master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
-
-        return std::ranges::equal(obj_merged, obj_master);
-    }
-
-    bool verifySolution(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<double> sol_merged(merged->get_ncols());
-        std::vector<double> sol_master(master->get_ncols());
-        merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
-        master->get_lp_sol(sol_master.data(), nullptr, nullptr);
-
-        return std::ranges::equal(sol_merged, sol_master);
-    }
-
-    template<typename T>
-
-    bool IsEqual(const T &lhs, const T &rhs, const T &epsilon = std::numeric_limits<T>::epsilon()) {
-        if constexpr (std::is_floating_point_v<T>) {
-            return std::abs(lhs - rhs) <= epsilon * std::max(std::abs(lhs), std::abs(rhs));
-        } else return (lhs == rhs);
-    }
-
-    bool verifyConstraints(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<int> mstart(merged->get_nrows() + 1);
-        std::vector<int> cindex(merged->get_nelems());
-        std::vector<double> matval_merged(merged->get_nelems());
-        int n_merged = 0;
-        merged->get_rows(mstart.data(), cindex.data(), matval_merged.data(), merged->get_nelems(), &n_merged, 0,
-                         merged->get_nrows() - 1);
-
-        std::vector<int> mstart_master(master->get_nrows() + 1);
-        std::vector<int> cindex_master(master->get_nelems());
-        std::vector<double> matval_master(master->get_nelems());
-        int n_master = 0;
-        master->get_rows(mstart_master.data(), cindex_master.data(), matval_master.data(), master->get_nelems(),
-                         &n_master,
-                         0,
-                         master->get_nrows() - 1);
-
-        if (n_merged != n_master) {
-            return false;
-        }
-        return std::ranges::equal(mstart, mstart_master)
-               && std::ranges::equal(cindex, cindex_master)
-               && std::ranges::equal(matval_merged, matval_master, [](auto l, auto r) {
-                   return IsEqual(l, r);
-               });
-    }
-
-    bool verifyRHS(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<double> rhs_merged(merged->get_nrows());
-        std::vector<double> rhs_master(master->get_nrows());
-        merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
-        master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
-
-        return std::ranges::equal(rhs_merged, rhs_master, [](auto l, auto r) {
-            return IsEqual(l, r);
-        });
-    }
-
-    bool verifyRowTypes(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<char> order_merged(merged->get_nrows());
-        std::vector<char> order_master(master->get_nrows());
-        merged->get_row_type(order_merged.data(), 0, merged->get_nrows() - 1);
-        master->get_row_type(order_master.data(), 0, master->get_nrows() - 1);
-
-        return std::ranges::equal(order_merged, order_master);
-    }
-
-    bool verifyBounds(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<double> lb_merged(merged->get_ncols());
-        std::vector<double> lb_master(master->get_ncols());
-        merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
-        master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
-
-        if (!std::ranges::equal(lb_merged, lb_master, [](auto l, auto r) {
-            return IsEqual(l, r);
-        })) {
-            return false;
-        }
-
-        std::vector<double> ub_merged(merged->get_ncols());
-        std::vector<double> ub_master(master->get_ncols());
-        merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
-        master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
-
-        if (!std::ranges::equal(ub_merged, ub_master, [](auto l, auto r) {
-            return IsEqual(l, r);
-        })) {
-            return false;
-        }
-        return true;
+    else
+    {
+        return (lhs == rhs);
     }
 }
 
-bool SolverAbstract::operator==(const SolverAbstract &other) const {
-    if (this == &other) {
+bool verifyConstraints(const SolverAbstract* merged, const SolverAbstract* master)
+{
+    std::vector<int> mstart(merged->get_nrows() + 1);
+    std::vector<int> cindex(merged->get_nelems());
+    std::vector<double> matval_merged(merged->get_nelems());
+    int n_merged = 0;
+    merged->get_rows(mstart.data(),
+                     cindex.data(),
+                     matval_merged.data(),
+                     merged->get_nelems(),
+                     &n_merged,
+                     0,
+                     merged->get_nrows() - 1);
+
+    std::vector<int> mstart_master(master->get_nrows() + 1);
+    std::vector<int> cindex_master(master->get_nelems());
+    std::vector<double> matval_master(master->get_nelems());
+    int n_master = 0;
+    master->get_rows(mstart_master.data(),
+                     cindex_master.data(),
+                     matval_master.data(),
+                     master->get_nelems(),
+                     &n_master,
+                     0,
+                     master->get_nrows() - 1);
+
+    if (n_merged != n_master)
+    {
+        return false;
+    }
+    return std::ranges::equal(mstart, mstart_master) && std::ranges::equal(cindex, cindex_master)
+           && std::ranges::equal(matval_merged,
+                                 matval_master,
+                                 [](auto l, auto r) { return IsEqual(l, r); });
+}
+
+bool verifyRHS(const SolverAbstract* merged, const SolverAbstract* master)
+{
+    std::vector<double> rhs_merged(merged->get_nrows());
+    std::vector<double> rhs_master(master->get_nrows());
+    merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
+
+    return std::ranges::equal(rhs_merged, rhs_master, [](auto l, auto r) { return IsEqual(l, r); });
+}
+
+bool verifyRowTypes(const SolverAbstract* merged, const SolverAbstract* master)
+{
+    std::vector<char> order_merged(merged->get_nrows());
+    std::vector<char> order_master(master->get_nrows());
+    merged->get_row_type(order_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_row_type(order_master.data(), 0, master->get_nrows() - 1);
+
+    return std::ranges::equal(order_merged, order_master);
+}
+
+bool verifyBounds(const SolverAbstract* merged, const SolverAbstract* master)
+{
+    std::vector<double> lb_merged(merged->get_ncols());
+    std::vector<double> lb_master(master->get_ncols());
+    merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
+
+    if (!std::ranges::equal(lb_merged, lb_master, [](auto l, auto r) { return IsEqual(l, r); }))
+    {
+        return false;
+    }
+
+    std::vector<double> ub_merged(merged->get_ncols());
+    std::vector<double> ub_master(master->get_ncols());
+    merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
+
+    if (!std::ranges::equal(ub_merged, ub_master, [](auto l, auto r) { return IsEqual(l, r); }))
+    {
+        return false;
+    }
+    return true;
+}
+} // namespace
+
+bool SolverAbstract::operator==(const SolverAbstract& other) const
+{
+    if (this == &other)
+    {
         return true;
     }
     bool is_equal = true;

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -2,13 +2,9 @@
 
 namespace {
     bool verifyProblemDimensions(const SolverAbstract *merged, const SolverAbstract *master) {
-        if (merged->get_ncols() != master->get_ncols())
-            return false;
-        if (merged->get_nrows() != master->get_nrows())
-            return false;
-        if (merged->get_nelems() != master->get_nelems())
-            return false;
-        return true;
+        return (merged->get_ncols() == master->get_ncols())
+               && (merged->get_nrows() == master->get_nrows())
+               && (merged->get_nelems() == master->get_nelems());
     }
 
     bool verifyObjectiveFunction(const SolverAbstract *merged, const SolverAbstract *master) {
@@ -17,11 +13,7 @@ namespace {
         merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
         master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
 
-        for (int i = 0; i < merged->get_ncols(); ++i) {
-            if (obj_merged[i] != obj_master[i])
-                return false;
-        }
-        return true;
+        return std::ranges::equal(obj_merged, obj_master);
     }
 
     bool verifySolution(const SolverAbstract *merged, const SolverAbstract *master) {
@@ -30,12 +22,7 @@ namespace {
         merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
         master->get_lp_sol(sol_master.data(), nullptr, nullptr);
 
-        for (int i = 0; i < merged->get_ncols(); ++i) {
-            if (sol_merged[i] != sol_master[i]) {
-                return false;
-            }
-        }
-        return true;
+        return std::ranges::equal(sol_merged, sol_master);
     }
 
     template<typename T>
@@ -66,18 +53,11 @@ namespace {
         if (n_merged != n_master) {
             return false;
         }
-        for (int i = 0; i < n_merged; ++i) {
-            if (mstart[i] != mstart_master[i]) {
-                return false;
-            }
-            if (cindex[i] != cindex_master[i]) {
-                return false;
-            }
-            if (!IsEqual(matval_merged[i], matval_master[i])) {
-                return false;
-            }
-        }
-        return true;
+        return std::ranges::equal(mstart, mstart_master)
+               && std::ranges::equal(cindex, cindex_master)
+               && std::ranges::equal(matval_merged, matval_master, [](auto l, auto r) {
+                   return IsEqual(l, r);
+               });
     }
 
     bool verifyRHS(const SolverAbstract *merged, const SolverAbstract *master) {
@@ -86,12 +66,9 @@ namespace {
         merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
         master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
 
-        for (int i = 0; i < merged->get_nrows(); ++i) {
-            if (!IsEqual(rhs_merged[i], rhs_master[i])) {
-                return false;
-            }
-        }
-        return true;
+        return std::ranges::equal(rhs_merged, rhs_master, [](auto l, auto r) {
+            return IsEqual(l, r);
+        });
     }
 
     bool verifyRowTypes(const SolverAbstract *merged, const SolverAbstract *master) {
@@ -100,12 +77,7 @@ namespace {
         merged->get_row_type(order_merged.data(), 0, merged->get_nrows() - 1);
         master->get_row_type(order_master.data(), 0, master->get_nrows() - 1);
 
-        for (int i = 0; i < merged->get_nrows(); ++i) {
-            if (order_merged[i] != order_master[i]) {
-                return false;
-            }
-        }
-        return true;
+        return std::ranges::equal(order_merged, order_master);
     }
 
     bool verifyBounds(const SolverAbstract *merged, const SolverAbstract *master) {
@@ -114,22 +86,21 @@ namespace {
         merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
         master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
 
-        for (int i = 0; i < merged->get_ncols(); ++i) {
-            if (!IsEqual(lb_merged[i], lb_master[i])) {
-                return false;
-            }
+        if (!std::ranges::equal(lb_merged, lb_master, [](auto l, auto r) {
+            return IsEqual(l, r);
+        })) {
+            return false;
         }
-
 
         std::vector<double> ub_merged(merged->get_ncols());
         std::vector<double> ub_master(master->get_ncols());
         merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
         master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
 
-        for (int i = 0; i < merged->get_ncols(); ++i) {
-            if (!IsEqual(ub_merged[i], ub_master[i])) {
-                return false;
-            }
+        if (!std::ranges::equal(ub_merged, ub_master, [](auto l, auto r) {
+            return IsEqual(l, r);
+        })) {
+            return false;
         }
         return true;
     }

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -146,6 +146,5 @@ bool SolverAbstract::operator==(const SolverAbstract &other) const {
     is_equal = is_equal && verifyRHS(this, &other);
     is_equal = is_equal && verifyRowTypes(this, &other);
     is_equal = is_equal && verifyBounds(this, &other);
-    is_equal = is_equal && verifySolution(this, &other);
     return is_equal;
 }

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -142,10 +142,10 @@ bool SolverAbstract::operator==(const SolverAbstract &other) const {
     bool is_equal = true;
     is_equal = is_equal && verifyProblemDimensions(this, &other);
     is_equal = is_equal && verifyObjectiveFunction(this, &other);
-    is_equal = is_equal && verifySolution(this, &other);
     is_equal = is_equal && verifyConstraints(this, &other);
     is_equal = is_equal && verifyRHS(this, &other);
     is_equal = is_equal && verifyRowTypes(this, &other);
     is_equal = is_equal && verifyBounds(this, &other);
+    is_equal = is_equal && verifySolution(this, &other);
     return is_equal;
 }

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -47,14 +47,14 @@ namespace {
     }
 
     bool verifyConstraints(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<int> mstart(merged->get_ncols() + 1);
+        std::vector<int> mstart(merged->get_nrows() + 1);
         std::vector<int> cindex(merged->get_nelems());
         std::vector<double> matval_merged(merged->get_nelems());
         int n_merged = 0;
         merged->get_rows(mstart.data(), cindex.data(), matval_merged.data(), merged->get_nelems(), &n_merged, 0,
                          merged->get_nrows() - 1);
 
-        std::vector<int> mstart_master(master->get_ncols() + 1);
+        std::vector<int> mstart_master(master->get_nrows() + 1);
         std::vector<int> cindex_master(master->get_nelems());
         std::vector<double> matval_master(master->get_nelems());
         int n_master = 0;
@@ -95,13 +95,13 @@ namespace {
     }
 
     bool verifyRowTypes(const SolverAbstract *merged, const SolverAbstract *master) {
-        std::vector<char> sense_merged(merged->get_nrows());
-        std::vector<char> sense_master(master->get_nrows());
-        merged->get_row_type(sense_merged.data(), 0, merged->get_nrows() - 1);
-        master->get_row_type(sense_master.data(), 0, master->get_nrows() - 1);
+        std::vector<char> order_merged(merged->get_nrows());
+        std::vector<char> order_master(master->get_nrows());
+        merged->get_row_type(order_merged.data(), 0, merged->get_nrows() - 1);
+        master->get_row_type(order_master.data(), 0, master->get_nrows() - 1);
 
         for (int i = 0; i < merged->get_nrows(); ++i) {
-            if (sense_merged[i] != sense_master[i]) {
+            if (order_merged[i] != order_master[i]) {
                 return false;
             }
         }

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -4,8 +4,7 @@ namespace
 {
 bool areProblemDimensionsEquals(const SolverAbstract* one, const SolverAbstract* other)
 {
-    return (one->get_ncols() == other->get_ncols())
-           && (one->get_nrows() == other->get_nrows())
+    return (one->get_ncols() == other->get_ncols()) && (one->get_nrows() == other->get_nrows())
            && (one->get_nelems() == other->get_nelems());
 }
 
@@ -40,24 +39,24 @@ bool areConstraintsEquals(const SolverAbstract* one, const SolverAbstract* other
     std::vector<double> matval_one(one->get_nelems());
     int n_one = 0;
     one->get_rows(mstart.data(),
-                     cindex.data(),
-                     matval_one.data(),
-                     one->get_nelems(),
-                     &n_one,
-                     0,
-                     one->get_nrows() - 1);
+                  cindex.data(),
+                  matval_one.data(),
+                  one->get_nelems(),
+                  &n_one,
+                  0,
+                  one->get_nrows() - 1);
 
     std::vector<int> mstart_other(other->get_nrows() + 1);
     std::vector<int> cindex_other(other->get_nelems());
     std::vector<double> matval_other(other->get_nelems());
     int n_other = 0;
     other->get_rows(mstart_other.data(),
-                     cindex_other.data(),
-                     matval_other.data(),
-                     other->get_nelems(),
-                     &n_other,
-                     0,
-                     other->get_nrows() - 1);
+                    cindex_other.data(),
+                    matval_other.data(),
+                    other->get_nelems(),
+                    &n_other,
+                    0,
+                    other->get_nrows() - 1);
 
     if (n_one != n_other)
     {

--- a/src/cpp/multisolver_interface/SolverAbstract.cpp
+++ b/src/cpp/multisolver_interface/SolverAbstract.cpp
@@ -2,31 +2,21 @@
 
 namespace
 {
-bool verifyProblemDimensions(const SolverAbstract* merged, const SolverAbstract* master)
+bool areProblemDimensionsEquals(const SolverAbstract* one, const SolverAbstract* other)
 {
-    return (merged->get_ncols() == master->get_ncols())
-           && (merged->get_nrows() == master->get_nrows())
-           && (merged->get_nelems() == master->get_nelems());
+    return (one->get_ncols() == other->get_ncols())
+           && (one->get_nrows() == other->get_nrows())
+           && (one->get_nelems() == other->get_nelems());
 }
 
-bool verifyObjectiveFunction(const SolverAbstract* merged, const SolverAbstract* master)
+bool areObjectiveFunctionEquals(const SolverAbstract* one, const SolverAbstract* other)
 {
-    std::vector<double> obj_merged(merged->get_ncols());
-    std::vector<double> obj_master(master->get_ncols());
-    merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
+    std::vector<double> obj_one(one->get_ncols());
+    std::vector<double> obj_other(other->get_ncols());
+    one->get_obj(obj_one.data(), 0, one->get_ncols() - 1);
+    other->get_obj(obj_other.data(), 0, other->get_ncols() - 1);
 
-    return std::ranges::equal(obj_merged, obj_master);
-}
-
-bool verifySolution(const SolverAbstract* merged, const SolverAbstract* master)
-{
-    std::vector<double> sol_merged(merged->get_ncols());
-    std::vector<double> sol_master(master->get_ncols());
-    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
-    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
-
-    return std::ranges::equal(sol_merged, sol_master);
+    return std::ranges::equal(obj_one, obj_other);
 }
 
 template<typename T>
@@ -43,80 +33,80 @@ bool IsEqual(const T& lhs, const T& rhs, const T& epsilon = std::numeric_limits<
     }
 }
 
-bool verifyConstraints(const SolverAbstract* merged, const SolverAbstract* master)
+bool areConstraintsEquals(const SolverAbstract* one, const SolverAbstract* other)
 {
-    std::vector<int> mstart(merged->get_nrows() + 1);
-    std::vector<int> cindex(merged->get_nelems());
-    std::vector<double> matval_merged(merged->get_nelems());
-    int n_merged = 0;
-    merged->get_rows(mstart.data(),
+    std::vector<int> mstart(one->get_nrows() + 1);
+    std::vector<int> cindex(one->get_nelems());
+    std::vector<double> matval_one(one->get_nelems());
+    int n_one = 0;
+    one->get_rows(mstart.data(),
                      cindex.data(),
-                     matval_merged.data(),
-                     merged->get_nelems(),
-                     &n_merged,
+                     matval_one.data(),
+                     one->get_nelems(),
+                     &n_one,
                      0,
-                     merged->get_nrows() - 1);
+                     one->get_nrows() - 1);
 
-    std::vector<int> mstart_master(master->get_nrows() + 1);
-    std::vector<int> cindex_master(master->get_nelems());
-    std::vector<double> matval_master(master->get_nelems());
-    int n_master = 0;
-    master->get_rows(mstart_master.data(),
-                     cindex_master.data(),
-                     matval_master.data(),
-                     master->get_nelems(),
-                     &n_master,
+    std::vector<int> mstart_other(other->get_nrows() + 1);
+    std::vector<int> cindex_other(other->get_nelems());
+    std::vector<double> matval_other(other->get_nelems());
+    int n_other = 0;
+    other->get_rows(mstart_other.data(),
+                     cindex_other.data(),
+                     matval_other.data(),
+                     other->get_nelems(),
+                     &n_other,
                      0,
-                     master->get_nrows() - 1);
+                     other->get_nrows() - 1);
 
-    if (n_merged != n_master)
+    if (n_one != n_other)
     {
         return false;
     }
-    return std::ranges::equal(mstart, mstart_master) && std::ranges::equal(cindex, cindex_master)
-           && std::ranges::equal(matval_merged,
-                                 matval_master,
+    return std::ranges::equal(mstart, mstart_other) && std::ranges::equal(cindex, cindex_other)
+           && std::ranges::equal(matval_one,
+                                 matval_other,
                                  [](auto l, auto r) { return IsEqual(l, r); });
 }
 
-bool verifyRHS(const SolverAbstract* merged, const SolverAbstract* master)
+bool areRHSEquals(const SolverAbstract* one, const SolverAbstract* other)
 {
-    std::vector<double> rhs_merged(merged->get_nrows());
-    std::vector<double> rhs_master(master->get_nrows());
-    merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
-    master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
+    std::vector<double> rhs_one(one->get_nrows());
+    std::vector<double> rhs_other(other->get_nrows());
+    one->get_rhs(rhs_one.data(), 0, one->get_nrows() - 1);
+    other->get_rhs(rhs_other.data(), 0, other->get_nrows() - 1);
 
-    return std::ranges::equal(rhs_merged, rhs_master, [](auto l, auto r) { return IsEqual(l, r); });
+    return std::ranges::equal(rhs_one, rhs_other, [](auto l, auto r) { return IsEqual(l, r); });
 }
 
-bool verifyRowTypes(const SolverAbstract* merged, const SolverAbstract* master)
+bool areRowTypesEquals(const SolverAbstract* one, const SolverAbstract* other)
 {
-    std::vector<char> order_merged(merged->get_nrows());
-    std::vector<char> order_master(master->get_nrows());
-    merged->get_row_type(order_merged.data(), 0, merged->get_nrows() - 1);
-    master->get_row_type(order_master.data(), 0, master->get_nrows() - 1);
+    std::vector<char> order_one(one->get_nrows());
+    std::vector<char> order_other(other->get_nrows());
+    one->get_row_type(order_one.data(), 0, one->get_nrows() - 1);
+    other->get_row_type(order_other.data(), 0, other->get_nrows() - 1);
 
-    return std::ranges::equal(order_merged, order_master);
+    return std::ranges::equal(order_one, order_other);
 }
 
-bool verifyBounds(const SolverAbstract* merged, const SolverAbstract* master)
+bool areBoundsEquals(const SolverAbstract* one, const SolverAbstract* other)
 {
-    std::vector<double> lb_merged(merged->get_ncols());
-    std::vector<double> lb_master(master->get_ncols());
-    merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
+    std::vector<double> lb_one(one->get_ncols());
+    std::vector<double> lb_other(other->get_ncols());
+    one->get_lb(lb_one.data(), 0, one->get_ncols() - 1);
+    other->get_lb(lb_other.data(), 0, other->get_ncols() - 1);
 
-    if (!std::ranges::equal(lb_merged, lb_master, [](auto l, auto r) { return IsEqual(l, r); }))
+    if (!std::ranges::equal(lb_one, lb_other, [](auto l, auto r) { return IsEqual(l, r); }))
     {
         return false;
     }
 
-    std::vector<double> ub_merged(merged->get_ncols());
-    std::vector<double> ub_master(master->get_ncols());
-    merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
+    std::vector<double> ub_one(one->get_ncols());
+    std::vector<double> ub_other(other->get_ncols());
+    one->get_ub(ub_one.data(), 0, one->get_ncols() - 1);
+    other->get_ub(ub_other.data(), 0, other->get_ncols() - 1);
 
-    if (!std::ranges::equal(ub_merged, ub_master, [](auto l, auto r) { return IsEqual(l, r); }))
+    if (!std::ranges::equal(ub_one, ub_other, [](auto l, auto r) { return IsEqual(l, r); }))
     {
         return false;
     }
@@ -131,11 +121,11 @@ bool SolverAbstract::operator==(const SolverAbstract& other) const
         return true;
     }
     bool is_equal = true;
-    is_equal = is_equal && verifyProblemDimensions(this, &other);
-    is_equal = is_equal && verifyObjectiveFunction(this, &other);
-    is_equal = is_equal && verifyConstraints(this, &other);
-    is_equal = is_equal && verifyRHS(this, &other);
-    is_equal = is_equal && verifyRowTypes(this, &other);
-    is_equal = is_equal && verifyBounds(this, &other);
+    is_equal = is_equal && areProblemDimensionsEquals(this, &other);
+    is_equal = is_equal && areObjectiveFunctionEquals(this, &other);
+    is_equal = is_equal && areConstraintsEquals(this, &other);
+    is_equal = is_equal && areRHSEquals(this, &other);
+    is_equal = is_equal && areRowTypesEquals(this, &other);
+    is_equal = is_equal && areBoundsEquals(this, &other);
     return is_equal;
 }

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -791,8 +791,7 @@ int SolverCbc::get_splex_num_of_ite_last() const
     return _cbc.solver()->getIterationCount();
 }
 
-void SolverCbc::get_lp_sol(double* primals, double* duals, double* reduced_costs)
-{
+void SolverCbc::get_lp_sol(double* primals, double* duals, double* reduced_costs) const {
     if (primals != nullptr)
     {
         const double* primalSol = _cbc.solver()->getColSolution();

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -791,7 +791,8 @@ int SolverCbc::get_splex_num_of_ite_last() const
     return _cbc.solver()->getIterationCount();
 }
 
-void SolverCbc::get_lp_sol(double* primals, double* duals, double* reduced_costs) const {
+void SolverCbc::get_lp_sol(double* primals, double* duals, double* reduced_costs) const
+{
     if (primals != nullptr)
     {
         const double* primalSol = _cbc.solver()->getColSolution();

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -642,8 +642,7 @@ int SolverClp::get_splex_num_of_ite_last() const
     return _clp.numberIterations();
 }
 
-void SolverClp::get_lp_sol(double* primals, double* duals, double* reduced_costs)
-{
+void SolverClp::get_lp_sol(double* primals, double* duals, double* reduced_costs) const {
     if (primals != NULL)
     {
         double* primalSol = _clp.primalColumnSolution();

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -642,7 +642,8 @@ int SolverClp::get_splex_num_of_ite_last() const
     return _clp.numberIterations();
 }
 
-void SolverClp::get_lp_sol(double* primals, double* duals, double* reduced_costs) const {
+void SolverClp::get_lp_sol(double* primals, double* duals, double* reduced_costs) const
+{
     if (primals != NULL)
     {
         double* primalSol = _clp.primalColumnSolution();

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -661,7 +661,8 @@ int SolverXpress::get_splex_num_of_ite_last() const
     return result;
 }
 
-void SolverXpress::get_lp_sol(double* primals, double* duals, double* reduced_costs) const {
+void SolverXpress::get_lp_sol(double* primals, double* duals, double* reduced_costs) const
+{
     int status = XPRSgetlpsol(_xprs, primals, NULL, duals, reduced_costs);
     zero_status_check(status, "get LP sol", LOGLOCATION);
 }

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -661,8 +661,7 @@ int SolverXpress::get_splex_num_of_ite_last() const
     return result;
 }
 
-void SolverXpress::get_lp_sol(double* primals, double* duals, double* reduced_costs)
-{
+void SolverXpress::get_lp_sol(double* primals, double* duals, double* reduced_costs) const {
     int status = XPRSgetlpsol(_xprs, primals, NULL, duals, reduced_costs);
     zero_status_check(status, "get LP sol", LOGLOCATION);
 }

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -13,19 +13,26 @@
 
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
-class SolverLogManager {
+class SolverLogManager
+{
 public:
     explicit SolverLogManager() = default;
 
-    explicit SolverLogManager(const SolverLogManager &other): SolverLogManager(other.log_file_path) {
+    explicit SolverLogManager(const SolverLogManager& other):
+        SolverLogManager(other.log_file_path)
+    {
     }
 
-    explicit SolverLogManager(const std::filesystem::path &log_file): log_file_path(log_file) {
+    explicit SolverLogManager(const std::filesystem::path& log_file):
+        log_file_path(log_file)
+    {
         init();
     }
 
-    SolverLogManager &operator=(const SolverLogManager &other) {
-        if (this == &other) {
+    SolverLogManager& operator=(const SolverLogManager& other)
+    {
+        if (this == &other)
+        {
             return *this;
         }
         log_file_path = other.log_file_path;
@@ -33,7 +40,8 @@ public:
         return *this;
     }
 
-    void init() {
+    void init()
+    {
 #ifdef __linux__
         if (log_file_path.empty()
             || (log_file_ptr = fopen(log_file_path.string().c_str(), "a+")) == nullptr)
@@ -44,113 +52,139 @@ public:
 #endif
         {
             std::cout << "Invalid log file name passed as parameter: "
-                    << std::quoted(log_file_path.string()) << std::endl;
-        } else {
+                      << std::quoted(log_file_path.string()) << std::endl;
+        }
+        else
+        {
             setvbuf(log_file_ptr, nullptr, _IONBF, 0);
         }
     }
 
-    ~SolverLogManager() {
-        if (log_file_ptr) {
+    ~SolverLogManager()
+    {
+        if (log_file_ptr)
+        {
             fclose(log_file_ptr);
             log_file_ptr = nullptr;
         }
     }
 
-    FILE *log_file_ptr = nullptr;
+    FILE* log_file_ptr = nullptr;
     std::filesystem::path log_file_path = "";
 };
 
-class InvalidStatusException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidStatusException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidStatusException(int status, const std::string &action,
-                           const std::string &log_message): LogUtils::XpansionError<std::runtime_error>(
-        "Failed to " + action + ": invalid status "
-        + std::to_string(status) + " (0 expected)",
-        log_message) {
+    InvalidStatusException(int status, const std::string& action, const std::string& log_message):
+        LogUtils::XpansionError<std::runtime_error>("Failed to " + action + ": invalid status "
+                                                      + std::to_string(status) + " (0 expected)",
+                                                    log_message)
+    {
     }
 };
 
-class InvalidRowSizeException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidRowSizeException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidRowSizeException(int expected_size, int actual_size,
-                            const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
-        "Invalid row size for solver. " + std::to_string(actual_size) + " rows available ("
-        + std::to_string(expected_size) + " expected)",
-        log_location) {
+    InvalidRowSizeException(int expected_size, int actual_size, const std::string& log_location):
+        LogUtils::XpansionError<std::runtime_error>(
+          "Invalid row size for solver. " + std::to_string(actual_size) + " rows available ("
+            + std::to_string(expected_size) + " expected)",
+          log_location)
+    {
     }
 };
 
-class InvalidColSizeException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidColSizeException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidColSizeException(int expected_size, int actual_size,
-                            const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
-        "Invalid col size for solver. " + std::to_string(actual_size) + " cols available ("
-        + std::to_string(expected_size) + " expected)",
-        log_location) {
+    InvalidColSizeException(int expected_size, int actual_size, const std::string& log_location):
+        LogUtils::XpansionError<std::runtime_error>(
+          "Invalid col size for solver. " + std::to_string(actual_size) + " cols available ("
+            + std::to_string(expected_size) + " expected)",
+          log_location)
+    {
     }
 };
 
-class InvalidBoundTypeException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidBoundTypeException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidBoundTypeException(char qbtype, const std::string &log_location): LogUtils::XpansionError<
-        std::runtime_error>(std::string("Invalid bound type ") + qbtype
-                            + " for solver.",
-                            log_location) {
+    InvalidBoundTypeException(char qbtype, const std::string& log_location):
+        LogUtils::XpansionError<std::runtime_error>(std::string("Invalid bound type ") + qbtype
+                                                      + " for solver.",
+                                                    log_location)
+    {
     }
 };
 
-class InvalidColTypeException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidColTypeException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidColTypeException(char qctype, const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
-        std::string("Invalid col type ") + qctype
-        + " for solver.",
-        log_location) {
+    InvalidColTypeException(char qctype, const std::string& log_location):
+        LogUtils::XpansionError<std::runtime_error>(std::string("Invalid col type ") + qctype
+                                                      + " for solver.",
+                                                    log_location)
+    {
     }
 };
 
-class InvalidSolverOptionException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidSolverOptionException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidSolverOptionException(const std::string &option, const std::string &log_location): LogUtils::XpansionError<
-        std::runtime_error>(std::string("Invalid option '") + option
-                            + "' for solver.",
-                            log_location) {
+    InvalidSolverOptionException(const std::string& option, const std::string& log_location):
+        LogUtils::XpansionError<std::runtime_error>(std::string("Invalid option '") + option
+                                                      + "' for solver.",
+                                                    log_location)
+    {
     }
 };
 
-class InvalidSolverForCopyException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidSolverForCopyException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidSolverForCopyException(const std::string &from_solver,
-                                  const std::string &to_solver,
-                                  const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
-        "Can't copy " + from_solver + "solver from "
-        + to_solver,
-        log_location) {
+    InvalidSolverForCopyException(const std::string& from_solver,
+                                  const std::string& to_solver,
+                                  const std::string& log_location):
+        LogUtils::XpansionError<std::runtime_error>("Can't copy " + from_solver + "solver from "
+                                                      + to_solver,
+                                                    log_location)
+    {
     }
 };
 
-class InvalidSolverNameException : public LogUtils::XpansionError<std::runtime_error> {
+class InvalidSolverNameException: public LogUtils::XpansionError<std::runtime_error>
+{
 public:
-    InvalidSolverNameException(const std::string &solver_name, const std::string &log_location): LogUtils::XpansionError
-        <std::runtime_error>("Solver '" + solver_name + "' not supported",
-                             log_location) {
+    InvalidSolverNameException(const std::string& solver_name, const std::string& log_location):
+        LogUtils::XpansionError<std::runtime_error>("Solver '" + solver_name + "' not supported",
+                                                    log_location)
+    {
     }
 };
 
-class GenericSolverException : public std::runtime_error {
+class GenericSolverException: public std::runtime_error
+{
 public:
-    GenericSolverException(const std::string &message): std::runtime_error(message) {
+    GenericSolverException(const std::string& message):
+        std::runtime_error(message)
+    {
     }
 };
 
-class NotImplementedFeatureSolverException : public std::runtime_error {
+class NotImplementedFeatureSolverException: public std::runtime_error
+{
 public:
-    NotImplementedFeatureSolverException(const std::string &message): std::runtime_error(message) {
+    NotImplementedFeatureSolverException(const std::string& message):
+        std::runtime_error(message)
+    {
     }
 };
 
 // Definition of optimality codes
-enum SOLVER_STATUS {
+enum SOLVER_STATUS
+{
     OPTIMAL,
     INFEASIBLE,
     UNBOUNDED,
@@ -162,15 +196,14 @@ enum SOLVER_STATUS {
  * \class class SolverAbstract
  * \brief Virtual class to implement solvers methods
  */
-class SolverAbstract {
+class SolverAbstract
+{
 public:
-    std::vector<std::string> SOLVER_STRING_STATUS = {
-        "OPTIMAL",
-        "INFEASIBLE",
-        "UNBOUNDED",
-        "INForUNBOUND",
-        "UNKNOWN"
-    };
+    std::vector<std::string> SOLVER_STRING_STATUS = {"OPTIMAL",
+                                                     "INFEASIBLE",
+                                                     "UNBOUNDED",
+                                                     "INForUNBOUND",
+                                                     "UNKNOWN"};
 
     /*************************************************************************************************
     ----------------------------------------    ATTRIBUTES
@@ -178,10 +211,10 @@ public:
     *************************************************************************************************/
 
 public:
-    std::string _name; /*!< Name of the problem */
+    std::string _name;                           /*!< Name of the problem */
     typedef std::shared_ptr<SolverAbstract> Ptr; /*!< Ptr to the solver */
-    std::list<std::ostream *>
-    _streams; /*!< List of streams to print the output (default std::cout) */
+    std::list<std::ostream*>
+      _streams; /*!< List of streams to print the output (default std::cout) */
 
     /*************************************************************************************************
     -----------------------------------    Constructor/Desctructor
@@ -192,8 +225,7 @@ public:
     /**
      * @brief constructor of SolverAbstract class : does nothing
      */
-    SolverAbstract() {
-    };
+    SolverAbstract(){};
 
     /**
      * @brief Copy constructor, copy the problem "toCopy" in memory and name it
@@ -203,14 +235,12 @@ public:
      * @param toCopy : Pointer to an AbstractSolver object, containing a solver
      * object to copy
      */
-    SolverAbstract(const std::string &name, const SolverAbstract::Ptr toCopy) {
-    };
+    SolverAbstract(const std::string& name, const SolverAbstract::Ptr toCopy){};
 
     /**
      * @brief destructor of SolverAbstract class : does nothing
      */
-    virtual ~SolverAbstract() {
-    };
+    virtual ~SolverAbstract(){};
 
     /**
      * @brief Returns number of instances of solver currently in memory
@@ -231,11 +261,12 @@ public:
     /**
      * @brief returns the list of streams used by the solver instance
      */
-    std::list<std::ostream *> &get_stream() {
+    std::list<std::ostream*>& get_stream()
+    {
         return _streams;
     }
 
-    FILE *_fp = nullptr;
+    FILE* _fp = nullptr;
     std::filesystem::path _log_file = "";
 
     /**
@@ -243,11 +274,13 @@ public:
      *
      * @param stream  : reference to a std::ostream object
      */
-    void add_stream(std::ostream &stream) {
+    void add_stream(std::ostream& stream)
+    {
         get_stream().push_back(&stream);
     }
 
-    void set_fp(FILE *fp) {
+    void set_fp(FILE* fp)
+    {
         _fp = fp;
     }
 
@@ -260,9 +293,11 @@ public:
                             used to print the error message.
     */
     void zero_status_check(int status,
-                           const std::string &action_failed,
-                           const std::string &log_location) const {
-        if (status != 0) {
+                           const std::string& action_failed,
+                           const std::string& log_location) const
+    {
+        if (status != 0)
+        {
             throw InvalidStatusException(status, action_failed, log_location);
         }
     }
@@ -294,14 +329,14 @@ public:
      *
      * @param name   : name of the file to write
      */
-    virtual void write_prob_mps(const std::filesystem::path &filename) = 0;
+    virtual void write_prob_mps(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief writes an optimization problem in a LP file
      *
      * @param name   : name of the file to write
      */
-    virtual void write_prob_lp(const std::filesystem::path &filename) = 0;
+    virtual void write_prob_lp(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief write an optimisation problem in a file
@@ -310,7 +345,7 @@ public:
      *
      * @param name   : name of the file to read
      */
-    virtual void save_prob(const std::filesystem::path &filename) = 0;
+    virtual void save_prob(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief Writes the current basis to a file for later input into the
@@ -318,21 +353,21 @@ public:
      *
      * @param filename    : file name where the basis is written
      */
-    virtual void write_basis(const std::filesystem::path &filename) = 0;
+    virtual void write_basis(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief reads an optimization problem contained in a MPS file
      *
      * @param name   : name of the file to read
      */
-    virtual void read_prob_mps(const std::filesystem::path &filename) = 0;
+    virtual void read_prob_mps(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief reads an optimization problem contained in a MPS file
      *
      * @param name   : name of the file to read
      */
-    virtual void read_prob_lp(const std::filesystem::path &filename) = 0;
+    virtual void read_prob_lp(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief read an optimisation problem from a file
@@ -341,7 +376,7 @@ public:
      *
      * @param name   : name of the file to read
      */
-    virtual void restore_prob(const std::filesystem::path &filename) = 0;
+    virtual void restore_prob(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief Instructs the optimizer to read in a previously saved basis from a
@@ -349,7 +384,7 @@ public:
      *
      * @param filename: File name where the basis is to be read
      */
-    virtual void read_basis(const std::filesystem::path &filename) = 0;
+    virtual void read_basis(const std::filesystem::path& filename) = 0;
 
     /**
      * @brief copy an existing problem
@@ -389,7 +424,7 @@ public:
      * @brief returns the objective function coefficients for the columns in a
      * given range
      */
-    virtual void get_obj(double *obj, int first, int last) const = 0;
+    virtual void get_obj(double* obj, int first, int last) const = 0;
 
     /**
      * @brief Set the objective function coefficients to zero
@@ -400,7 +435,7 @@ public:
      * @brief Set the objective function coefficients for the columns in a
      * given range
      */
-    virtual void set_obj(const double *obj, int first, int last) = 0;
+    virtual void set_obj(const double* obj, int first, int last) = 0;
 
     /**
     * @brief get coefficients of rows from index first to last
@@ -417,14 +452,14 @@ public:
     * @param first      : first index of row to get
     * @param last       : last index of row to get
     */
-    virtual void get_rows(int *mstart,
-                          int *mclind,
-                          double *dmatval,
+    virtual void get_rows(int* mstart,
+                          int* mclind,
+                          double* dmatval,
                           int size,
-                          int *nels,
+                          int* nels,
                           int first,
                           int last) const
-    = 0;
+      = 0;
 
     /**
     * @brief Returns the row types for the rows in a given range.
@@ -434,7 +469,7 @@ public:
     * @param first  : first index of row to get
     * @param last   : last index of row to get
     */
-    virtual void get_row_type(char *qrtype, int first, int last) const = 0;
+    virtual void get_row_type(char* qrtype, int first, int last) const = 0;
 
     /**
      * @brief Returns the right-hand sides of the rows in a given range.
@@ -444,7 +479,7 @@ public:
      * @param first  : first index of row to get
      * @param last   : last index of row to get
      */
-    virtual void get_rhs(double *rhs, int first, int last) const = 0;
+    virtual void get_rhs(double* rhs, int first, int last) const = 0;
 
     /**
     * @brief Returns the right hand side range values for the rows in a given
@@ -455,7 +490,7 @@ public:
     * @param first  : first index of row to get
     * @param last   : last index of row to get
     */
-    virtual void get_rhs_range(double *range, int first, int last) const = 0;
+    virtual void get_rhs_range(double* range, int first, int last) const = 0;
 
     /**
     * @brief Returns the column types for the columns in a given range.
@@ -466,7 +501,7 @@ public:
     * @param first      : first index of row to get
     * @param last       : last index of row to get
     */
-    virtual void get_col_type(char *coltype, int first, int last) const = 0;
+    virtual void get_col_type(char* coltype, int first, int last) const = 0;
 
     /**
      * @brief Returns the lower bounds for variables in a given range.
@@ -476,7 +511,7 @@ public:
      * @param first  : First column in the range.
      * @param last   : Last column in the range.
      */
-    virtual void get_lb(double *lb, int fisrt, int last) const = 0;
+    virtual void get_lb(double* lb, int fisrt, int last) const = 0;
 
     /**
      * @brief Returns the upper bounds for variables in a given range.
@@ -486,21 +521,21 @@ public:
      * @param first  : First column in the range.
      * @param last   : Last column in the range.
      */
-    virtual void get_ub(double *ub, int fisrt, int last) const = 0;
+    virtual void get_ub(double* ub, int fisrt, int last) const = 0;
 
     /**
      * @brief Returns the index of row named "name"
      *
      * @param name : name of row to get the index
      */
-    virtual int get_row_index(const std::string &name) = 0;
+    virtual int get_row_index(const std::string& name) = 0;
 
     /**
      * @brief Returns the index of column named "name"
      *
      * @param name : name of column to get the index
      */
-    virtual int get_col_index(const std::string &name) = 0;
+    virtual int get_col_index(const std::string& name) = 0;
 
     /**
      * @brief Returns the names of row from index first to last
@@ -571,14 +606,14 @@ public:
     */
     virtual void add_rows(int newrows,
                           int newnz,
-                          const char *qrtype,
-                          const double *rhs,
-                          const double *range,
-                          const int *mstart,
-                          const int *mclind,
-                          const double *dmatval,
-                          const std::vector<std::string> &row_names)
-    = 0;
+                          const char* qrtype,
+                          const double* rhs,
+                          const double* range,
+                          const int* mstart,
+                          const int* mclind,
+                          const double* dmatval,
+                          const std::vector<std::string>& row_names)
+      = 0;
 
     /**
     * @brief Adds new columns to the problem
@@ -602,14 +637,14 @@ public:
     */
     virtual void add_cols(int newcol,
                           int newnz,
-                          const double *objx,
-                          const int *mstart,
-                          const int *mrwind,
-                          const double *dmatval,
-                          const double *bdl,
-                          const double *bdu,
-                          const std::vector<std::string> &col_names)
-    = 0;
+                          const double* objx,
+                          const int* mstart,
+                          const int* mrwind,
+                          const double* dmatval,
+                          const double* bdl,
+                          const double* bdu,
+                          const std::vector<std::string>& col_names)
+      = 0;
 
     /**
      * @brief Adds a name to a row or a column
@@ -619,10 +654,10 @@ public:
      * names.
      * @param indice : index of the row or of the column.
      */
-    virtual void add_name(int type, const char *cnames, int indice) = 0;
+    virtual void add_name(int type, const char* cnames, int indice) = 0;
 
-    virtual void add_names(int type, const std::vector<std::string> &cnames, int first, int end)
-    = 0;
+    virtual void add_names(int type, const std::vector<std::string>& cnames, int first, int end)
+      = 0;
 
     /**
      * @brief Change coefficients in objective function
@@ -630,7 +665,7 @@ public:
      * @param mindex : indices of columns to modify
      * @param obj    : Values to set in objective function
      */
-    virtual void chg_obj(const std::vector<int> &mindex, const std::vector<double> &obj) = 0;
+    virtual void chg_obj(const std::vector<int>& mindex, const std::vector<double>& obj) = 0;
 
     /**
      * @brief Change the problem's objective function sense to minimize or
@@ -649,10 +684,10 @@ public:
      * both)
      * @param bnd    : new values for the bounds
      */
-    virtual void chg_bounds(const std::vector<int> &mindex,
-                            const std::vector<char> &qbtype,
-                            const std::vector<double> &bnd)
-    = 0;
+    virtual void chg_bounds(const std::vector<int>& mindex,
+                            const std::vector<char>& qbtype,
+                            const std::vector<double>& bnd)
+      = 0;
 
     /**
      * @brief Change type of some columns
@@ -661,7 +696,7 @@ public:
      * @param mindex : indices of columns to modify
      * @param qctype : New types of columns
      */
-    virtual void chg_col_type(const std::vector<int> &mindex, const std::vector<char> &qctype) = 0;
+    virtual void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) = 0;
 
     /**
      * @brief Change rhs of a row
@@ -686,7 +721,7 @@ public:
      * @param id_row : index of the row
      * @param name   : new name of the row
      */
-    virtual void chg_row_name(int id_row, const std::string &name) = 0;
+    virtual void chg_row_name(int id_row, const std::string& name) = 0;
 
     /**
      * @brief Change the name of a variable
@@ -694,7 +729,7 @@ public:
      * @param id_col : index of the column
      * @param name   : new name of the column
      */
-    virtual void chg_col_name(int id_col, const std::string &name) = 0;
+    virtual void chg_col_name(int id_col, const std::string& name) = 0;
 
     /*************************************************************************************************
     -----------------------------    Methods to solve the problem
@@ -733,7 +768,7 @@ public:
     the columns in the constraint matrix. The values depend on the solver used.May
     be NULL if not required.
     */
-    virtual void get_basis(int *rstatus, int *cstatus) const = 0;
+    virtual void get_basis(int* rstatus, int* cstatus) const = 0;
 
     /**
      * @brief Get the optimal value of a MIP problem (available after method
@@ -767,14 +802,14 @@ public:
      * @param duals      : values of dual variables
      * @param reduced_cost: reduced_cost in an optimal basis
      */
-    virtual void get_lp_sol(double *primals, double *duals, double *reduced_costs) const = 0;
+    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) const = 0;
 
     /**
      * @brief Get MIP solution of a problem (available after method "solve_mip")
      *
      * @param primals    : values of primal variables
      */
-    virtual void get_mip_sol(double *primals) = 0;
+    virtual void get_mip_sol(double* primals) = 0;
 
     /*************************************************************************************************
     ------------------------    Methods to set algorithm or logs levels
@@ -794,7 +829,7 @@ public:
      *
      * @param algo : string of the name of the algorithm
      */
-    virtual void set_algorithm(const std::string &algo) = 0;
+    virtual void set_algorithm(const std::string& algo) = 0;
 
     /**
      * @brief Sets the maximum number of threads used to perform optimization
@@ -817,5 +852,5 @@ public:
      */
     virtual void set_simplex_iter(int iter) = 0;
 
-    bool operator==(const SolverAbstract &) const;
+    bool operator==(const SolverAbstract&) const;
 };

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -816,4 +816,6 @@ public:
      * @param iter: maximum number of simplex iterations
      */
     virtual void set_simplex_iter(int iter) = 0;
+
+    bool operator==(const SolverAbstract &) const;
 };

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -13,26 +13,19 @@
 
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
-class SolverLogManager
-{
+class SolverLogManager {
 public:
     explicit SolverLogManager() = default;
 
-    explicit SolverLogManager(const SolverLogManager& other):
-        SolverLogManager(other.log_file_path)
-    {
+    explicit SolverLogManager(const SolverLogManager &other): SolverLogManager(other.log_file_path) {
     }
 
-    explicit SolverLogManager(const std::filesystem::path& log_file):
-        log_file_path(log_file)
-    {
+    explicit SolverLogManager(const std::filesystem::path &log_file): log_file_path(log_file) {
         init();
     }
 
-    SolverLogManager& operator=(const SolverLogManager& other)
-    {
-        if (this == &other)
-        {
+    SolverLogManager &operator=(const SolverLogManager &other) {
+        if (this == &other) {
             return *this;
         }
         log_file_path = other.log_file_path;
@@ -40,8 +33,7 @@ public:
         return *this;
     }
 
-    void init()
-    {
+    void init() {
 #ifdef __linux__
         if (log_file_path.empty()
             || (log_file_ptr = fopen(log_file_path.string().c_str(), "a+")) == nullptr)
@@ -52,139 +44,113 @@ public:
 #endif
         {
             std::cout << "Invalid log file name passed as parameter: "
-                      << std::quoted(log_file_path.string()) << std::endl;
-        }
-        else
-        {
+                    << std::quoted(log_file_path.string()) << std::endl;
+        } else {
             setvbuf(log_file_ptr, nullptr, _IONBF, 0);
         }
     }
 
-    ~SolverLogManager()
-    {
-        if (log_file_ptr)
-        {
+    ~SolverLogManager() {
+        if (log_file_ptr) {
             fclose(log_file_ptr);
             log_file_ptr = nullptr;
         }
     }
 
-    FILE* log_file_ptr = nullptr;
+    FILE *log_file_ptr = nullptr;
     std::filesystem::path log_file_path = "";
 };
 
-class InvalidStatusException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidStatusException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidStatusException(int status, const std::string& action, const std::string& log_message):
-        LogUtils::XpansionError<std::runtime_error>("Failed to " + action + ": invalid status "
-                                                      + std::to_string(status) + " (0 expected)",
-                                                    log_message)
-    {
+    InvalidStatusException(int status, const std::string &action,
+                           const std::string &log_message): LogUtils::XpansionError<std::runtime_error>(
+        "Failed to " + action + ": invalid status "
+        + std::to_string(status) + " (0 expected)",
+        log_message) {
     }
 };
 
-class InvalidRowSizeException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidRowSizeException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidRowSizeException(int expected_size, int actual_size, const std::string& log_location):
-        LogUtils::XpansionError<std::runtime_error>(
-          "Invalid row size for solver. " + std::to_string(actual_size) + " rows available ("
-            + std::to_string(expected_size) + " expected)",
-          log_location)
-    {
+    InvalidRowSizeException(int expected_size, int actual_size,
+                            const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
+        "Invalid row size for solver. " + std::to_string(actual_size) + " rows available ("
+        + std::to_string(expected_size) + " expected)",
+        log_location) {
     }
 };
 
-class InvalidColSizeException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidColSizeException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidColSizeException(int expected_size, int actual_size, const std::string& log_location):
-        LogUtils::XpansionError<std::runtime_error>(
-          "Invalid col size for solver. " + std::to_string(actual_size) + " cols available ("
-            + std::to_string(expected_size) + " expected)",
-          log_location)
-    {
+    InvalidColSizeException(int expected_size, int actual_size,
+                            const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
+        "Invalid col size for solver. " + std::to_string(actual_size) + " cols available ("
+        + std::to_string(expected_size) + " expected)",
+        log_location) {
     }
 };
 
-class InvalidBoundTypeException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidBoundTypeException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidBoundTypeException(char qbtype, const std::string& log_location):
-        LogUtils::XpansionError<std::runtime_error>(std::string("Invalid bound type ") + qbtype
-                                                      + " for solver.",
-                                                    log_location)
-    {
+    InvalidBoundTypeException(char qbtype, const std::string &log_location): LogUtils::XpansionError<
+        std::runtime_error>(std::string("Invalid bound type ") + qbtype
+                            + " for solver.",
+                            log_location) {
     }
 };
 
-class InvalidColTypeException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidColTypeException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidColTypeException(char qctype, const std::string& log_location):
-        LogUtils::XpansionError<std::runtime_error>(std::string("Invalid col type ") + qctype
-                                                      + " for solver.",
-                                                    log_location)
-    {
+    InvalidColTypeException(char qctype, const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
+        std::string("Invalid col type ") + qctype
+        + " for solver.",
+        log_location) {
     }
 };
 
-class InvalidSolverOptionException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidSolverOptionException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidSolverOptionException(const std::string& option, const std::string& log_location):
-        LogUtils::XpansionError<std::runtime_error>(std::string("Invalid option '") + option
-                                                      + "' for solver.",
-                                                    log_location)
-    {
+    InvalidSolverOptionException(const std::string &option, const std::string &log_location): LogUtils::XpansionError<
+        std::runtime_error>(std::string("Invalid option '") + option
+                            + "' for solver.",
+                            log_location) {
     }
 };
 
-class InvalidSolverForCopyException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidSolverForCopyException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidSolverForCopyException(const std::string& from_solver,
-                                  const std::string& to_solver,
-                                  const std::string& log_location):
-        LogUtils::XpansionError<std::runtime_error>("Can't copy " + from_solver + "solver from "
-                                                      + to_solver,
-                                                    log_location)
-    {
+    InvalidSolverForCopyException(const std::string &from_solver,
+                                  const std::string &to_solver,
+                                  const std::string &log_location): LogUtils::XpansionError<std::runtime_error>(
+        "Can't copy " + from_solver + "solver from "
+        + to_solver,
+        log_location) {
     }
 };
 
-class InvalidSolverNameException: public LogUtils::XpansionError<std::runtime_error>
-{
+class InvalidSolverNameException : public LogUtils::XpansionError<std::runtime_error> {
 public:
-    InvalidSolverNameException(const std::string& solver_name, const std::string& log_location):
-        LogUtils::XpansionError<std::runtime_error>("Solver '" + solver_name + "' not supported",
-                                                    log_location)
-    {
+    InvalidSolverNameException(const std::string &solver_name, const std::string &log_location): LogUtils::XpansionError
+        <std::runtime_error>("Solver '" + solver_name + "' not supported",
+                             log_location) {
     }
 };
 
-class GenericSolverException: public std::runtime_error
-{
+class GenericSolverException : public std::runtime_error {
 public:
-    GenericSolverException(const std::string& message):
-        std::runtime_error(message)
-    {
+    GenericSolverException(const std::string &message): std::runtime_error(message) {
     }
 };
 
-class NotImplementedFeatureSolverException: public std::runtime_error
-{
+class NotImplementedFeatureSolverException : public std::runtime_error {
 public:
-    NotImplementedFeatureSolverException(const std::string& message):
-        std::runtime_error(message)
-    {
+    NotImplementedFeatureSolverException(const std::string &message): std::runtime_error(message) {
     }
 };
 
 // Definition of optimality codes
-enum SOLVER_STATUS
-{
+enum SOLVER_STATUS {
     OPTIMAL,
     INFEASIBLE,
     UNBOUNDED,
@@ -196,14 +162,15 @@ enum SOLVER_STATUS
  * \class class SolverAbstract
  * \brief Virtual class to implement solvers methods
  */
-class SolverAbstract
-{
+class SolverAbstract {
 public:
-    std::vector<std::string> SOLVER_STRING_STATUS = {"OPTIMAL",
-                                                     "INFEASIBLE",
-                                                     "UNBOUNDED",
-                                                     "INForUNBOUND",
-                                                     "UNKNOWN"};
+    std::vector<std::string> SOLVER_STRING_STATUS = {
+        "OPTIMAL",
+        "INFEASIBLE",
+        "UNBOUNDED",
+        "INForUNBOUND",
+        "UNKNOWN"
+    };
 
     /*************************************************************************************************
     ----------------------------------------    ATTRIBUTES
@@ -211,10 +178,10 @@ public:
     *************************************************************************************************/
 
 public:
-    std::string _name;                           /*!< Name of the problem */
+    std::string _name; /*!< Name of the problem */
     typedef std::shared_ptr<SolverAbstract> Ptr; /*!< Ptr to the solver */
-    std::list<std::ostream*>
-      _streams; /*!< List of streams to print the output (default std::cout) */
+    std::list<std::ostream *>
+    _streams; /*!< List of streams to print the output (default std::cout) */
 
     /*************************************************************************************************
     -----------------------------------    Constructor/Desctructor
@@ -225,7 +192,8 @@ public:
     /**
      * @brief constructor of SolverAbstract class : does nothing
      */
-    SolverAbstract(){};
+    SolverAbstract() {
+    };
 
     /**
      * @brief Copy constructor, copy the problem "toCopy" in memory and name it
@@ -235,12 +203,14 @@ public:
      * @param toCopy : Pointer to an AbstractSolver object, containing a solver
      * object to copy
      */
-    SolverAbstract(const std::string& name, const SolverAbstract::Ptr toCopy){};
+    SolverAbstract(const std::string &name, const SolverAbstract::Ptr toCopy) {
+    };
 
     /**
      * @brief destructor of SolverAbstract class : does nothing
      */
-    virtual ~SolverAbstract(){};
+    virtual ~SolverAbstract() {
+    };
 
     /**
      * @brief Returns number of instances of solver currently in memory
@@ -261,12 +231,11 @@ public:
     /**
      * @brief returns the list of streams used by the solver instance
      */
-    std::list<std::ostream*>& get_stream()
-    {
+    std::list<std::ostream *> &get_stream() {
         return _streams;
     }
 
-    FILE* _fp = nullptr;
+    FILE *_fp = nullptr;
     std::filesystem::path _log_file = "";
 
     /**
@@ -274,13 +243,11 @@ public:
      *
      * @param stream  : reference to a std::ostream object
      */
-    void add_stream(std::ostream& stream)
-    {
+    void add_stream(std::ostream &stream) {
         get_stream().push_back(&stream);
     }
 
-    void set_fp(FILE* fp)
-    {
+    void set_fp(FILE *fp) {
         _fp = fp;
     }
 
@@ -293,11 +260,9 @@ public:
                             used to print the error message.
     */
     void zero_status_check(int status,
-                           const std::string& action_failed,
-                           const std::string& log_location) const
-    {
-        if (status != 0)
-        {
+                           const std::string &action_failed,
+                           const std::string &log_location) const {
+        if (status != 0) {
             throw InvalidStatusException(status, action_failed, log_location);
         }
     }
@@ -329,14 +294,14 @@ public:
      *
      * @param name   : name of the file to write
      */
-    virtual void write_prob_mps(const std::filesystem::path& filename) = 0;
+    virtual void write_prob_mps(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief writes an optimization problem in a LP file
      *
      * @param name   : name of the file to write
      */
-    virtual void write_prob_lp(const std::filesystem::path& filename) = 0;
+    virtual void write_prob_lp(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief write an optimisation problem in a file
@@ -345,7 +310,7 @@ public:
      *
      * @param name   : name of the file to read
      */
-    virtual void save_prob(const std::filesystem::path& filename) = 0;
+    virtual void save_prob(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief Writes the current basis to a file for later input into the
@@ -353,21 +318,21 @@ public:
      *
      * @param filename    : file name where the basis is written
      */
-    virtual void write_basis(const std::filesystem::path& filename) = 0;
+    virtual void write_basis(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief reads an optimization problem contained in a MPS file
      *
      * @param name   : name of the file to read
      */
-    virtual void read_prob_mps(const std::filesystem::path& filename) = 0;
+    virtual void read_prob_mps(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief reads an optimization problem contained in a MPS file
      *
      * @param name   : name of the file to read
      */
-    virtual void read_prob_lp(const std::filesystem::path& filename) = 0;
+    virtual void read_prob_lp(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief read an optimisation problem from a file
@@ -376,7 +341,7 @@ public:
      *
      * @param name   : name of the file to read
      */
-    virtual void restore_prob(const std::filesystem::path& filename) = 0;
+    virtual void restore_prob(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief Instructs the optimizer to read in a previously saved basis from a
@@ -384,7 +349,7 @@ public:
      *
      * @param filename: File name where the basis is to be read
      */
-    virtual void read_basis(const std::filesystem::path& filename) = 0;
+    virtual void read_basis(const std::filesystem::path &filename) = 0;
 
     /**
      * @brief copy an existing problem
@@ -424,7 +389,7 @@ public:
      * @brief returns the objective function coefficients for the columns in a
      * given range
      */
-    virtual void get_obj(double* obj, int first, int last) const = 0;
+    virtual void get_obj(double *obj, int first, int last) const = 0;
 
     /**
      * @brief Set the objective function coefficients to zero
@@ -435,7 +400,7 @@ public:
      * @brief Set the objective function coefficients for the columns in a
      * given range
      */
-    virtual void set_obj(const double* obj, int first, int last) = 0;
+    virtual void set_obj(const double *obj, int first, int last) = 0;
 
     /**
     * @brief get coefficients of rows from index first to last
@@ -452,14 +417,14 @@ public:
     * @param first      : first index of row to get
     * @param last       : last index of row to get
     */
-    virtual void get_rows(int* mstart,
-                          int* mclind,
-                          double* dmatval,
+    virtual void get_rows(int *mstart,
+                          int *mclind,
+                          double *dmatval,
                           int size,
-                          int* nels,
+                          int *nels,
                           int first,
                           int last) const
-      = 0;
+    = 0;
 
     /**
     * @brief Returns the row types for the rows in a given range.
@@ -469,7 +434,7 @@ public:
     * @param first  : first index of row to get
     * @param last   : last index of row to get
     */
-    virtual void get_row_type(char* qrtype, int first, int last) const = 0;
+    virtual void get_row_type(char *qrtype, int first, int last) const = 0;
 
     /**
      * @brief Returns the right-hand sides of the rows in a given range.
@@ -479,7 +444,7 @@ public:
      * @param first  : first index of row to get
      * @param last   : last index of row to get
      */
-    virtual void get_rhs(double* rhs, int first, int last) const = 0;
+    virtual void get_rhs(double *rhs, int first, int last) const = 0;
 
     /**
     * @brief Returns the right hand side range values for the rows in a given
@@ -490,7 +455,7 @@ public:
     * @param first  : first index of row to get
     * @param last   : last index of row to get
     */
-    virtual void get_rhs_range(double* range, int first, int last) const = 0;
+    virtual void get_rhs_range(double *range, int first, int last) const = 0;
 
     /**
     * @brief Returns the column types for the columns in a given range.
@@ -501,7 +466,7 @@ public:
     * @param first      : first index of row to get
     * @param last       : last index of row to get
     */
-    virtual void get_col_type(char* coltype, int first, int last) const = 0;
+    virtual void get_col_type(char *coltype, int first, int last) const = 0;
 
     /**
      * @brief Returns the lower bounds for variables in a given range.
@@ -511,7 +476,7 @@ public:
      * @param first  : First column in the range.
      * @param last   : Last column in the range.
      */
-    virtual void get_lb(double* lb, int fisrt, int last) const = 0;
+    virtual void get_lb(double *lb, int fisrt, int last) const = 0;
 
     /**
      * @brief Returns the upper bounds for variables in a given range.
@@ -521,21 +486,21 @@ public:
      * @param first  : First column in the range.
      * @param last   : Last column in the range.
      */
-    virtual void get_ub(double* ub, int fisrt, int last) const = 0;
+    virtual void get_ub(double *ub, int fisrt, int last) const = 0;
 
     /**
      * @brief Returns the index of row named "name"
      *
      * @param name : name of row to get the index
      */
-    virtual int get_row_index(const std::string& name) = 0;
+    virtual int get_row_index(const std::string &name) = 0;
 
     /**
      * @brief Returns the index of column named "name"
      *
      * @param name : name of column to get the index
      */
-    virtual int get_col_index(const std::string& name) = 0;
+    virtual int get_col_index(const std::string &name) = 0;
 
     /**
      * @brief Returns the names of row from index first to last
@@ -606,14 +571,14 @@ public:
     */
     virtual void add_rows(int newrows,
                           int newnz,
-                          const char* qrtype,
-                          const double* rhs,
-                          const double* range,
-                          const int* mstart,
-                          const int* mclind,
-                          const double* dmatval,
-                          const std::vector<std::string>& row_names)
-      = 0;
+                          const char *qrtype,
+                          const double *rhs,
+                          const double *range,
+                          const int *mstart,
+                          const int *mclind,
+                          const double *dmatval,
+                          const std::vector<std::string> &row_names)
+    = 0;
 
     /**
     * @brief Adds new columns to the problem
@@ -637,14 +602,14 @@ public:
     */
     virtual void add_cols(int newcol,
                           int newnz,
-                          const double* objx,
-                          const int* mstart,
-                          const int* mrwind,
-                          const double* dmatval,
-                          const double* bdl,
-                          const double* bdu,
-                          const std::vector<std::string>& col_names)
-      = 0;
+                          const double *objx,
+                          const int *mstart,
+                          const int *mrwind,
+                          const double *dmatval,
+                          const double *bdl,
+                          const double *bdu,
+                          const std::vector<std::string> &col_names)
+    = 0;
 
     /**
      * @brief Adds a name to a row or a column
@@ -654,9 +619,10 @@ public:
      * names.
      * @param indice : index of the row or of the column.
      */
-    virtual void add_name(int type, const char* cnames, int indice) = 0;
-    virtual void add_names(int type, const std::vector<std::string>& cnames, int first, int end)
-      = 0;
+    virtual void add_name(int type, const char *cnames, int indice) = 0;
+
+    virtual void add_names(int type, const std::vector<std::string> &cnames, int first, int end)
+    = 0;
 
     /**
      * @brief Change coefficients in objective function
@@ -664,7 +630,7 @@ public:
      * @param mindex : indices of columns to modify
      * @param obj    : Values to set in objective function
      */
-    virtual void chg_obj(const std::vector<int>& mindex, const std::vector<double>& obj) = 0;
+    virtual void chg_obj(const std::vector<int> &mindex, const std::vector<double> &obj) = 0;
 
     /**
      * @brief Change the problem's objective function sense to minimize or
@@ -683,10 +649,10 @@ public:
      * both)
      * @param bnd    : new values for the bounds
      */
-    virtual void chg_bounds(const std::vector<int>& mindex,
-                            const std::vector<char>& qbtype,
-                            const std::vector<double>& bnd)
-      = 0;
+    virtual void chg_bounds(const std::vector<int> &mindex,
+                            const std::vector<char> &qbtype,
+                            const std::vector<double> &bnd)
+    = 0;
 
     /**
      * @brief Change type of some columns
@@ -695,7 +661,7 @@ public:
      * @param mindex : indices of columns to modify
      * @param qctype : New types of columns
      */
-    virtual void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) = 0;
+    virtual void chg_col_type(const std::vector<int> &mindex, const std::vector<char> &qctype) = 0;
 
     /**
      * @brief Change rhs of a row
@@ -720,7 +686,7 @@ public:
      * @param id_row : index of the row
      * @param name   : new name of the row
      */
-    virtual void chg_row_name(int id_row, const std::string& name) = 0;
+    virtual void chg_row_name(int id_row, const std::string &name) = 0;
 
     /**
      * @brief Change the name of a variable
@@ -728,7 +694,7 @@ public:
      * @param id_col : index of the column
      * @param name   : new name of the column
      */
-    virtual void chg_col_name(int id_col, const std::string& name) = 0;
+    virtual void chg_col_name(int id_col, const std::string &name) = 0;
 
     /*************************************************************************************************
     -----------------------------    Methods to solve the problem
@@ -767,7 +733,7 @@ public:
     the columns in the constraint matrix. The values depend on the solver used.May
     be NULL if not required.
     */
-    virtual void get_basis(int* rstatus, int* cstatus) const = 0;
+    virtual void get_basis(int *rstatus, int *cstatus) const = 0;
 
     /**
      * @brief Get the optimal value of a MIP problem (available after method
@@ -801,14 +767,14 @@ public:
      * @param duals      : values of dual variables
      * @param reduced_cost: reduced_cost in an optimal basis
      */
-    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) = 0;
+    virtual void get_lp_sol(double *primals, double *duals, double *reduced_costs) const = 0;
 
     /**
      * @brief Get MIP solution of a problem (available after method "solve_mip")
      *
      * @param primals    : values of primal variables
      */
-    virtual void get_mip_sol(double* primals) = 0;
+    virtual void get_mip_sol(double *primals) = 0;
 
     /*************************************************************************************************
     ------------------------    Methods to set algorithm or logs levels
@@ -828,7 +794,7 @@ public:
      *
      * @param algo : string of the name of the algorithm
      */
-    virtual void set_algorithm(const std::string& algo) = 0;
+    virtual void set_algorithm(const std::string &algo) = 0;
 
     /**
      * @brief Sets the maximum number of threads used to perform optimization

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -208,7 +208,7 @@ public:
     virtual double get_mip_value() const override;
     virtual double get_lp_value() const override;
     virtual int get_splex_num_of_ite_last() const override;
-    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) override;
+    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) const override;
     virtual void get_mip_sol(double* primals) override;
 
     /*************************************************************************************************

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -206,7 +206,7 @@ public:
     virtual double get_mip_value() const override;
     virtual double get_lp_value() const override;
     virtual int get_splex_num_of_ite_last() const override;
-    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) override;
+    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) const override;
     virtual void get_mip_sol(double* primals) override;
 
     /*************************************************************************************************

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -204,7 +204,7 @@ public:
     virtual double get_mip_value() const override;
     virtual double get_lp_value() const override;
     virtual int get_splex_num_of_ite_last() const override;
-    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) override;
+    virtual void get_lp_sol(double* primals, double* duals, double* reduced_costs) const override;
     virtual void get_mip_sol(double* primals) override;
 
     /*************************************************************************************************

--- a/src/python/antares_xpansion/input_checker.py
+++ b/src/python/antares_xpansion/input_checker.py
@@ -127,7 +127,7 @@ def _check_candidate_option_type(option, value):
         if option_type is None:
             logger.error(
                 f"check_candidate_option_type: {option} option not recognized in candidates file.\n" +
-                "Authorized options are: %s" + '\n'.join(
+                "Valid options are: %s" + '\n'.join(
                     candidate_options_type.keys()))
             raise UnrecognizedCandidateOptionType
         if option_type == "string":

--- a/src/python/antares_xpansion/input_checker.py
+++ b/src/python/antares_xpansion/input_checker.py
@@ -552,11 +552,7 @@ def _check_setting_option_value(option, value):
     ):
         return True
 
-    if (
-            (option == "optimality_gap")
-            or (option == "relative_gap")
-            or (option == "relaxed_optimality_gap")
-    ):
+    if option in ("optimality_gap", "relative_gap", "relaxed_optimality_gap"):
         if float(value) >= 0:
             return True
         else:

--- a/src/python/antares_xpansion/input_checker.py
+++ b/src/python/antares_xpansion/input_checker.py
@@ -127,7 +127,7 @@ def _check_candidate_option_type(option, value):
         if option_type is None:
             logger.error(
                 f"check_candidate_option_type: {option} option not recognized in candidates file.\n" +
-                "Authorized options are: %s"+'\n'.join(
+                "Authorized options are: %s" + '\n'.join(
                     candidate_options_type.keys()))
             raise UnrecognizedCandidateOptionType
         if option_type == "string":
@@ -221,9 +221,9 @@ def _check_candidate_attributes(ini_file):
         for (option, value) in ini_file.items(each_section):
             if not _check_candidate_option_type(option, value):
                 err_msg += f"value {value} for option {option} has the wrong type, it has to be {candidate_options_type[option]}\n"
-    
-    if(err_msg!=""):
-        logger.error(err_msg)                
+
+    if (err_msg != ""):
+        logger.error(err_msg)
         raise CandidateFileWrongTypeValue
 
 
@@ -344,23 +344,19 @@ class NotHandledOption(Exception):
 class NotHandledValue(Exception):
     pass
 
+
 # return ->tuple[is_a_bool: bool, result: bool]
 
 
 # -> tuple[bool, bool]: not working with python <3.9
-def str_to_bool(my_str: str):
-    if my_str in ["true", "True", "TRUE", "1"]:
-        return (True, True)
-    elif my_str in ["false", "False", "False", "0"]:
-        return (True, False)
-    else:
-        return (False, False)
+def is_bool(my_str: str):
+    return my_str.lower() in ("true", "false", "1", "0")
+
 
 type_str = str
 type_int = int
 type_float = float
 type_bool = bool
-
 
 # "option": (type, legal_value(s))
 options_types_and_legal_values = {
@@ -422,7 +418,7 @@ def _check_setting_option_type(option, value):
                     'check_setting_option_type: Illegal %s option in type, integer is expected .' % option)
                 return False
     elif option_type == type_bool:
-        [is_a_bool, ret] = str_to_bool(value)
+        is_a_bool = is_bool(value)
         if is_a_bool:
             return True
         else:
@@ -523,8 +519,6 @@ def _check_batch_size(value) -> bool:
         raise BatchSizeValueError
 
 
-
-
 def _check_separation(value) -> bool:
     if 0 <= float(value) <= 1:
         return True
@@ -554,14 +548,14 @@ def _check_setting_option_value(option, value):
     skip_verif = ["yearly-weights", "additional-constraints", "solver"]
 
     if ((legal_values is not None) and (value in legal_values)) or (
-        option in skip_verif
+            option in skip_verif
     ):
         return True
 
     if (
-        (option == "optimality_gap")
-        or (option == "relative_gap")
-        or (option == "relaxed_optimality_gap")
+            (option == "optimality_gap")
+            or (option == "relative_gap")
+            or (option == "relaxed_optimality_gap")
     ):
         if float(value) >= 0:
             return True

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -5,14 +5,14 @@
 # ===========================================================================
 # External requirements
 # ===========================================================================
-find_package (GTest REQUIRED)
+find_package(GTest REQUIRED)
 
-message ("Gtest found here: " ${GTEST_INCLUDE_DIRS})
+message("Gtest found here: " ${GTEST_INCLUDE_DIRS})
 find_package(MPI REQUIRED)
 
-if(UNIX)
-set(CMAKE_CXX_COMPILER ${MPI_CXX_COMPILER})
-endif()
+if (UNIX)
+    set(CMAKE_CXX_COMPILER ${MPI_CXX_COMPILER})
+endif ()
 # ===========================================================================
 # Targets
 # ===========================================================================
@@ -26,6 +26,7 @@ add_subdirectory(helpers)
 add_subdirectory(json_output_writer)
 add_subdirectory(logger)
 add_subdirectory(lp_namer)
+add_subdirectory(merge_mps)
 add_subdirectory(outer_loop)
 add_subdirectory(restart_benders)
 add_subdirectory(sensitivity)

--- a/tests/cpp/TestDoubles/InMemoryWriter.h
+++ b/tests/cpp/TestDoubles/InMemoryWriter.h
@@ -7,9 +7,12 @@
 #include "antares-xpansion/benders/output/OutputWriter.h"
 
 namespace Xpansion::Test {
-    class WriterNOOPStub : public Output::OutputWriter {
+    class InMemoryWriter : public Output::OutputWriter {
     public:
+        Output::SolutionData solution_data_;
+
         void update_solution(const Output::SolutionData &solution_data) override {
+            solution_data_ = solution_data;
         }
 
         void dump() override {

--- a/tests/cpp/TestDoubles/LoggerStub.h
+++ b/tests/cpp/TestDoubles/LoggerStub.h
@@ -6,35 +6,76 @@
 
 #include "antares-xpansion/xpansion_interfaces/ILogger.h"
 
-class LoggerNOOPStub : public ILogger {
- public:
-  void display_message(const std::string& str) override {}
-  void display_message(const std::string& str, LogUtils::LOGLEVEL level,
-                       const std::string& context) override {}
-  void PrintIterationSeparatorBegin() override {
-    //
-  }
-  void PrintIterationSeparatorEnd() override {
-    //
-  }
-  void log_at_initialization(const int it_number) override {}
-  void log_iteration_candidates(const LogData& d) override {}
-  void log_master_solving_duration(double durationInSeconds) override {}
-  void LogSubproblemsSolvingWalltime(double durationInSeconds) override {}
-  void LogSubproblemsSolvingCumulativeCpuTime(
-      double durationInSeconds) override {}
-  void log_at_iteration_end(const LogData& d) override {}
-  void log_at_ending(const LogData& d) override {}
-  void log_total_duration(double durationInSeconds) override {}
-  void log_stop_criterion_reached(
-      const StoppingCriterion stopping_criterion) override {}
-  void display_restart_message() override {}
-  void restart_elapsed_time(const double elapsed_time) override {}
-  void number_of_iterations_before_restart(const int num_iterations) override {}
-  void restart_best_iteration(const int best_iterations) override {}
-  void restart_best_iterations_infos(
-      const LogData& best_iterations_data) override {}
-  void LogAtInitialRelaxation() override {}
-  void LogAtSwitchToInteger() override {}
-  void cumulative_number_of_sub_problem_solved(int number) override {}
-};
+namespace Xpansion::Test {
+    class LoggerNOOPStub : public ILogger {
+    public:
+        void display_message(const std::string &str) override {
+        }
+
+        void display_message(const std::string &str, LogUtils::LOGLEVEL level,
+                             const std::string &context) override {
+        }
+
+        void PrintIterationSeparatorBegin() override {
+            //
+        }
+
+        void PrintIterationSeparatorEnd() override {
+            //
+        }
+
+        void log_at_initialization(const int it_number) override {
+        }
+
+        void log_iteration_candidates(const LogData &d) override {
+        }
+
+        void log_master_solving_duration(double durationInSeconds) override {
+        }
+
+        void LogSubproblemsSolvingWalltime(double durationInSeconds) override {
+        }
+
+        void LogSubproblemsSolvingCumulativeCpuTime(
+            double durationInSeconds) override {
+        }
+
+        void log_at_iteration_end(const LogData &d) override {
+        }
+
+        void log_at_ending(const LogData &d) override {
+        }
+
+        void log_total_duration(double durationInSeconds) override {
+        }
+
+        void log_stop_criterion_reached(
+            const StoppingCriterion stopping_criterion) override {
+        }
+
+        void display_restart_message() override {
+        }
+
+        void restart_elapsed_time(const double elapsed_time) override {
+        }
+
+        void number_of_iterations_before_restart(const int num_iterations) override {
+        }
+
+        void restart_best_iteration(const int best_iterations) override {
+        }
+
+        void restart_best_iterations_infos(
+            const LogData &best_iterations_data) override {
+        }
+
+        void LogAtInitialRelaxation() override {
+        }
+
+        void LogAtSwitchToInteger() override {
+        }
+
+        void cumulative_number_of_sub_problem_solved(int number) override {
+        }
+    };
+}

--- a/tests/cpp/benders/benders_sequential_test.cpp
+++ b/tests/cpp/benders/benders_sequential_test.cpp
@@ -10,7 +10,7 @@
 #include "gtest/gtest.h"
 
 class BendersSequentialDouble : public BendersSequential {
- public:
+public:
   bool parametrized_stop = false;
   int parametrized_it = 0;
   int parametrized_nsubproblem = 0;
@@ -24,9 +24,10 @@ class BendersSequentialDouble : public BendersSequential {
   bool _setDataPostRelaxationCall = false;
 
   explicit BendersSequentialDouble(
-      BendersBaseOptions const &options, Logger &logger, std::shared_ptr<Output::OutputWriter> writer,
-      std::shared_ptr<MathLoggerDriver> mathLoggerDriver)
-      : BendersSequential(options, logger, writer, mathLoggerDriver) {};
+    BendersBaseOptions const &options, Logger &logger, std::shared_ptr<Output::OutputWriter> writer,
+    std::shared_ptr<MathLoggerDriver> mathLoggerDriver)
+    : BendersSequential(options, logger, writer, mathLoggerDriver) {
+  };
 
   void init_data() override {
     BendersBase::init_data();
@@ -41,16 +42,31 @@ class BendersSequentialDouble : public BendersSequential {
     return BendersSequential::get_master();
   };
 
-  void get_master_value() override {};
-  void BuildCut() override {};
+  void get_master_value() override {
+  };
+
+  void BuildCut() override {
+  };
   void compute_ub() override { _data.ub = parametrized_ub; };
   CurrentIterationData get_data() const { return _data; }
-  void write_basis() const override {};
-  void EndWritingInOutputFile() const override {};
-  void UpdateTrace() override {};
-  void post_run_actions() const override {};
-  void SaveCurrentBendersData() override {};
-  void free() override {};
+
+  void write_basis() const override {
+  };
+
+  void EndWritingInOutputFile() const override {
+  };
+
+  void UpdateTrace() override {
+  };
+
+  void post_run_actions() const override {
+  };
+
+  void SaveCurrentBendersData() override {
+  };
+
+  void free() override {
+  };
   SubproblemsMapPtr problems() const { return GetSubProblemMap(); }
 
   void DeactivateIntegrityConstraints() const override {
@@ -68,6 +84,7 @@ class BendersSequentialDouble : public BendersSequential {
     _setDataPreRelaxationCall = true;
     BendersBase::SetDataPreRelaxation();
   }
+
   void ResetDataPostRelaxation() override {
     _setDataPostRelaxationCall = true;
     BendersBase::ResetDataPostRelaxation();
@@ -78,20 +95,23 @@ class BendersSequentialDouble : public BendersSequential {
     parametrized_nsubproblem = nsubproblem;
     _data.nsubproblem = nsubproblem;
   }
+
   void set_bounds(double lb, double best_ub) {
     parametrized_lb = lb;
     parametrized_best_ub = best_ub;
   }
+
   void set_bestx(Point x_out, Point x_in) {
     _data.x_out = x_out;
     _data.x_in = x_in;
   }
+
   void set_ub(double ub) { parametrized_ub = ub; }
   void set_it(int it) { parametrized_it = it; }
 };
 
 class BendersSequentialTest : public ::testing::Test {
- public:
+public:
   Logger logger;
   std::shared_ptr<MathLoggerDriver> mathLoggerDriver;
   std::shared_ptr<Output::OutputWriter> writer;
@@ -99,9 +119,9 @@ class BendersSequentialTest : public ::testing::Test {
   const std::filesystem::path mps_dir = data_test_dir / "mps";
   std::filesystem::path tmpDir;
 
- protected:
+protected:
   void SetUp() override {
-    logger = std::make_shared<LoggerNOOPStub>();
+    logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
     writer = std::make_shared<Output::JsonWriter>(std::make_shared<Clock>(),
                                                   std::tmpnam(nullptr));
     original_dir = std::filesystem::current_path();
@@ -123,7 +143,7 @@ class BendersSequentialTest : public ::testing::Test {
 
     std::filesystem::copy(data_dir, tmpDir,
                           std::filesystem::copy_options::recursive |
-                              std::filesystem::copy_options::update_existing);
+                          std::filesystem::copy_options::update_existing);
   }
 
   BaseOptions init_base_options(const std::string &solver = "COIN") const {
@@ -144,8 +164,8 @@ class BendersSequentialTest : public ::testing::Test {
   }
 
   BendersBaseOptions init_benders_options(
-      MasterFormulation master_formulation, int max_iter, double relaxed_gap,
-      double sep_param, const std::string &solver = "COIN") const {
+    MasterFormulation master_formulation, int max_iter, double relaxed_gap,
+    double sep_param, const std::string &solver = "COIN") const {
     BaseOptions base_options(init_base_options(solver));
     BendersBaseOptions options(base_options);
 
@@ -170,25 +190,26 @@ class BendersSequentialTest : public ::testing::Test {
   }
 
   BendersSequentialDouble init_benders_sequential(
-      MasterFormulation master_formulation, int max_iter, double relaxed_gap,
-      double sep_param, const std::string &solver = "COIN",
-      ProblemsFormat format = ProblemsFormat::MPS_FILE) {
+    MasterFormulation master_formulation, int max_iter, double relaxed_gap,
+    double sep_param, const std::string &solver = "COIN",
+    ProblemsFormat format = ProblemsFormat::MPS_FILE) {
     BendersBaseOptions options = init_benders_options(
-        master_formulation, max_iter, relaxed_gap, sep_param, solver);
+      master_formulation, max_iter, relaxed_gap, sep_param, solver);
     options.PROBLEMS_FORMAT = format;
     return BendersSequentialDouble(options, logger, writer, mathLoggerDriver);
   }
 
   std::vector<char> get_nb_units_col_types(
-      const BendersSequentialDouble &benders) const {
+    const BendersSequentialDouble &benders) const {
     char col_type;
     std::vector<char> nb_units_col_types;
-    for (auto col_id : benders.get_master()->get_id_nb_units()) {
+    for (auto col_id: benders.get_master()->get_id_nb_units()) {
       benders.get_master()->solver()->get_col_type(&col_type, col_id, col_id);
       nb_units_col_types.push_back(col_type);
     }
     return nb_units_col_types;
   }
+
   std::filesystem::path original_dir;
 };
 
@@ -199,7 +220,7 @@ TEST_F(BendersSequentialTest, MasterNotRelaxedWhenSepSetToOne) {
   double relaxed_gap = 1e-2;
   double sep_param = 1;
   BendersSequentialDouble benders = init_benders_sequential(
-      master_formulation, max_iter, relaxed_gap, sep_param);
+    master_formulation, max_iter, relaxed_gap, sep_param);
 
   benders.set_data(true, 0);
 
@@ -219,7 +240,7 @@ TEST_F(BendersSequentialTest, MasterRelaxedWhenSepLowerThanOne) {
   double relaxed_gap = 1e-2;
   double sep_param = 0.7;
   BendersSequentialDouble benders = init_benders_sequential(
-      master_formulation, max_iter, relaxed_gap, sep_param);
+    master_formulation, max_iter, relaxed_gap, sep_param);
 
   benders.set_data(true, 0);
   benders.launch();
@@ -239,7 +260,7 @@ TEST_F(BendersSequentialTest, ReactivateIntConstraintAfterRelaxedGapReached) {
   double relaxed_gap = 1e-2;
   double sep_param = 0.7;
   BendersSequentialDouble benders = init_benders_sequential(
-      master_formulation, max_iter, relaxed_gap, sep_param);
+    master_formulation, max_iter, relaxed_gap, sep_param);
 
   benders.set_data(false, 0);
   benders.set_bounds(1000, 1001);
@@ -261,7 +282,7 @@ TEST_F(BendersSequentialTest,
   double relaxed_gap = 1e-5;
   double sep_param = 0.7;
   BendersSequentialDouble benders = init_benders_sequential(
-      master_formulation, max_iter, relaxed_gap, sep_param);
+    master_formulation, max_iter, relaxed_gap, sep_param);
 
   int expec_benders_run_it = 2;
 
@@ -286,7 +307,7 @@ TEST_F(BendersSequentialTest, CheckDataPostRelaxation) {
   double relaxed_gap = 1e-2;
   double sep_param = 0.7;
   BendersSequentialDouble benders = init_benders_sequential(
-      master_formulation, max_iter, relaxed_gap, sep_param);
+    master_formulation, max_iter, relaxed_gap, sep_param);
 
   benders.set_data(false, 0);
   benders.set_bounds(1000, 1001);
@@ -317,7 +338,7 @@ TEST_F(BendersSequentialTest, CheckInOutDataWhithoutImprovement) {
   Point x_in = {{"x1", 3}, {"x2", 6}};
 
   BendersSequentialDouble benders = init_benders_sequential(
-      master_formulation, max_iter, relaxed_gap, sep_param);
+    master_formulation, max_iter, relaxed_gap, sep_param);
 
   benders.set_data(false, 0);
   benders.set_bounds(init_lb, init_ub);
@@ -326,7 +347,7 @@ TEST_F(BendersSequentialTest, CheckInOutDataWhithoutImprovement) {
   benders.set_ub(current_ub);
 
   Point expec_x_cut;
-  for (const auto &[coord, val] : x_out) {
+  for (const auto &[coord, val]: x_out) {
     expec_x_cut[coord] =
         sep_param * x_out[coord] + (1 - sep_param) * x_in[coord];
   }
@@ -361,7 +382,7 @@ TEST_F(BendersSequentialTest, CheckInOutDataWhenImprovement) {
   Point x_in = {{"x1", 3}, {"x2", 6}};
 
   BendersSequentialDouble benders = init_benders_sequential(
-      master_formulation, max_iter, relaxed_gap, sep_param);
+    master_formulation, max_iter, relaxed_gap, sep_param);
 
   benders.set_data(false, 0);
   benders.set_bounds(init_lb, init_ub);
@@ -370,7 +391,7 @@ TEST_F(BendersSequentialTest, CheckInOutDataWhenImprovement) {
   benders.set_ub(current_ub);
 
   Point expec_x_cut;
-  for (const auto &[coord, val] : x_out) {
+  for (const auto &[coord, val]: x_out) {
     expec_x_cut[coord] =
         sep_param * x_out[coord] + (1 - sep_param) * x_in[coord];
   }
@@ -393,7 +414,7 @@ auto solvers() {
   std::vector<std::string> solvers_name;
   solvers_name.push_back("COIN");
   if (LoadXpress::XpressLoader xpressLoader;
-      xpressLoader.XpressIsCorrectlyInstalled()) {
+    xpressLoader.XpressIsCorrectlyInstalled()) {
     solvers_name.push_back("XPRESS");
   }
   return solvers_name;
@@ -401,12 +422,13 @@ auto solvers() {
 
 class BendersSequentialTestBySolver
     : public BendersSequentialTest,
-      public ::testing::WithParamInterface<std::string> {};
+      public ::testing::WithParamInterface<std::string> {
+};
 
 TEST_P(BendersSequentialTestBySolver, CreateMasterProblemProperly) {
   copyMasterMps();
   BendersSequentialDouble benders = init_benders_sequential(
-      MasterFormulation::RELAXED, 100, 1e-4, 1e-6, GetParam());
+    MasterFormulation::RELAXED, 100, 1e-4, 1e-6, GetParam());
   benders.InitializeProblems();
 
   // Assert that the master problem has been created properly
@@ -436,7 +458,8 @@ TEST_P(BendersSequentialTestBySolver, CreateProblemsProperly) {
 class BendersSequentialTestSolverAndFormat
     : public BendersSequentialTest,
       public ::testing::WithParamInterface<
-          std::tuple<std::string, ProblemsFormat>> {};
+        std::tuple<std::string, ProblemsFormat> > {
+};
 
 // Master svf
 TEST_P(BendersSequentialTestBySolver, CreateMasterProblemProperlyWhenRestore) {
@@ -485,7 +508,7 @@ TEST_P(BendersSequentialTestBySolver, CreateProblemsProperlyWhenRestore) {
   SolverFactory factory;
   auto &&solver =
       factory.create_solver(GetParam() == "COIN" ? "CBC" : GetParam());
-  for (std::string problem : {"SP1", "SP2"}) {
+  for (std::string problem: {"SP1", "SP2"}) {
     solver->read_prob_mps(tmpDir / (problem + ".mps"));
     std::filesystem::remove(tmpDir / (problem + ".mps"));
     solver->save_prob(tmpDir / problem);

--- a/tests/cpp/benders/benders_sequential_test.cpp
+++ b/tests/cpp/benders/benders_sequential_test.cpp
@@ -446,7 +446,7 @@ TEST_P(BendersSequentialTestBySolver, CreateProblemsProperly) {
   BendersSequentialDouble benders(options.get_benders_options(), logger, writer,
                                   mathLoggerDriver);
   auto coupling_map = CouplingMapGenerator::BuildInput(options.STRUCTURE_FILE,
-                                                       logger, "Benders");
+                                                       logger.get(), "Benders");
   benders.set_input_map(coupling_map);
   benders.InitializeProblems();
   auto &&problems = benders.problems();
@@ -519,7 +519,7 @@ TEST_P(BendersSequentialTestBySolver, CreateProblemsProperlyWhenRestore) {
   BendersSequentialDouble benders(options.get_benders_options(), logger, writer,
                                   mathLoggerDriver);
   auto coupling_map = CouplingMapGenerator::BuildInput(options.STRUCTURE_FILE,
-                                                       logger, "Benders");
+                                                       logger.get(), "Benders");
   benders.set_input_map(coupling_map);
   benders.InitializeProblems();
   auto &&problems = benders.problems();

--- a/tests/cpp/lp_namer/NOOPSolver.h
+++ b/tests/cpp/lp_namer/NOOPSolver.h
@@ -82,7 +82,7 @@ class NOOPSolver : public SolverAbstract {
   virtual double get_lp_value() const override { return 0; }
   virtual int get_splex_num_of_ite_last() const override { return 0; }
   virtual void get_lp_sol(double *primals, double *duals,
-                          double *reduced_costs) override {}
+                          double *reduced_costs) const override {}
   virtual void get_mip_sol(double *primals) override {}
   virtual void set_output_log_level(int loglevel) override {}
   virtual void set_algorithm(const std::string &algo) override {}

--- a/tests/cpp/merge_mps/CMakeLists.txt
+++ b/tests/cpp/merge_mps/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(merge_mps_test merge_mps_test.cpp)
+
+find_package(fmt REQUIRED)
+target_link_libraries(merge_mps_test
+        PRIVATE
+        antaresXpansion::merge_mps_core
+        tests_utils
+        GTest::Main
+        fmt::fmt
+)
+
+target_include_directories(merge_mps_test
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../TestDoubles/
+)
+
+add_test(NAME unit_merge_mps COMMAND merge_mps_test)
+set_property(TEST unit_merge_mps PROPERTY LABELS unit)

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -16,7 +16,7 @@ protected:
         writer_ = std::make_shared<Xpansion::Test::InMemoryWriter>();
 
         options_.SOLVER_NAME = "COIN";
-        options_.STRUCTURE_FILE = tmp_dir_ / "structure_file.txt";
+        options_.STRUCTURE_FILE = (tmp_dir_ / "structure_file.txt").string();
         options_.OUTPUTROOT = tmp_dir_.string();
     }
 
@@ -43,7 +43,7 @@ BOUNDS
  UP BOUND      X2        4.0
 ENDATA)";
         master_problem.close();
-        options_.MASTER_NAME = tmp_dir_ / "master.mps";
+        options_.MASTER_NAME = (tmp_dir_ / "master.mps").string();
     }
 
     void createStructureFile(const std::vector<std::tuple<std::string, std::string, int> > &entries) {
@@ -66,7 +66,7 @@ TEST(MergeMPS, empty_input_ok) {
 
     MergeMPSOptions options;
     options.SOLVER_NAME = "COIN";
-    options.STRUCTURE_FILE = tmpDir / "structure_file.txt";
+    options.STRUCTURE_FILE = (tmpDir / "structure_file.txt").string();
     auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
     auto writer = std::make_shared<Xpansion::Test::InMemoryWriter>();
     MergeMPS mergeMPS(options, logger, writer);
@@ -140,7 +140,7 @@ BOUNDS
     UP BOUND      Y2        50.0
 ENDATA)";
     slave1.close();
-    options_.weights[tmp_dir_ / "slave1.mps"] = 1;
+    options_.weights[(tmp_dir_ / "slave1.mps").string()] = 1;
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();
     auto lastSolution = writer_->solution_data_;

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -25,6 +25,15 @@ protected:
     void TearDown() override {
     }
 
+    /**
+     * Create the following problem :
+     * Minimize
+     * Obj: 3X1 + 4X2
+     * 2x1 + x2 <= 8
+     * x1 + 2x2 >= 3
+     * 0 <=X1 <= 4
+     * 0 <=X2 <= 4
+     */
     void createMasterProblem() {
         std::ofstream master_problem(tmp_dir_ / "master.mps"s);
         master_problem << R"(NAME          MASTER  FREE
@@ -62,16 +71,15 @@ ENDATA)";
     std::shared_ptr<Xpansion::Test::InMemoryWriter> writer_;
 };
 
-TEST(MergeMPS, empty_input_ok) {
-    auto tmpDir = CreateRandomSubDir(std::filesystem::temp_directory_path());
-    std::ofstream structure_file(tmpDir / "structure_file.txt"s);
+TEST_F(MergeMPSTest, empty_input_ok) {
+    std::ofstream structure_file(tmp_dir_ / "structure_file.txt"s);
 
     MergeMPSOptions options;
     options.SOLVER_NAME = "COIN";
-    options.STRUCTURE_FILE = (tmpDir / "structure_file.txt"s).string();
+    options.STRUCTURE_FILE = (tmp_dir_ / "structure_file.txt"s).string();
     auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
     auto writer = std::make_shared<Xpansion::Test::InMemoryWriter>();
-    std::filesystem::current_path(tmpDir);
+    std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options, logger, writer);
     mergeMPS.launch();
     auto lastSolution = writer->solution_data_;
@@ -90,13 +98,6 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     std::cout << tmp_dir_ / "log_merged.mps" << std::endl;
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"s));
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"s));
-    //Print the merged problem
-    std::ifstream merged_mps(tmp_dir_ / "log_merged.mps"s);
-    std::string line;
-    while (std::getline(merged_mps, line)) {
-        std::cout << line << std::endl;
-    }
-    merged_mps.close();
     SolverFactory factory;
     auto merged = factory.create_solver("CBC");
     merged->read_prob_lp(tmp_dir_ / "log_merged.lp"s);
@@ -122,6 +123,58 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     for (int i = 0; i < merged->get_ncols(); ++i) {
         EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
     }
+    //Rows are the same
+    std::vector<int> mstart(merged->get_ncols() + 1);
+    std::vector<int> cindex(merged->get_nelems());
+    std::vector<double> matval_merged(merged->get_nelems());
+    int n_merged = 0;
+    merged->get_rows(mstart.data(), cindex.data(), matval_merged.data(), merged->get_nelems(), &n_merged, 0,
+                     merged->get_nrows() - 1);
+    std::vector<int> mstart_master(master->get_ncols() + 1);
+    std::vector<int> cindex_master(master->get_nelems());
+    std::vector<double> matval_master(master->get_nelems());
+    int n_master = 0;
+    master->get_rows(mstart_master.data(), cindex_master.data(), matval_master.data(), master->get_nelems(), &n_master,
+                     0,
+                     master->get_nrows() - 1);
+    EXPECT_EQ(merged->get_nrows(), master->get_nrows());
+    EXPECT_EQ(n_merged, n_master);
+    for (int i = 0; i < n_merged; ++i) {
+        EXPECT_EQ(mstart[i], mstart_master[i]);
+        EXPECT_EQ(cindex[i], cindex_master[i]);
+        EXPECT_DOUBLE_EQ(matval_merged[i], matval_master[i]);
+    }
+    // RHS are the same
+    DblVector rhs_merged(merged->get_nrows());
+    DblVector rhs_master(master->get_nrows());
+    merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
+    for (int i = 0; i < merged->get_nrows(); ++i) {
+        EXPECT_DOUBLE_EQ(rhs_merged[i], rhs_master[i]);
+    }
+    //Row type are the same
+    CharVector sense_merged(merged->get_nrows());
+    CharVector sense_master(master->get_nrows());
+    merged->get_row_type(sense_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_row_type(sense_master.data(), 0, master->get_nrows() - 1);
+    for (int i = 0; i < merged->get_nrows(); ++i) {
+        EXPECT_EQ(sense_merged[i], sense_master[i]);
+    }
+    //Bounds are the same
+    DblVector lb_merged(merged->get_ncols());
+    DblVector lb_master(master->get_ncols());
+    merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(lb_merged[i], lb_master[i]);
+    }
+    DblVector ub_merged(merged->get_ncols());
+    DblVector ub_master(master->get_ncols());
+    merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(ub_merged[i], ub_master[i]);
+    }
 }
 
 //TEst with 2 problems the result is a problem with variables from both problems
@@ -129,10 +182,10 @@ TEST_F(MergeMPSTest, two_problems_ok) {
     createMasterProblem();
     createStructureFile({
         {"master.mps", "X1", 0}, {"master.mps", "X2", 1},
-        {"slave1.mps", "Y1", 0}, {"slave1.mps", "Y2", 1}
+        {"satellite1.mps", "Y1", 0}, {"satellite1.mps", "Y2", 1}
     });
-    std::ofstream slave1(tmp_dir_ / "slave1.mps");
-    slave1 << R"(NAME          SLAVE1  FREE
+    std::ofstream satellite1(tmp_dir_ / "satellite1.mps");
+    satellite1 << R"(NAME          satellite1  FREE
 ROWS
     N  OBJROW
     L  C10
@@ -151,23 +204,11 @@ BOUNDS
     UP BOUND      Y1        50.0
     UP BOUND      Y2        50.0
 ENDATA)";
-    slave1.close();
-    options_.weights["slave1.mps"] = 1;
+    satellite1.close();
+    options_.weights["satellite1.mps"] = 1;
     std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();
-    //Print the merged problem
-    std::ifstream merged_mps(tmp_dir_ / "log_merged.mps"s);
-    std::string line;
-    while (std::getline(merged_mps, line)) {
-        std::cout << line << std::endl;
-    }
-    std::cout << "-------\n";
-    std::ifstream merged_lp(tmp_dir_ / "log_merged.lp"s);
-    std::string line2;
-    while (std::getline(merged_lp, line2)) {
-        std::cout << line2 << std::endl;
-    }
     auto lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
     //log_merged_mps exists
@@ -178,36 +219,36 @@ ENDATA)";
     merged->read_prob_mps(tmp_dir_ / "log_merged.lp"s);
     auto master = factory.create_solver("CBC");
     master->read_prob_mps(tmp_dir_ / "master.mps"s);
-    auto slave = factory.create_solver("CBC");
-    slave->read_prob_mps(tmp_dir_ / "slave1.mps"s);
-    //Merged has master + slave number of constraints
-    EXPECT_EQ(merged->get_nrows(), master->get_nrows() + slave->get_nrows());
-    //Merged has master + slave number of variables
-    EXPECT_EQ(merged->get_ncols(), master->get_ncols() + slave->get_ncols());
-    //Merged obj is the combination of master and slave
+    auto satellite = factory.create_solver("CBC");
+    satellite->read_prob_mps(tmp_dir_ / "satellite1.mps"s);
+    //Merged has master + satellite number of constraints
+    EXPECT_EQ(merged->get_nrows(), master->get_nrows() + satellite->get_nrows());
+    //Merged has master + satellite number of variables
+    EXPECT_EQ(merged->get_ncols(), master->get_ncols() + satellite->get_ncols());
+    //Merged obj is the combination of master and satellite
     DblVector obj_merged(merged->get_ncols());
     DblVector obj_master(master->get_ncols());
-    DblVector obj_slave(slave->get_ncols());
+    DblVector obj_satellite(satellite->get_ncols());
     merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
     master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
-    slave->get_obj(obj_slave.data(), 0, slave->get_ncols() - 1);
+    satellite->get_obj(obj_satellite.data(), 0, satellite->get_ncols() - 1);
     for (int i = 0; i < master->get_ncols(); ++i) {
         EXPECT_DOUBLE_EQ(obj_merged[i], obj_master[i]);
     }
-    for (int i = 0; i < slave->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(obj_merged[i + master->get_ncols()], obj_slave[i]);
+    for (int i = 0; i < satellite->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(obj_merged[i + master->get_ncols()], obj_satellite[i]);
     }
-    //Merged has the same solution as master and slave
+    //Merged has the same solution as master and satellite
     DblVector sol_merged(merged->get_ncols());
     DblVector sol_master(master->get_ncols());
-    DblVector sol_slave(slave->get_ncols());
+    DblVector sol_satellite(satellite->get_ncols());
     merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
     master->get_lp_sol(sol_master.data(), nullptr, nullptr);
-    slave->get_lp_sol(sol_slave.data(), nullptr, nullptr);
+    satellite->get_lp_sol(sol_satellite.data(), nullptr, nullptr);
     for (int i = 0; i < master->get_ncols(); ++i) {
         EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
     }
-    for (int i = 0; i < slave->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(sol_merged[i + master->get_ncols()], sol_slave[i]);
+    for (int i = 0; i < satellite->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(sol_merged[i + master->get_ncols()], sol_satellite[i]);
     }
 }

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -10,100 +10,6 @@ size_t StandardLp::appendCNT = 0;
 
 using namespace std::string_literals;
 
-void verifyProblemDimensions(const SolverAbstract *merged, const SolverAbstract *master) {
-    EXPECT_EQ(merged->get_ncols(), master->get_ncols());
-    EXPECT_EQ(merged->get_nrows(), master->get_nrows());
-    EXPECT_EQ(merged->get_nelems(), master->get_nelems());
-}
-
-void verifyObjectiveFunction(const SolverAbstract *merged, const SolverAbstract *master) {
-    DblVector obj_merged(merged->get_ncols());
-    DblVector obj_master(master->get_ncols());
-    merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
-
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(obj_merged[i], obj_master[i]);
-    }
-}
-
-void verifySolution(const SolverAbstract *merged, const SolverAbstract *master) {
-    DblVector sol_merged(merged->get_ncols());
-    DblVector sol_master(master->get_ncols());
-    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
-    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
-
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
-    }
-}
-
-void verifyConstraints(const SolverAbstract *merged, const SolverAbstract *master) {
-    std::vector<int> mstart(merged->get_ncols() + 1);
-    std::vector<int> cindex(merged->get_nelems());
-    std::vector<double> matval_merged(merged->get_nelems());
-    int n_merged = 0;
-    merged->get_rows(mstart.data(), cindex.data(), matval_merged.data(), merged->get_nelems(), &n_merged, 0,
-                     merged->get_nrows() - 1);
-
-    std::vector<int> mstart_master(master->get_ncols() + 1);
-    std::vector<int> cindex_master(master->get_nelems());
-    std::vector<double> matval_master(master->get_nelems());
-    int n_master = 0;
-    master->get_rows(mstart_master.data(), cindex_master.data(), matval_master.data(), master->get_nelems(), &n_master,
-                     0,
-                     master->get_nrows() - 1);
-
-    EXPECT_EQ(n_merged, n_master);
-    for (int i = 0; i < n_merged; ++i) {
-        EXPECT_EQ(mstart[i], mstart_master[i]);
-        EXPECT_EQ(cindex[i], cindex_master[i]);
-        EXPECT_DOUBLE_EQ(matval_merged[i], matval_master[i]);
-    }
-}
-
-void verifyRHS(const SolverAbstract *merged, const SolverAbstract *master) {
-    DblVector rhs_merged(merged->get_nrows());
-    DblVector rhs_master(master->get_nrows());
-    merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
-    master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
-
-    for (int i = 0; i < merged->get_nrows(); ++i) {
-        EXPECT_DOUBLE_EQ(rhs_merged[i], rhs_master[i]);
-    }
-}
-
-void verifyRowTypes(const SolverAbstract *merged, const SolverAbstract *master) {
-    CharVector sense_merged(merged->get_nrows());
-    CharVector sense_master(master->get_nrows());
-    merged->get_row_type(sense_merged.data(), 0, merged->get_nrows() - 1);
-    master->get_row_type(sense_master.data(), 0, master->get_nrows() - 1);
-
-    for (int i = 0; i < merged->get_nrows(); ++i) {
-        EXPECT_EQ(sense_merged[i], sense_master[i]);
-    }
-}
-
-void verifyBounds(const SolverAbstract *merged, const SolverAbstract *master) {
-    DblVector lb_merged(merged->get_ncols());
-    DblVector lb_master(master->get_ncols());
-    merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
-
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(lb_merged[i], lb_master[i]);
-    }
-
-    DblVector ub_merged(merged->get_ncols());
-    DblVector ub_master(master->get_ncols());
-    merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
-
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(ub_merged[i], ub_master[i]);
-    }
-}
-
 class MergeMPSTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -198,13 +104,7 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     auto master = factory.create_solver("CBC");
     master->read_prob_mps(tmp_dir_ / "master.mps"s);
 
-    verifyProblemDimensions(merged.get(), master.get());
-    verifyObjectiveFunction(merged.get(), master.get());
-    verifySolution(merged.get(), master.get());
-    verifyConstraints(merged.get(), master.get());
-    verifyRHS(merged.get(), master.get());
-    verifyRowTypes(merged.get(), master.get());
-    verifyBounds(merged.get(), master.get());
+    EXPECT_TRUE(*(merged.get()) == *(master.get()));
 }
 
 //TEst with 2 problems the result is a problem with variables from both problems

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -111,3 +111,78 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
         EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
     }
 }
+
+//TEst with 2 problems the result is a problem with variables from both problems
+TEST_F(MergeMPSTest, two_problems_ok) {
+    createMasterProblem();
+    createStructureFile({
+        {"master.mps", "X1", 0}, {"master.mps", "X2", 1},
+        {"slave1.mps", "Y1", 0}, {"slave1.mps", "Y2", 1}
+    });
+    std::ofstream slave1(tmp_dir_ / "slave1.mps");
+    slave1 << R"(NAME          SLAVE1  FREE
+ROWS
+    N  OBJROW
+    L  C10
+    G  C20
+COLUMNS
+    Y1        OBJROW    1.0
+    Y1        C10       1.0
+    Y1        C20       1.0
+    Y2        OBJROW    1.0
+    Y2        C10        1.0
+    Y2        C20        2.0
+RHS
+    RHS      C10        100.0
+    RHS      C20        50.0
+BOUNDS
+    UP BOUND      Y1        50.0
+    UP BOUND      Y2        50.0
+ENDATA)";
+    slave1.close();
+    options_.weights[tmp_dir_ / "slave1.mps"] = 1;
+    MergeMPS mergeMPS(options_, logger_, writer_);
+    mergeMPS.launch();
+    auto lastSolution = writer_->solution_data_;
+    EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
+    //log_merged_mps exists
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"));
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"));
+    SolverFactory factory;
+    auto merged = factory.create_solver("CBC");
+    merged->read_prob_mps(tmp_dir_ / "log_merged.mps");
+    auto master = factory.create_solver("CBC");
+    master->read_prob_mps(tmp_dir_ / "master.mps");
+    auto slave = factory.create_solver("CBC");
+    slave->read_prob_mps(tmp_dir_ / "slave1.mps");
+    //Merged has master + slave number of constraints
+    EXPECT_EQ(merged->get_nrows(), master->get_nrows() + slave->get_nrows());
+    //Merged has master + slave number of variables
+    EXPECT_EQ(merged->get_ncols(), master->get_ncols() + slave->get_ncols());
+    //Merged obj is the combination of master and slave
+    DblVector obj_merged(merged->get_ncols());
+    DblVector obj_master(master->get_ncols());
+    DblVector obj_slave(slave->get_ncols());
+    merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
+    slave->get_obj(obj_slave.data(), 0, slave->get_ncols() - 1);
+    for (int i = 0; i < master->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(obj_merged[i], obj_master[i]);
+    }
+    for (int i = 0; i < slave->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(obj_merged[i + master->get_ncols()], obj_slave[i]);
+    }
+    //Merged has the same solution as master and slave
+    DblVector sol_merged(merged->get_ncols());
+    DblVector sol_master(master->get_ncols());
+    DblVector sol_slave(slave->get_ncols());
+    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
+    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
+    slave->get_lp_sol(sol_slave.data(), nullptr, nullptr);
+    for (int i = 0; i < master->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
+    }
+    for (int i = 0; i < slave->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(sol_merged[i + master->get_ncols()], sol_slave[i]);
+    }
+}

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -87,6 +87,13 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     //log_merged_mps exists
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"s));
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"s));
+    //Print the merged problem
+    std::ifstream merged_mps(tmp_dir_ / "log_merged.mps"s);
+    std::string line;
+    while (std::getline(merged_mps, line)) {
+        std::cout << line << std::endl;
+    }
+    merged_mps.close();
     SolverFactory factory;
     auto merged = factory.create_solver("CBC");
     merged->read_prob_lp(tmp_dir_ / "log_merged.lp"s);

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -8,6 +8,8 @@
 
 size_t StandardLp::appendCNT = 0;
 
+using namespace std::string_literals;
+
 class MergeMPSTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -24,7 +26,7 @@ protected:
     }
 
     void createMasterProblem() {
-        std::ofstream master_problem(tmp_dir_ / "master.mps");
+        std::ofstream master_problem(tmp_dir_ / "master.mps"s);
         master_problem << R"(NAME          MASTER  FREE
 ROWS
  N  OBJROW
@@ -43,7 +45,7 @@ BOUNDS
  UP BOUND      X2        4.0
 ENDATA)";
         master_problem.close();
-        options_.MASTER_NAME = (tmp_dir_ / "master.mps").string();
+        options_.MASTER_NAME = (tmp_dir_ / "master.mps"s).string();
     }
 
     void createStructureFile(const std::vector<std::tuple<std::string, std::string, int> > &entries) {
@@ -62,11 +64,11 @@ ENDATA)";
 
 TEST(MergeMPS, empty_input_ok) {
     auto tmpDir = CreateRandomSubDir(std::filesystem::temp_directory_path());
-    std::ofstream structure_file(tmpDir / "structure_file.txt");
+    std::ofstream structure_file(tmpDir / "structure_file.txt"s);
 
     MergeMPSOptions options;
     options.SOLVER_NAME = "COIN";
-    options.STRUCTURE_FILE = (tmpDir / "structure_file.txt").string();
+    options.STRUCTURE_FILE = (tmpDir / "structure_file.txt"s).string();
     auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
     auto writer = std::make_shared<Xpansion::Test::InMemoryWriter>();
     MergeMPS mergeMPS(options, logger, writer);
@@ -83,13 +85,13 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     auto lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
     //log_merged_mps exists
-    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"));
-    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"));
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"s));
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"s));
     SolverFactory factory;
     auto merged = factory.create_solver("CBC");
-    merged->read_prob_mps(tmp_dir_ / "log_merged.mps");
+    merged->read_prob_lp(tmp_dir_ / "log_merged.lp"s);
     auto master = factory.create_solver("CBC");
-    master->read_prob_mps(tmp_dir_ / "master.mps");
+    master->read_prob_mps(tmp_dir_ / "master.mps"s);
     //Merged and master problems are identical
     EXPECT_EQ(merged->get_ncols(), master->get_ncols());
     EXPECT_EQ(merged->get_nrows(), master->get_nrows());
@@ -146,15 +148,15 @@ ENDATA)";
     auto lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
     //log_merged_mps exists
-    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"));
-    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"));
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"s));
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"s));
     SolverFactory factory;
     auto merged = factory.create_solver("CBC");
-    merged->read_prob_mps(tmp_dir_ / "log_merged.mps");
+    merged->read_prob_mps(tmp_dir_ / "log_merged.lp"s);
     auto master = factory.create_solver("CBC");
-    master->read_prob_mps(tmp_dir_ / "master.mps");
+    master->read_prob_mps(tmp_dir_ / "master.mps"s);
     auto slave = factory.create_solver("CBC");
-    slave->read_prob_mps(tmp_dir_ / "slave1.mps");
+    slave->read_prob_mps(tmp_dir_ / "slave1.mps"s);
     //Merged has master + slave number of constraints
     EXPECT_EQ(merged->get_nrows(), master->get_nrows() + slave->get_nrows());
     //Merged has master + slave number of variables

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -152,7 +152,7 @@ BOUNDS
     UP BOUND      Y2        50.0
 ENDATA)";
     slave1.close();
-    options_.weights[(tmp_dir_ / "slave1.mps").string()] = 1;
+    options_.weights["slave1.mps"] = 1;
     std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -82,7 +82,7 @@ TEST_F(MergeMPSTest, empty_input_ok) {
     std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options, logger, writer);
     mergeMPS.launch();
-    auto lastSolution = writer->solution_data_;
+    const auto &lastSolution = writer->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "ERROR");
 }
 

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -45,13 +45,13 @@ BOUNDS
  UP BOUND      X2        4.0
 ENDATA)";
         master_problem.close();
-        options_.MASTER_NAME = (tmp_dir_ / "master.mps"s).string();
+        options_.MASTER_NAME = "master.mps";
     }
 
     void createStructureFile(const std::vector<std::tuple<std::string, std::string, int> > &entries) {
         std::ofstream structure_file(options_.STRUCTURE_FILE);
         for (const auto &[mps, var, idx]: entries) {
-            structure_file << fmt::format("{3}/{0} {1} {2}\n", mps, var, idx, tmp_dir_.string());
+            structure_file << fmt::format("{0} {1} {2}\n", mps, var, idx);
         }
         structure_file.close();
     }
@@ -71,6 +71,7 @@ TEST(MergeMPS, empty_input_ok) {
     options.STRUCTURE_FILE = (tmpDir / "structure_file.txt"s).string();
     auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
     auto writer = std::make_shared<Xpansion::Test::InMemoryWriter>();
+    std::filesystem::current_path(tmpDir);
     MergeMPS mergeMPS(options, logger, writer);
     mergeMPS.launch();
     auto lastSolution = writer->solution_data_;
@@ -80,11 +81,13 @@ TEST(MergeMPS, empty_input_ok) {
 TEST_F(MergeMPSTest, one_master_Problem_ok) {
     createMasterProblem();
     createStructureFile({{"master.mps", "X1", 0}, {"master.mps", "X2", 1}});
+    std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();
     auto lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
     //log_merged_mps exists
+    std::cout << tmp_dir_ / "log_merged.mps" << std::endl;
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"s));
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"s));
     //Print the merged problem
@@ -150,6 +153,7 @@ BOUNDS
 ENDATA)";
     slave1.close();
     options_.weights[(tmp_dir_ / "slave1.mps").string()] = 1;
+    std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();
     auto lastSolution = writer_->solution_data_;

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -10,6 +10,100 @@ size_t StandardLp::appendCNT = 0;
 
 using namespace std::string_literals;
 
+void verifyProblemDimensions(const SolverAbstract *merged, const SolverAbstract *master) {
+    EXPECT_EQ(merged->get_ncols(), master->get_ncols());
+    EXPECT_EQ(merged->get_nrows(), master->get_nrows());
+    EXPECT_EQ(merged->get_nelems(), master->get_nelems());
+}
+
+void verifyObjectiveFunction(const SolverAbstract *merged, const SolverAbstract *master) {
+    DblVector obj_merged(merged->get_ncols());
+    DblVector obj_master(master->get_ncols());
+    merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
+
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(obj_merged[i], obj_master[i]);
+    }
+}
+
+void verifySolution(const SolverAbstract *merged, const SolverAbstract *master) {
+    DblVector sol_merged(merged->get_ncols());
+    DblVector sol_master(master->get_ncols());
+    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
+    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
+
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
+    }
+}
+
+void verifyConstraints(const SolverAbstract *merged, const SolverAbstract *master) {
+    std::vector<int> mstart(merged->get_ncols() + 1);
+    std::vector<int> cindex(merged->get_nelems());
+    std::vector<double> matval_merged(merged->get_nelems());
+    int n_merged = 0;
+    merged->get_rows(mstart.data(), cindex.data(), matval_merged.data(), merged->get_nelems(), &n_merged, 0,
+                     merged->get_nrows() - 1);
+
+    std::vector<int> mstart_master(master->get_ncols() + 1);
+    std::vector<int> cindex_master(master->get_nelems());
+    std::vector<double> matval_master(master->get_nelems());
+    int n_master = 0;
+    master->get_rows(mstart_master.data(), cindex_master.data(), matval_master.data(), master->get_nelems(), &n_master,
+                     0,
+                     master->get_nrows() - 1);
+
+    EXPECT_EQ(n_merged, n_master);
+    for (int i = 0; i < n_merged; ++i) {
+        EXPECT_EQ(mstart[i], mstart_master[i]);
+        EXPECT_EQ(cindex[i], cindex_master[i]);
+        EXPECT_DOUBLE_EQ(matval_merged[i], matval_master[i]);
+    }
+}
+
+void verifyRHS(const SolverAbstract *merged, const SolverAbstract *master) {
+    DblVector rhs_merged(merged->get_nrows());
+    DblVector rhs_master(master->get_nrows());
+    merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
+
+    for (int i = 0; i < merged->get_nrows(); ++i) {
+        EXPECT_DOUBLE_EQ(rhs_merged[i], rhs_master[i]);
+    }
+}
+
+void verifyRowTypes(const SolverAbstract *merged, const SolverAbstract *master) {
+    CharVector sense_merged(merged->get_nrows());
+    CharVector sense_master(master->get_nrows());
+    merged->get_row_type(sense_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_row_type(sense_master.data(), 0, master->get_nrows() - 1);
+
+    for (int i = 0; i < merged->get_nrows(); ++i) {
+        EXPECT_EQ(sense_merged[i], sense_master[i]);
+    }
+}
+
+void verifyBounds(const SolverAbstract *merged, const SolverAbstract *master) {
+    DblVector lb_merged(merged->get_ncols());
+    DblVector lb_master(master->get_ncols());
+    merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
+
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(lb_merged[i], lb_master[i]);
+    }
+
+    DblVector ub_merged(merged->get_ncols());
+    DblVector ub_master(master->get_ncols());
+    merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
+
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(ub_merged[i], ub_master[i]);
+    }
+}
+
 class MergeMPSTest : public ::testing::Test {
 protected:
     void SetUp() override {
@@ -103,78 +197,14 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     merged->read_prob_lp(tmp_dir_ / "log_merged.lp"s);
     auto master = factory.create_solver("CBC");
     master->read_prob_mps(tmp_dir_ / "master.mps"s);
-    //Merged and master problems are identical
-    EXPECT_EQ(merged->get_ncols(), master->get_ncols());
-    EXPECT_EQ(merged->get_nrows(), master->get_nrows());
-    EXPECT_EQ(merged->get_nelems(), master->get_nelems());
-    //Merged and master problems have the same objective function
-    DblVector obj_merged(merged->get_ncols());
-    DblVector obj_master(master->get_ncols());
-    merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(obj_merged[i], obj_master[i]);
-    }
-    //BOth have the same solution
-    DblVector sol_merged(merged->get_ncols());
-    DblVector sol_master(master->get_ncols());
-    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
-    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
-    }
-    //Rows are the same
-    std::vector<int> mstart(merged->get_ncols() + 1);
-    std::vector<int> cindex(merged->get_nelems());
-    std::vector<double> matval_merged(merged->get_nelems());
-    int n_merged = 0;
-    merged->get_rows(mstart.data(), cindex.data(), matval_merged.data(), merged->get_nelems(), &n_merged, 0,
-                     merged->get_nrows() - 1);
-    std::vector<int> mstart_master(master->get_ncols() + 1);
-    std::vector<int> cindex_master(master->get_nelems());
-    std::vector<double> matval_master(master->get_nelems());
-    int n_master = 0;
-    master->get_rows(mstart_master.data(), cindex_master.data(), matval_master.data(), master->get_nelems(), &n_master,
-                     0,
-                     master->get_nrows() - 1);
-    EXPECT_EQ(merged->get_nrows(), master->get_nrows());
-    EXPECT_EQ(n_merged, n_master);
-    for (int i = 0; i < n_merged; ++i) {
-        EXPECT_EQ(mstart[i], mstart_master[i]);
-        EXPECT_EQ(cindex[i], cindex_master[i]);
-        EXPECT_DOUBLE_EQ(matval_merged[i], matval_master[i]);
-    }
-    // RHS are the same
-    DblVector rhs_merged(merged->get_nrows());
-    DblVector rhs_master(master->get_nrows());
-    merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
-    master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
-    for (int i = 0; i < merged->get_nrows(); ++i) {
-        EXPECT_DOUBLE_EQ(rhs_merged[i], rhs_master[i]);
-    }
-    //Row type are the same
-    CharVector sense_merged(merged->get_nrows());
-    CharVector sense_master(master->get_nrows());
-    merged->get_row_type(sense_merged.data(), 0, merged->get_nrows() - 1);
-    master->get_row_type(sense_master.data(), 0, master->get_nrows() - 1);
-    for (int i = 0; i < merged->get_nrows(); ++i) {
-        EXPECT_EQ(sense_merged[i], sense_master[i]);
-    }
-    //Bounds are the same
-    DblVector lb_merged(merged->get_ncols());
-    DblVector lb_master(master->get_ncols());
-    merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(lb_merged[i], lb_master[i]);
-    }
-    DblVector ub_merged(merged->get_ncols());
-    DblVector ub_master(master->get_ncols());
-    merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
-    master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
-    for (int i = 0; i < merged->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(ub_merged[i], ub_master[i]);
-    }
+
+    verifyProblemDimensions(merged.get(), master.get());
+    verifyObjectiveFunction(merged.get(), master.get());
+    verifySolution(merged.get(), master.get());
+    verifyConstraints(merged.get(), master.get());
+    verifyRHS(merged.get(), master.get());
+    verifyRowTypes(merged.get(), master.get());
+    verifyBounds(merged.get(), master.get());
 }
 
 //TEst with 2 problems the result is a problem with variables from both problems

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -86,7 +86,10 @@ TEST_F(MergeMPSTest, empty_input_ok) {
     EXPECT_EQ(lastSolution.problem_status, "ERROR");
 }
 
-TEST_F(MergeMPSTest, one_master_Problem_ok) {
+/**
+ * Result and master should be identical
+ */
+TEST_F(MergeMPSTest, only_master_identical_to_merged) {
     createMasterProblem();
     createStructureFile({{"master.mps", "X1", 0}, {"master.mps", "X2", 1}});
     std::filesystem::current_path(tmp_dir_);
@@ -121,12 +124,39 @@ auto get_rows(const SolverAbstract *solver) {
 }
 
 //Test with 2 problems not sharing variables
-TEST_F(MergeMPSTest, two_disconected_problems_ok) {
+/**
+ * Expectation :
+\Problem name: ClpDefaultName
+
+Minimize
+obj: 3 x0 + 4 x1 + x2 + x3
+Subject To
+cons0:  2 x0 + x1 <= 8
+cons1:  x0 + 2 x1 >= 3
+cons2:  x2 + x3 <= 100
+cons3:  x2 + 2 x3 >= 50
+Bounds
+0 <= x0 <= 4
+0 <= x1 <= 4
+0 <= x2 <= 50
+0 <= x3 <= 50
+End
+*/
+TEST_F(MergeMPSTest, two_disconected_problems_merged_is_concatenation_of_both) {
     createMasterProblem();
     createStructureFile({
         {"master.mps", "X1", 0}, {"master.mps", "X2", 1},
         {"satellite1.mps", "Y1", 0}, {"satellite1.mps", "Y2", 1}
     });
+    /* Satellite :
+     * Minimize Y1 + Y2
+     * Subject To
+     * C10: Y1 <= 100
+     * C20: Y2 <= 50
+     * Bounds
+     * 0 <= Y1 <= 50
+     * 0 <= Y2 <= 50
+     */
     std::ofstream satellite1(tmp_dir_ / "satellite1.mps");
     satellite1 << R"(NAME          satellite1  FREE
 ROWS

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -105,7 +105,7 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     auto master = factory.create_solver("CBC");
     master->read_prob_mps(tmp_dir_ / "master.mps"s);
 
-    EXPECT_TRUE(*merged.get() == *master.get());
+    EXPECT_EQ(*merged, *master);
 }
 
 //Test with 2 problems not sharing variables

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -156,6 +156,18 @@ ENDATA)";
     std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();
+    //Print the merged problem
+    std::ifstream merged_mps(tmp_dir_ / "log_merged.mps"s);
+    std::string line;
+    while (std::getline(merged_mps, line)) {
+        std::cout << line << std::endl;
+    }
+    std::cout << "-------\n";
+    std::ifstream merged_lp(tmp_dir_ / "log_merged.lp"s);
+    std::string line2;
+    while (std::getline(merged_lp, line2)) {
+        std::cout << line2 << std::endl;
+    }
     auto lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
     //log_merged_mps exists

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -92,23 +92,24 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();
+
     auto lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
-    //log_merged_mps exists
-    std::cout << tmp_dir_ / "log_merged.mps" << std::endl;
+
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"s));
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"s));
+
     SolverFactory factory;
     auto merged = factory.create_solver("CBC");
-    merged->read_prob_lp(tmp_dir_ / "log_merged.lp"s);
+    merged->read_prob_mps(tmp_dir_ / "log_merged.mps"s);
     auto master = factory.create_solver("CBC");
     master->read_prob_mps(tmp_dir_ / "master.mps"s);
 
-    EXPECT_TRUE(*(merged.get()) == *(master.get()));
+    EXPECT_TRUE(*merged.get() == *master.get());
 }
 
-//TEst with 2 problems the result is a problem with variables from both problems
-TEST_F(MergeMPSTest, two_problems_ok) {
+//Test with 2 problems not sharing variables
+TEST_F(MergeMPSTest, two_disconected_problems_ok) {
     createMasterProblem();
     createStructureFile({
         {"master.mps", "X1", 0}, {"master.mps", "X2", 1},
@@ -135,22 +136,30 @@ BOUNDS
     UP BOUND      Y2        50.0
 ENDATA)";
     satellite1.close();
+
+    //Required to avoid missing contribution to Obj
     options_.weights["satellite1.mps"] = 1;
+
     std::filesystem::current_path(tmp_dir_);
     MergeMPS mergeMPS(options_, logger_, writer_);
     mergeMPS.launch();
+
     auto lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
-    //log_merged_mps exists
+
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"s));
     EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"s));
+
     SolverFactory factory;
     auto merged = factory.create_solver("CBC");
-    merged->read_prob_mps(tmp_dir_ / "log_merged.lp"s);
+    merged->read_prob_mps(tmp_dir_ / "log_merged.mps"s);
+
     auto master = factory.create_solver("CBC");
     master->read_prob_mps(tmp_dir_ / "master.mps"s);
+
     auto satellite = factory.create_solver("CBC");
     satellite->read_prob_mps(tmp_dir_ / "satellite1.mps"s);
+
     //Merged has master + satellite number of constraints
     EXPECT_EQ(merged->get_nrows(), master->get_nrows() + satellite->get_nrows());
     //Merged has master + satellite number of variables

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -1,0 +1,113 @@
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include "LoggerStub.h"
+#include "RandomDirGenerator.h"
+#include "InMemoryWriter.h"
+#include "antares-xpansion/benders/merge_mps/MergeMPS.h"
+
+size_t StandardLp::appendCNT = 0;
+
+class MergeMPSTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tmp_dir_ = CreateRandomSubDir(std::filesystem::temp_directory_path());
+        logger_ = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
+        writer_ = std::make_shared<Xpansion::Test::InMemoryWriter>();
+
+        options_.SOLVER_NAME = "COIN";
+        options_.STRUCTURE_FILE = tmp_dir_ / "structure_file.txt";
+        options_.OUTPUTROOT = tmp_dir_.string();
+    }
+
+    void TearDown() override {
+    }
+
+    void createMasterProblem() {
+        std::ofstream master_problem(tmp_dir_ / "master.mps");
+        master_problem << R"(NAME          MASTER  FREE
+ROWS
+ N  OBJROW
+ L  C1
+ G  C2
+COLUMNS
+    X1        OBJROW       3.0   C1        2.0
+    X1        C2        1.0
+    X2        OBJROW       4.0   C1        1.0
+    X2        C2        2.0
+RHS
+    RHS      C1        8.0
+    RHS      C2        3.0
+BOUNDS
+ UP BOUND      X1        4.0
+ UP BOUND      X2        4.0
+ENDATA)";
+        master_problem.close();
+        options_.MASTER_NAME = tmp_dir_ / "master.mps";
+    }
+
+    void createStructureFile(const std::vector<std::tuple<std::string, std::string, int> > &entries) {
+        std::ofstream structure_file(options_.STRUCTURE_FILE);
+        for (const auto &[mps, var, idx]: entries) {
+            structure_file << fmt::format("{3}/{0} {1} {2}\n", mps, var, idx, tmp_dir_.string());
+        }
+        structure_file.close();
+    }
+
+    std::filesystem::path tmp_dir_;
+    MergeMPSOptions options_;
+    std::shared_ptr<Xpansion::Test::LoggerNOOPStub> logger_;
+    std::shared_ptr<Xpansion::Test::InMemoryWriter> writer_;
+};
+
+TEST(MergeMPS, empty_input_ok) {
+    auto tmpDir = CreateRandomSubDir(std::filesystem::temp_directory_path());
+    std::ofstream structure_file(tmpDir / "structure_file.txt");
+
+    MergeMPSOptions options;
+    options.SOLVER_NAME = "COIN";
+    options.STRUCTURE_FILE = tmpDir / "structure_file.txt";
+    auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
+    auto writer = std::make_shared<Xpansion::Test::InMemoryWriter>();
+    MergeMPS mergeMPS(options, logger, writer);
+    mergeMPS.launch();
+    auto lastSolution = writer->solution_data_;
+    EXPECT_EQ(lastSolution.problem_status, "ERROR");
+}
+
+TEST_F(MergeMPSTest, one_master_Problem_ok) {
+    createMasterProblem();
+    createStructureFile({{"master.mps", "X1", 0}, {"master.mps", "X2", 1}});
+    MergeMPS mergeMPS(options_, logger_, writer_);
+    mergeMPS.launch();
+    auto lastSolution = writer_->solution_data_;
+    EXPECT_EQ(lastSolution.problem_status, "OPTIMAL");
+    //log_merged_mps exists
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.mps"));
+    EXPECT_TRUE(std::filesystem::exists(tmp_dir_ / "log_merged.lp"));
+    SolverFactory factory;
+    auto merged = factory.create_solver("CBC");
+    merged->read_prob_mps(tmp_dir_ / "log_merged.mps");
+    auto master = factory.create_solver("CBC");
+    master->read_prob_mps(tmp_dir_ / "master.mps");
+    //Merged and master problems are identical
+    EXPECT_EQ(merged->get_ncols(), master->get_ncols());
+    EXPECT_EQ(merged->get_nrows(), master->get_nrows());
+    EXPECT_EQ(merged->get_nelems(), master->get_nelems());
+    //Merged and master problems have the same objective function
+    DblVector obj_merged(merged->get_ncols());
+    DblVector obj_master(master->get_ncols());
+    merged->get_obj(obj_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_obj(obj_master.data(), 0, master->get_ncols() - 1);
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(obj_merged[i], obj_master[i]);
+    }
+    //BOth have the same solution
+    DblVector sol_merged(merged->get_ncols());
+    DblVector sol_master(master->get_ncols());
+    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
+    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
+    for (int i = 0; i < merged->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
+    }
+}

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -77,12 +77,11 @@ TEST_F(MergeMPSTest, empty_input_ok) {
     MergeMPSOptions options;
     options.SOLVER_NAME = "COIN";
     options.STRUCTURE_FILE = (tmp_dir_ / "structure_file.txt"s).string();
-    auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
-    auto writer = std::make_shared<Xpansion::Test::InMemoryWriter>();
+
     std::filesystem::current_path(tmp_dir_);
-    MergeMPS mergeMPS(options, logger, writer);
+    MergeMPS mergeMPS(options, logger_, writer_);
     mergeMPS.launch();
-    const auto &lastSolution = writer->solution_data_;
+    const auto &lastSolution = writer_->solution_data_;
     EXPECT_EQ(lastSolution.problem_status, "ERROR");
 }
 

--- a/tests/cpp/merge_mps/merge_mps_test.cpp
+++ b/tests/cpp/merge_mps/merge_mps_test.cpp
@@ -108,6 +108,18 @@ TEST_F(MergeMPSTest, one_master_Problem_ok) {
     EXPECT_EQ(*merged, *master);
 }
 
+auto get_rows(const SolverAbstract *solver) {
+    std::vector<int> mstart_merged(solver->get_nrows() + 1);
+    std::vector<int> mclind_merged(solver->get_nelems());
+    std::vector<double> dmatval_merged(solver->get_nelems());
+    int merge_ret = 0;
+    solver->get_rows(mstart_merged.data(), mclind_merged.data(), dmatval_merged.data(), solver->get_nelems(),
+                     &merge_ret,
+                     0,
+                     solver->get_nrows() - 1);
+    return std::tuple{mstart_merged, mclind_merged, dmatval_merged, merge_ret};
+}
+
 //Test with 2 problems not sharing variables
 TEST_F(MergeMPSTest, two_disconected_problems_ok) {
     createMasterProblem();
@@ -160,11 +172,12 @@ ENDATA)";
     auto satellite = factory.create_solver("CBC");
     satellite->read_prob_mps(tmp_dir_ / "satellite1.mps"s);
 
-    //Merged has master + satellite number of constraints
+    //Verify dimensions
     EXPECT_EQ(merged->get_nrows(), master->get_nrows() + satellite->get_nrows());
-    //Merged has master + satellite number of variables
     EXPECT_EQ(merged->get_ncols(), master->get_ncols() + satellite->get_ncols());
-    //Merged obj is the combination of master and satellite
+    EXPECT_EQ(merged->get_nelems(), master->get_nelems() + satellite->get_nelems());
+
+    //Verify objective
     DblVector obj_merged(merged->get_ncols());
     DblVector obj_master(master->get_ncols());
     DblVector obj_satellite(satellite->get_ncols());
@@ -177,17 +190,71 @@ ENDATA)";
     for (int i = 0; i < satellite->get_ncols(); ++i) {
         EXPECT_DOUBLE_EQ(obj_merged[i + master->get_ncols()], obj_satellite[i]);
     }
-    //Merged has the same solution as master and satellite
-    DblVector sol_merged(merged->get_ncols());
-    DblVector sol_master(master->get_ncols());
-    DblVector sol_satellite(satellite->get_ncols());
-    merged->get_lp_sol(sol_merged.data(), nullptr, nullptr);
-    master->get_lp_sol(sol_master.data(), nullptr, nullptr);
-    satellite->get_lp_sol(sol_satellite.data(), nullptr, nullptr);
+
+    //Verify lb
+    DblVector lb_merged(merged->get_ncols());
+    DblVector lb_master(master->get_ncols());
+    DblVector lb_satellite(satellite->get_ncols());
+    merged->get_lb(lb_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_lb(lb_master.data(), 0, master->get_ncols() - 1);
+    satellite->get_lb(lb_satellite.data(), 0, satellite->get_ncols() - 1);
     for (int i = 0; i < master->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(sol_merged[i], sol_master[i]);
+        EXPECT_DOUBLE_EQ(lb_merged[i], lb_master[i]);
     }
     for (int i = 0; i < satellite->get_ncols(); ++i) {
-        EXPECT_DOUBLE_EQ(sol_merged[i + master->get_ncols()], sol_satellite[i]);
+        EXPECT_DOUBLE_EQ(lb_merged[i + master->get_ncols()], lb_satellite[i]);
+    }
+
+    //verify ub
+    DblVector ub_merged(merged->get_ncols());
+    DblVector ub_master(master->get_ncols());
+    DblVector ub_satellite(satellite->get_ncols());
+    merged->get_ub(ub_merged.data(), 0, merged->get_ncols() - 1);
+    master->get_ub(ub_master.data(), 0, master->get_ncols() - 1);
+    satellite->get_ub(ub_satellite.data(), 0, satellite->get_ncols() - 1);
+    for (int i = 0; i < master->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(ub_merged[i], ub_master[i]);
+    }
+    for (int i = 0; i < satellite->get_ncols(); ++i) {
+        EXPECT_DOUBLE_EQ(ub_merged[i + master->get_ncols()], ub_satellite[i]);
+    }
+
+    //Verify RHS
+    DblVector rhs_merged(merged->get_nrows());
+    DblVector rhs_master(master->get_nrows());
+    DblVector rhs_satellite(satellite->get_nrows());
+    merged->get_rhs(rhs_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_rhs(rhs_master.data(), 0, master->get_nrows() - 1);
+    satellite->get_rhs(rhs_satellite.data(), 0, satellite->get_nrows() - 1);
+    for (int i = 0; i < master->get_nrows(); ++i) {
+        EXPECT_DOUBLE_EQ(rhs_merged[i], rhs_master[i]);
+    }
+    for (int i = 0; i < satellite->get_nrows(); ++i) {
+        EXPECT_DOUBLE_EQ(rhs_merged[i + master->get_nrows()], rhs_satellite[i]);
+    }
+
+    //Verify row (LHS)
+    auto [mstart_merged, mclind_merged, dmatval_merged, merge_ret] = get_rows(merged.get());
+    auto [mstart_master, mclind_master, dmatval_master, master_ret] = get_rows(master.get());
+    auto [mstart_satellite, mclind_satellite, dmatval_satellite, satellite_ret] = get_rows(satellite.get());
+    for (int i = 0; i < master->get_nelems(); ++i) {
+        EXPECT_DOUBLE_EQ(dmatval_merged[i], dmatval_master[i]);
+    }
+    for (int i = 0; i < satellite->get_nelems(); ++i) {
+        EXPECT_DOUBLE_EQ(dmatval_merged[i + master->get_nelems()], dmatval_satellite[i]);
+    }
+
+    //RHS type
+    std::vector<char> order_merged(merged->get_nrows());
+    std::vector<char> order_master(master->get_nrows());
+    std::vector<char> order_satellite(satellite->get_nrows());
+    merged->get_row_type(order_merged.data(), 0, merged->get_nrows() - 1);
+    master->get_row_type(order_master.data(), 0, master->get_nrows() - 1);
+    satellite->get_row_type(order_satellite.data(), 0, satellite->get_nrows() - 1);
+    for (int i = 0; i < master->get_nrows(); ++i) {
+        EXPECT_EQ(order_merged[i], order_master[i]);
+    }
+    for (int i = 0; i < satellite->get_nrows(); ++i) {
+        EXPECT_EQ(order_merged[i + master->get_nrows()], order_satellite[i]);
     }
 }

--- a/tests/cpp/outer_loop/outer_loop_test.cpp
+++ b/tests/cpp/outer_loop/outer_loop_test.cpp
@@ -10,13 +10,13 @@
 #include "antares-xpansion/multisolver_interface/environment.h"
 #include "gtest/gtest.h"
 
-boost::mpi::environment* penv = nullptr;
-boost::mpi::communicator* pworld = nullptr;
+boost::mpi::environment *penv = nullptr;
+boost::mpi::communicator *pworld = nullptr;
 
 using namespace Outerloop;
 using namespace Benders::Criterion;
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
   mpi::environment env(argc, argv);
@@ -35,7 +35,7 @@ const auto OPTIONS_FILE = LP_DIR / "options.json";
 const auto OUTER_OPTIONS_FILE = "adequacy_criterion.yml";
 
 class MasterUpdateBaseTest : public ::testing::TestWithParam<std::string> {
- public:
+public:
   pBendersBase benders;
   std::shared_ptr<MathLoggerDriver> math_log_driver;
   Logger logger;
@@ -51,6 +51,7 @@ class MasterUpdateBaseTest : public ::testing::TestWithParam<std::string> {
     logger = build_void_logger();
     writer = build_void_writer();
   }
+
   BendersBaseOptions BuildBendersOptions() {
     SimulationOptions options(OPTIONS_FILE);
     return options.get_benders_options();
@@ -60,6 +61,7 @@ class MasterUpdateBaseTest : public ::testing::TestWithParam<std::string> {
     // Restore the original working directory after the test
     std::filesystem::current_path(original_working_dir_);
   }
+
   std::filesystem::path original_working_dir_;
 };
 
@@ -67,7 +69,7 @@ auto solvers() {
   std::vector<std::string> solvers_name;
   solvers_name.push_back("COIN");
   if (LoadXpress::XpressLoader xpressLoader;
-      xpressLoader.XpressIsCorrectlyInstalled()) {
+    xpressLoader.XpressIsCorrectlyInstalled()) {
     solvers_name.push_back("XPRESS");
   }
   return solvers_name;
@@ -75,22 +77,23 @@ auto solvers() {
 
 INSTANTIATE_TEST_SUITE_P(availsolvers, MasterUpdateBaseTest,
                          ::testing::ValuesIn(solvers()));
+
 double LambdaMax(pBendersBase benders) {
-  const auto& obj = benders->MasterObjectiveFunctionCoeffs();
+  const auto &obj = benders->MasterObjectiveFunctionCoeffs();
   const auto max_invest = benders->BestIterationWorkerMaster().get_max_invest();
   double lambda_max = 0;
-  for (const auto& [var_name, var_id] : benders->MasterVariables()) {
+  for (const auto &[var_name, var_id]: benders->MasterVariables()) {
     lambda_max += obj[var_id] * max_invest.at(var_name);
   }
   return lambda_max;
 }
 
-void CheckMinInvestmentConstraint(const VariableMap& master_variables,
-                                  const std::vector<double>& expected_coeffs,
+void CheckMinInvestmentConstraint(const VariableMap &master_variables,
+                                  const std::vector<double> &expected_coeffs,
                                   const double expected_rhs, char expected_sign,
-                                  const std::vector<double>& coeffs,
+                                  const std::vector<double> &coeffs,
                                   const double rhs, char sign) {
-  for (auto const& [name, var_id] : master_variables) {
+  for (auto const &[name, var_id]: master_variables) {
     ASSERT_EQ(expected_coeffs[var_id], coeffs[var_id]);
   }
 
@@ -99,13 +102,12 @@ void CheckMinInvestmentConstraint(const VariableMap& master_variables,
 }
 
 
-
 TEST_P(MasterUpdateBaseTest, ConstraintIsAddedBendersMPI) {
   BendersBaseOptions bendersoptions = BuildBendersOptions();
   CouplingMap coupling_map = CouplingMapGenerator::BuildInput(
     std::filesystem::path(bendersoptions.INPUTROOT) /
     bendersoptions.STRUCTURE_FILE,
-    logger, ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    logger.get(), ::testing::UnitTest::GetInstance()->current_test_info()->name());
   // override solver
   bendersoptions.SOLVER_NAME = GetParam();
   bendersoptions.EXTERNAL_LOOP_OPTIONS.DO_OUTER_LOOP = true;
@@ -117,12 +119,12 @@ TEST_P(MasterUpdateBaseTest, ConstraintIsAddedBendersMPI) {
 
   auto outer_loop_input_data =
       Benders::Criterion::CriterionInputFromYaml().Read(
-          std::filesystem::path(bendersoptions.INPUTROOT) / OUTER_OPTIONS_FILE);
+        std::filesystem::path(bendersoptions.INPUTROOT) / OUTER_OPTIONS_FILE);
 
   benders->setCriterionComputationInputs(outer_loop_input_data);
 
   auto master_updater = std::make_shared<MasterUpdateBase>(
-      benders, 0.5, outer_loop_input_data.StoppingThreshold());
+    benders, 0.5, outer_loop_input_data.StoppingThreshold());
   auto cut_manager = std::make_shared<Outerloop::CutsManagerRunTime>();
   Outerloop::OuterLoopBenders out_loop(outer_loop_input_data.Criteria(),
                                        master_updater, cut_manager, benders, *pworld);
@@ -174,7 +176,8 @@ TEST_P(MasterUpdateBaseTest, ConstraintIsAddedBendersMPI) {
   benders->free();
 }
 
-class OuterLoopPatternTest : public ::testing::Test {};
+class OuterLoopPatternTest : public ::testing::Test {
+};
 
 TEST_F(OuterLoopPatternTest, RegexGivenPrefixAndBody) {
   const std::string prefix = "prefix";
@@ -186,7 +189,7 @@ TEST_F(OuterLoopPatternTest, RegexGivenPrefixAndBody) {
   ASSERT_EQ((prefix + body).find(ret_regex) != std::string::npos, false);
   ASSERT_EQ((prefix + "::" + body + "::suffix").find(ret_regex) != std::string::npos,
             false);
-  ASSERT_EQ((body + prefix).find(ret_regex) != std::string::npos , false);
+  ASSERT_EQ((body + prefix).find(ret_regex) != std::string::npos, false);
   ASSERT_EQ((prefix + "::").find(ret_regex) != std::string::npos, false);
   ASSERT_EQ((body).find(ret_regex) != std::string::npos, false);
   ASSERT_EQ((prefix + "area<" + body + ">").find(ret_regex) != std::string::npos, true);
@@ -194,17 +197,18 @@ TEST_F(OuterLoopPatternTest, RegexGivenPrefixAndBody) {
   ASSERT_EQ((prefix + "area<" + body + "_other_area>::suffix").find(ret_regex) != std::string::npos, false);
 }
 
-class OuterLoopInputFromYamlTest : public ::testing::Test {};
+class OuterLoopInputFromYamlTest : public ::testing::Test {
+};
 
 TEST_F(OuterLoopInputFromYamlTest, YamlFileDoesNotExist) {
   std::filesystem::path empty("");
   std::ostringstream expected_msg;
   expected_msg << "Could not read outer loop input file: " << empty << "\n"
-               << "bad file: " << empty.string();
+      << "bad file: " << empty.string();
   try {
     CriterionInputFromYaml parser;
     parser.Read(empty);
-  } catch (const CriterionInputFileError& e) {
+  } catch (const CriterionInputFileError &e) {
     ASSERT_EQ(expected_msg.str(), e.ErrorMessage());
   }
 }
@@ -220,7 +224,7 @@ TEST_F(OuterLoopInputFromYamlTest, YamlFileIsEmpty) {
   try {
     CriterionInputFromYaml parser;
     parser.Read(empty);
-  } catch (const CriterionInputFileIsEmpty& e) {
+  } catch (const CriterionInputFileIsEmpty &e) {
     ASSERT_EQ(expected_msg.str(), e.ErrorMessage());
   }
 }
@@ -234,30 +238,30 @@ TEST_F(OuterLoopInputFromYamlTest, YamlFileShouldContainsAtLeast1Pattern) {
 
   std::ostringstream expected_msg;
   expected_msg << "outer loop input file must contains at least one pattern."
-               << "\n";
+      << "\n";
   try {
     CriterionInputFromYaml parser;
     parser.Read(empty_patterns);
-  } catch (const CriterionInputFileNoPatternFound& e) {
+  } catch (const CriterionInputFileNoPatternFound &e) {
     ASSERT_EQ(expected_msg.str(), e.ErrorMessage());
   }
 }
 
 TEST_F(OuterLoopInputFromYamlTest, YamlFilePatternsShouldBeAnArray) {
   std::filesystem::path patterns_not_array(
-      std::filesystem::temp_directory_path() / "patterns_not_array.yml");
+    std::filesystem::temp_directory_path() / "patterns_not_array.yml");
   std::ofstream of(patterns_not_array);
   of << "stopping_threshold: " << 17.07 << "\n"
-     << "patterns: " << 786;
+      << "patterns: " << 786;
   of.close();
 
   std::ostringstream expected_msg;
   expected_msg << "In outer loop input file 'patterns' should be an array."
-               << "\n";
+      << "\n";
   try {
     CriterionInputFromYaml parser;
     parser.Read(patterns_not_array);
-  } catch (const CriterionInputPatternsShouldBeArray& e) {
+  } catch (const CriterionInputPatternsShouldBeArray &e) {
     ASSERT_EQ(expected_msg.str(), e.ErrorMessage());
   }
 }
@@ -293,7 +297,8 @@ patterns:
   ASSERT_EQ(pattern1.Pattern().GetBody(), "N0");
 }
 
-class VariablesGroupTest : public ::testing::Test {};
+class VariablesGroupTest : public ::testing::Test {
+};
 
 TEST_F(VariablesGroupTest, EmptyVariablesListGivesEmptyIndices) {
   std::vector<std::string> variables;
@@ -305,7 +310,8 @@ TEST_F(VariablesGroupTest, EmptyVariablesListGivesEmptyIndices) {
 
 TEST_F(VariablesGroupTest, EmptyPatternsListGivesEmptyIndices) {
   std::vector<std::string> variables{
-      "PositiveUnsuppliedEnergy::area<test>::hour<125>"};
+    "PositiveUnsuppliedEnergy::area<test>::hour<125>"
+  };
   std::vector<Benders::Criterion::CriterionSingleInputData> data;
 
   Benders::Criterion::VariablesGroup var_grp(variables, data);
@@ -314,66 +320,75 @@ TEST_F(VariablesGroupTest, EmptyPatternsListGivesEmptyIndices) {
 
 TEST_F(VariablesGroupTest, SingleDataWithInvalidPrefixAndBody) {
   std::vector<std::string> variables{
-      "PositiveUnsuppliedEnergy::area<test>::hour<125>"};
+    "PositiveUnsuppliedEnergy::area<test>::hour<125>"
+  };
   std::vector<Benders::Criterion::CriterionSingleInputData> data{
-      Benders::Criterion::CriterionSingleInputData("Pref", "Body", 1534.0)};
+    Benders::Criterion::CriterionSingleInputData("Pref", "Body", 1534.0)
+  };
 
   Benders::Criterion::VariablesGroup var_grp(variables, data);
-  const auto& vect_indices = var_grp.Indices();
+  const auto &vect_indices = var_grp.Indices();
   ASSERT_EQ(vect_indices.size(), 1);
   ASSERT_TRUE(vect_indices[0].empty());
 }
 
 TEST_F(VariablesGroupTest, SingleDataWithUnMatchedPrefix) {
   std::vector<std::string> variables{
-      "PositiveUnsuppliedEnergy::area<test>::hour<125>"};
+    "PositiveUnsuppliedEnergy::area<test>::hour<125>"
+  };
   std::vector<Benders::Criterion::CriterionSingleInputData> data{
-      Benders::Criterion::CriterionSingleInputData("UnsuppliedEnergy::", "test",
-                                                   1534.0)};
+    Benders::Criterion::CriterionSingleInputData("UnsuppliedEnergy::", "test",
+                                                 1534.0)
+  };
 
   Benders::Criterion::VariablesGroup var_grp(variables, data);
-  const auto& vect_indices = var_grp.Indices();
+  const auto &vect_indices = var_grp.Indices();
   ASSERT_EQ(vect_indices.size(), 1);
   ASSERT_TRUE(vect_indices[0].empty());
 }
 
 TEST_F(VariablesGroupTest, SingleDataWithUnMatchedBody) {
   std::vector<std::string> variables{
-      "PositiveUnsuppliedEnergy::area<test>::hour<125>"};
+    "PositiveUnsuppliedEnergy::area<test>::hour<125>"
+  };
   std::vector<Benders::Criterion::CriterionSingleInputData> data{
-      Benders::Criterion::CriterionSingleInputData(
-          "PositiveUnsuppliedEnergy::", "Body", 1534.0)};
+    Benders::Criterion::CriterionSingleInputData(
+      "PositiveUnsuppliedEnergy::", "Body", 1534.0)
+  };
 
   Benders::Criterion::VariablesGroup var_grp(variables, data);
-  const auto& vect_indices = var_grp.Indices();
+  const auto &vect_indices = var_grp.Indices();
   ASSERT_EQ(vect_indices.size(), 1);
   ASSERT_TRUE(vect_indices[0].empty());
 }
 
 static const std::vector<Benders::Criterion::CriterionSingleInputData> data{
-    {"Blue::", "Earth", 1534.0}, {"Red::", "Mars", 65.0}};
+  {"Blue::", "Earth", 1534.0}, {"Red::", "Mars", 65.0}
+};
 
 TEST_F(VariablesGroupTest, With2ValidPatterns) {
   std::vector<std::string> variables{
-      "Gold::area<Sun>::hour<9999>", "Blue::area<Earth>::hour<125>",
-      "Red::area<Mars>::hour<1546>", "Blue::area<Earth>::hour<3336>"};
+    "Gold::area<Sun>::hour<9999>", "Blue::area<Earth>::hour<125>",
+    "Red::area<Mars>::hour<1546>", "Blue::area<Earth>::hour<3336>"
+  };
 
   Benders::Criterion::VariablesGroup var_grp(variables, data);
-  const auto& vect_indices = var_grp.Indices();
+  const auto &vect_indices = var_grp.Indices();
   ASSERT_EQ(vect_indices.size(), 2);
   // 2 vars for the 1st pattern
-  const auto& first_pattern_vars = vect_indices[0];
+  const auto &first_pattern_vars = vect_indices[0];
   ASSERT_EQ(first_pattern_vars.size(), 2);
   // variable indices
   ASSERT_EQ(first_pattern_vars[0], 1);
   ASSERT_EQ(first_pattern_vars[1], 3);
   // 1 var for the 2nd pattern
-  const auto& second_pattern_vars = vect_indices[1];
+  const auto &second_pattern_vars = vect_indices[1];
   ASSERT_EQ(second_pattern_vars.size(), 1);
   ASSERT_EQ(second_pattern_vars[0], 2);
 }
 
-class OuterLoopBiLevelTest : public ::testing::Test {};
+class OuterLoopBiLevelTest : public ::testing::Test {
+};
 
 TEST_F(OuterLoopBiLevelTest, BiLevelBestUbInitialization) {
   Outerloop::OuterLoopBiLevel outerLoopBiLevel(data);

--- a/tests/cpp/outer_loop/outer_loop_test.cpp
+++ b/tests/cpp/outer_loop/outer_loop_test.cpp
@@ -103,9 +103,9 @@ void CheckMinInvestmentConstraint(const VariableMap& master_variables,
 TEST_P(MasterUpdateBaseTest, ConstraintIsAddedBendersMPI) {
   BendersBaseOptions bendersoptions = BuildBendersOptions();
   CouplingMap coupling_map = CouplingMapGenerator::BuildInput(
-      std::filesystem::path(bendersoptions.INPUTROOT) /
-          bendersoptions.STRUCTURE_FILE,
-      logger, ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    std::filesystem::path(bendersoptions.INPUTROOT) /
+    bendersoptions.STRUCTURE_FILE,
+    logger, ::testing::UnitTest::GetInstance()->current_test_info()->name());
   // override solver
   bendersoptions.SOLVER_NAME = GetParam();
   bendersoptions.EXTERNAL_LOOP_OPTIONS.DO_OUTER_LOOP = true;

--- a/tests/cpp/restart_benders/restart_lib_tests.cpp
+++ b/tests/cpp/restart_benders/restart_lib_tests.cpp
@@ -7,27 +7,29 @@
 #include "WriterStub.h"
 #include "antares-xpansion/benders/benders_core/common.h"
 #include "gtest/gtest.h"
-bool operator==(const LogPoint& lhs, const LogPoint& rhs) {
-  return lhs.size() == rhs.size() &&
-         std::equal(lhs.begin(), lhs.end(), rhs.begin());
+
+bool operator==(const LogPoint &lhs, const LogPoint &rhs) {
+    return lhs.size() == rhs.size() &&
+           std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
-bool operator==(const LogData& lhs, const LogData& rhs) {
-  return rhs.lb == lhs.lb && rhs.best_ub == lhs.best_ub && rhs.ub == lhs.ub &&
-         rhs.it == lhs.it && rhs.best_it == lhs.best_it &&
-         rhs.subproblem_cost == lhs.subproblem_cost &&
-         rhs.invest_cost == lhs.invest_cost && rhs.x_in == lhs.x_in &&
-         rhs.x_out == lhs.x_out && rhs.x_cut == lhs.x_cut &&
-         rhs.min_invest == lhs.min_invest && rhs.max_invest == lhs.max_invest &&
-         rhs.optimality_gap == lhs.optimality_gap &&
-         rhs.relative_gap == lhs.relative_gap &&
-         rhs.max_iterations == lhs.max_iterations &&
-         rhs.benders_elapsed_time == lhs.benders_elapsed_time &&
-         rhs.master_time == lhs.master_time &&
-         rhs.subproblem_time == lhs.subproblem_time &&
-         rhs.cumulative_number_of_subproblem_resolved ==
-             lhs.cumulative_number_of_subproblem_resolved;
+bool operator==(const LogData &lhs, const LogData &rhs) {
+    return rhs.lb == lhs.lb && rhs.best_ub == lhs.best_ub && rhs.ub == lhs.ub &&
+           rhs.it == lhs.it && rhs.best_it == lhs.best_it &&
+           rhs.subproblem_cost == lhs.subproblem_cost &&
+           rhs.invest_cost == lhs.invest_cost && rhs.x_in == lhs.x_in &&
+           rhs.x_out == lhs.x_out && rhs.x_cut == lhs.x_cut &&
+           rhs.min_invest == lhs.min_invest && rhs.max_invest == lhs.max_invest &&
+           rhs.optimality_gap == lhs.optimality_gap &&
+           rhs.relative_gap == lhs.relative_gap &&
+           rhs.max_iterations == lhs.max_iterations &&
+           rhs.benders_elapsed_time == lhs.benders_elapsed_time &&
+           rhs.master_time == lhs.master_time &&
+           rhs.subproblem_time == lhs.subproblem_time &&
+           rhs.cumulative_number_of_subproblem_resolved ==
+           lhs.cumulative_number_of_subproblem_resolved;
 }
+
 const LogPoint best_x_in = {{"candidate1", 56.e8}, {"candidate2", 6e4}};
 const LogPoint best_x_out = {{"candidate1", 568.e6}, {"candidate2", 682e9}};
 const LogPoint best_x_cut = {{"candidate1", 60e5}, {"candidate2", 12.4e8}};
@@ -37,125 +39,129 @@ const LogPoint last_x_cut = {{"candidate1", 6e5}, {"candidate2", 1.4e8}};
 const LogPoint min_invest = {{"candidate1", 68.e6}, {"candidate2", 62e9}};
 const LogPoint max_invest = {{"candidate1", 1568.e6}, {"candidate2", 3682e9}};
 const LogData best_iteration_data = {
-    15e5,   255e6,     200e6,      63,         63,         587e8,
+    15e5, 255e6, 200e6, 63, 63, 587e8,
     8562e8, best_x_in, best_x_out, best_x_cut, min_invest, max_invest,
-    9e9,    3e-15,     5876,       999,        898,        25};
+    9e9, 3e-15, 5876, 999, 898, 25
+};
 const LogData last_iteration_data = {
-    1e5,    255e6,     200e6,      159,        63,         587e8,
+    1e5, 255e6, 200e6, 159, 63, 587e8,
     8562e8, last_x_in, last_x_out, last_x_cut, min_invest, max_invest,
-    9e9,    3e-15,     5876,       9999,       898,        23};
+    9e9, 3e-15, 5876, 9999, 898, 23
+};
 
 class LastIterationReaderTest : public ::testing::Test {
- public:
-  LastIterationReaderTest() = default;
+public:
+    LastIterationReaderTest() = default;
 
-  const std::string invalid_file_path = "";
-  const std::filesystem::path _last_iteration_file = std::tmpnam(nullptr);
+    const std::string invalid_file_path = "";
+    const std::filesystem::path _last_iteration_file = std::tmpnam(nullptr);
 };
 
 TEST_F(LastIterationReaderTest, ShouldFailIfInvalidFileIsGiven) {
-  const auto delimiter = std::string("\n");
-  std::stringstream expectedErrorString;
-  expectedErrorString << delimiter << "Invalid Json file: " << invalid_file_path
-                      << delimiter;
+    const auto delimiter = std::string("\n");
+    std::stringstream expectedErrorString;
+    expectedErrorString << delimiter << "Invalid Json file: " << invalid_file_path
+            << delimiter;
 
-  std::stringstream redirectedErrorStream;
-  std::streambuf* initialBufferCerr =
-      std::cerr.rdbuf(redirectedErrorStream.rdbuf());
-  auto last_ite_reader = LastIterationReader(invalid_file_path);
-  std::cerr.rdbuf(initialBufferCerr);
-  auto err_str = redirectedErrorStream.str();
-  auto first_line_err =
-      err_str.substr(0, err_str.find(delimiter, delimiter.length()) + 1);
-  ASSERT_EQ(first_line_err, expectedErrorString.str());
+    std::stringstream redirectedErrorStream;
+    std::streambuf *initialBufferCerr =
+            std::cerr.rdbuf(redirectedErrorStream.rdbuf());
+    auto last_ite_reader = LastIterationReader(invalid_file_path);
+    std::cerr.rdbuf(initialBufferCerr);
+    auto err_str = redirectedErrorStream.str();
+    auto first_line_err =
+            err_str.substr(0, err_str.find(delimiter, delimiter.length()) + 1);
+    ASSERT_EQ(first_line_err, expectedErrorString.str());
 }
+
 TEST_F(LastIterationReaderTest,
        ReaderShouldReturnLastAndBestIterationsWrittenByWriter) {
-  auto writer = LastIterationWriter(_last_iteration_file);
-  writer.SaveBestAndLastIterations(best_iteration_data, last_iteration_data);
-  auto reader = LastIterationReader(_last_iteration_file);
-  const auto& [last, best] = reader.LastIterationData();
+    auto writer = LastIterationWriter(_last_iteration_file);
+    writer.SaveBestAndLastIterations(best_iteration_data, last_iteration_data);
+    auto reader = LastIterationReader(_last_iteration_file);
+    const auto &[last, best] = reader.LastIterationData();
 
-  LogData expec_last_iteration_data = last_iteration_data;
-  expec_last_iteration_data.x_in = {};
-  expec_last_iteration_data.x_out = {};
+    LogData expec_last_iteration_data = last_iteration_data;
+    expec_last_iteration_data.x_in = {};
+    expec_last_iteration_data.x_out = {};
 
-  LogData expec_best_iteration_data = best_iteration_data;
-  expec_best_iteration_data.x_in = {};
-  expec_best_iteration_data.x_out = {};
+    LogData expec_best_iteration_data = best_iteration_data;
+    expec_best_iteration_data.x_in = {};
+    expec_best_iteration_data.x_out = {};
 
-  ASSERT_TRUE(last == expec_last_iteration_data);
-  ASSERT_TRUE(best == expec_best_iteration_data);
+    ASSERT_TRUE(last == expec_last_iteration_data);
+    ASSERT_TRUE(best == expec_best_iteration_data);
 }
 
 class LastIterationWriterTest : public ::testing::Test {
- public:
-  LastIterationWriterTest() = default;
+public:
+    LastIterationWriterTest() = default;
 
-  const std::string _invalid_file_path = "";
+    const std::string _invalid_file_path = "";
 };
-TEST_F(LastIterationWriterTest, ShouldFailIfInvalidFileIsGiven) {
-  std::stringstream expectedErrorString;
-  expectedErrorString << "Invalid Json file: " << _invalid_file_path
-                      << std::endl;
 
-  std::stringstream redirectedErrorStream;
-  std::streambuf* initialBufferCerr =
-      std::cerr.rdbuf(redirectedErrorStream.rdbuf());
-  auto writer = LastIterationWriter(_invalid_file_path);
-  writer.SaveBestAndLastIterations(best_iteration_data, last_iteration_data);
-  std::cerr.rdbuf(initialBufferCerr);
-  ASSERT_EQ(redirectedErrorStream.str(), expectedErrorString.str());
+TEST_F(LastIterationWriterTest, ShouldFailIfInvalidFileIsGiven) {
+    std::stringstream expectedErrorString;
+    expectedErrorString << "Invalid Json file: " << _invalid_file_path
+            << std::endl;
+
+    std::stringstream redirectedErrorStream;
+    std::streambuf *initialBufferCerr =
+            std::cerr.rdbuf(redirectedErrorStream.rdbuf());
+    auto writer = LastIterationWriter(_invalid_file_path);
+    writer.SaveBestAndLastIterations(best_iteration_data, last_iteration_data);
+    std::cerr.rdbuf(initialBufferCerr);
+    ASSERT_EQ(redirectedErrorStream.str(), expectedErrorString.str());
 }
 
-class WriterMockStatus : public WriterNOOPStub {
- public:
-  std::string status = Output::OPTIMAL_C;
-  std::string solution_status() const override { return status; }
+class WriterMockStatus : public Xpansion::Test::WriterNOOPStub {
+public:
+    std::string status = Output::OPTIMAL_C;
+    std::string solution_status() const override { return status; }
 };
 
 TEST(Resume, ShouldNotResumeIfCriterionOk) {
-  Benders::StartUp start_up;
-  SimulationOptions options;
-  options.MAX_ITERATIONS = 10;
-  options.ABSOLUTE_GAP = 100.f;
-  options.RELATIVE_GAP = 200.f;
-  options.TIME_LIMIT = 500.f;
-  options.RESUME = true;
+    Benders::StartUp start_up;
+    SimulationOptions options;
+    options.MAX_ITERATIONS = 10;
+    options.ABSOLUTE_GAP = 100.f;
+    options.RELATIVE_GAP = 200.f;
+    options.TIME_LIMIT = 500.f;
+    options.RESUME = true;
 
-  auto writer = std::make_shared<WriterMockStatus>();
-  auto logger = std::make_shared<LoggerNOOPStub>();
-  ASSERT_EQ(start_up.StudyAlreadyAchievedCriterion(options, writer.get(), logger),
-            true);
+    auto writer = std::make_shared<WriterMockStatus>();
+    auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
+    ASSERT_EQ(start_up.StudyAlreadyAchievedCriterion(options, writer.get(), logger),
+              true);
 }
 
 TEST(Resume, DontResumeIfOptionOff) {
-  Benders::StartUp start_up;
-  SimulationOptions options;
-  options.MAX_ITERATIONS = 10;
-  options.ABSOLUTE_GAP = 100.f;
-  options.RELATIVE_GAP = 200.f;
-  options.TIME_LIMIT = 500.f;
-  options.RESUME = false;
+    Benders::StartUp start_up;
+    SimulationOptions options;
+    options.MAX_ITERATIONS = 10;
+    options.ABSOLUTE_GAP = 100.f;
+    options.RELATIVE_GAP = 200.f;
+    options.TIME_LIMIT = 500.f;
+    options.RESUME = false;
 
-  auto writer = std::make_shared<WriterMockStatus>();
-  auto logger = std::make_shared<LoggerNOOPStub>();
-  ASSERT_EQ(start_up.StudyAlreadyAchievedCriterion(options, writer.get(), logger),
-            false);
+    auto writer = std::make_shared<WriterMockStatus>();
+    auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
+    ASSERT_EQ(start_up.StudyAlreadyAchievedCriterion(options, writer.get(), logger),
+              false);
 }
 
 TEST(Resume, ContinueIfCreterionNotMatch) {
-  Benders::StartUp start_up;
-  SimulationOptions options;
-  options.MAX_ITERATIONS = 10;
-  options.ABSOLUTE_GAP = 100.f;
-  options.RELATIVE_GAP = 200.f;
-  options.TIME_LIMIT = 500.f;
-  options.RESUME = true;
+    Benders::StartUp start_up;
+    SimulationOptions options;
+    options.MAX_ITERATIONS = 10;
+    options.ABSOLUTE_GAP = 100.f;
+    options.RELATIVE_GAP = 200.f;
+    options.TIME_LIMIT = 500.f;
+    options.RESUME = true;
 
-  auto writer = std::make_shared<WriterMockStatus>();
-  writer->status = "NotOptimal";
-  auto logger = std::make_shared<LoggerNOOPStub>();
-  ASSERT_EQ(start_up.StudyAlreadyAchievedCriterion(options, writer.get(), logger),
-            false);
+    auto writer = std::make_shared<WriterMockStatus>();
+    writer->status = "NotOptimal";
+    auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
+    ASSERT_EQ(start_up.StudyAlreadyAchievedCriterion(options, writer.get(), logger),
+              false);
 }

--- a/tests/python/test_input_checker.py
+++ b/tests/python/test_input_checker.py
@@ -41,7 +41,6 @@ class TestCheckProfileFile:
         except ProfileFileWrongNumberOfcolumns:
             pytest.fail("ProfileFileWrongNumberOfcolumns raised improperly")
 
-
     def test_negative_values_in_profile_file(self, tmp_path):
         profile_file = TestCheckProfileFile.get_empty_file(tmp_path)
         line = "-0.5 10.02"
@@ -69,28 +68,24 @@ class TestCheckCandidateOptionType:
             _check_candidate_option_type(option, value)
 
     def test_fail_if_max_units_value_is_negative(self):
-
         option = "max-units"
         value = -1545
 
         assert _check_candidate_option_type(option, value) == False
 
     def test_fail_if_max_units_value_is_str(self):
-
         option = "max-units"
         value = "str"
 
         assert _check_candidate_option_type(option, value) == False
 
     def test_true_for_obsolete_value(self):
-
         option = "has-link-profile"
         value = "str"
 
         assert _check_candidate_option_type(option, value) == True
 
     def test_true_for_string_option_type(self):
-
         option = "link"
         value = "0-1"
 
@@ -100,12 +95,10 @@ class TestCheckCandidateOptionType:
 class TestCheckCandidateName:
 
     def test_empty_candidate_name(self):
-
         with pytest.raises(EmptyCandidateName):
             _check_candidate_name("", "section1236")
 
     def test_illegal_chars_in_candidate_name(self):
-
         with pytest.raises(IllegalCharsInCandidateName):
             _check_candidate_name("newline\n123", "section1236")
 
@@ -128,12 +121,10 @@ class TestCheckCandidateName:
 class TestCheckCandidateLink:
 
     def test_empty_link(self):
-
         with pytest.raises(EmptyCandidateLink):
             _check_candidate_link("", "section0")
 
     def test_fail_if_link_doesnt_contains_separator(self):
-
         with pytest.raises(CandidateLinkWithoutSeparator):
             _check_candidate_link("atob", "section")
         with pytest.raises(CandidateLinkWithoutSeparator):
@@ -147,7 +138,6 @@ class TestCheckCandidateLink:
 class TestCheckCandidatesFile:
 
     def test_wrong_option_type_ini_file(self, tmp_path):
-
         option = "max-units"
         value = -1545
 
@@ -162,7 +152,6 @@ class TestCheckCandidatesFile:
             check_candidates_file(ini_file, capa_dir)
 
     def test_duplicated_candidate_name_ini_file(self, tmp_path):
-
         option = "max-units"
         value = 1545
 
@@ -185,7 +174,6 @@ class TestCheckCandidatesFile:
             check_candidates_file(ini_file, capa_dir)
 
     def test_non_null_max_units_and_max_investment_simultaneaously(self, tmp_path):
-
         ini_file = tmp_path / "a.ini"
         ini_file.touch()
         ini_file.write_text(f"""[5] \n
@@ -201,7 +189,6 @@ class TestCheckCandidatesFile:
             check_candidates_file(ini_file, capa_dir)
 
     def test_null_max_units_and_max_investment_simultaneaously(self, tmp_path):
-
         ini_file = tmp_path / "a.ini"
         ini_file.touch()
         ini_file.write_text(f"""[5] \n
@@ -217,7 +204,6 @@ class TestCheckCandidatesFile:
             check_candidates_file(ini_file, capa_dir)
 
     def test_profile_file_existence(self, tmp_path):
-
         ini_file = tmp_path / "a.ini"
 
         ini_file.touch()
@@ -252,22 +238,20 @@ class TestCheckCandidatesFile:
             ini_file, capa_dir)
         assert _check_attribute_profile_values(profile.config, capa_dir) == False
 
+
 class TestCheckSettingOptionType:
 
     def test_check_setting_option_type(self):
-
         with pytest.raises(NotHandledOption):
             _check_setting_option_type("unknown option", "value")
 
     def test_str_options(self):
-
         assert _check_setting_option_type(
             "uc_type", "expansion_accurate") == True
         assert _check_setting_option_type("uc_type", 123) == False
         assert _check_setting_option_type("master", "a string") == True
 
     def test_int_options(self):
-
         assert _check_setting_option_type("timelimit", 1) == True
         assert _check_setting_option_type("timelimit", "str") == False
         assert _check_setting_option_type("timelimit", -1) == True
@@ -276,7 +260,6 @@ class TestCheckSettingOptionType:
         assert _check_setting_option_type("timelimit", 12.2) == False
 
     def test_double_options(self):
-
         assert _check_setting_option_type("relative_gap", 1.) == True
         assert _check_setting_option_type("relative_gap", -1.) == True
         assert _check_setting_option_type("relative_gap", "str") == False
@@ -289,38 +272,52 @@ class TestCheckSettingOptionValue:
             _check_setting_option_value("optimality_gap", -123)
 
     def test_optimality_gap_str_value(self):
-
         with pytest.raises(OptionTypeError):
             _check_setting_option_value("optimality_gap", "defe")
 
     def test_optimality_gap_negative_float(self):
-
         with pytest.raises(GapValueError):
             _check_setting_option_value("optimality_gap", -1.2)
 
     def test_float_max_iteration(self):
-
         with pytest.raises(OptionTypeError):
             _check_setting_option_value("max_iteration", -1.2)
 
     def test_negative_max_iteration(self):
-
         with pytest.raises(MaxIterValueError):
             _check_setting_option_value("max_iteration", -2)
 
     def test_wrong_time_limit(self):
-
         with pytest.raises(TimelimitValueError):
             _check_setting_option_value("timelimit", -30)
 
     def test_log_level(self):
-
         with pytest.raises(LogLevelValueError):
             _check_setting_option_value("log_level", -30)
 
     def test_separation_parameter_illegal_value(self):
         with pytest.raises(SeparationParameterValueError):
             _check_setting_option_value("separation_parameter", -1)
-    
+
     def test_separation_parameter_legal_value(self):
         assert _check_setting_option_value("separation_parameter", 0.39) == True
+
+    def test_is_bool_true_values(self):
+        assert is_bool("true")
+        assert is_bool("True")
+        assert is_bool("TRUE")
+        assert is_bool("1")
+
+    def test_is_bool_false_values(self):
+        assert is_bool("false")
+        assert is_bool("False")
+        assert is_bool("FALSE")
+        assert is_bool("0")
+
+    def test_is_bool_invalid_values(self):
+        assert not is_bool("oui")
+        assert not is_bool("non")
+        assert not is_bool("2")
+        assert not is_bool("")
+        assert not is_bool("vrai")
+        assert not is_bool("faux")


### PR DESCRIPTION
This pull request includes several changes to improve code quality and functionality across multiple files. The most significant changes involve the refactoring of pointer types, the addition of logging and utility functions, and the introduction of new test doubles.

### Add unit tests on Merge_mps

### Refactoring of pointer types:
* [`src/cpp/benders/benders_core/CouplingMapGenerator.cpp`](diffhunk://#diff-e5c5805ed18be849a2bcfcaf5f3a459394022162fe8c0b168ad0164688aac93eL25-R25): Changed `logger` parameter type from `std::shared_ptr<ILoggerXpansion>` to `ILoggerXpansion*` in `CouplingMapGenerator::BuildInput`.
* [`src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/CouplingMapGenerator.h`](diffhunk://#diff-2a07bb398e3d2d00e5899c2b0c02ae4da892bdcf20158651d1a4ce4c1a7b49c3L9-R9): Updated the `logger` parameter type to `ILoggerXpansion*` in the `CouplingMapGenerator` class.

### Logging and utility functions:
* [`src/cpp/benders/merge_mps/MergeMPS.cpp`](diffhunk://#diff-62757eadaf6524fb544de56dea6eb06fabf01df2063fbe9c5ca25cf8f0e88e2dR260-R266): Added logging for missing weights in `MergeMPS::slave_weight` and included the `<utility>` header for `std::move`. [[1]](diffhunk://#diff-62757eadaf6524fb544de56dea6eb06fabf01df2063fbe9c5ca25cf8f0e88e2dR260-R266) [[2]](diffhunk://#diff-62757eadaf6524fb544de56dea6eb06fabf01df2063fbe9c5ca25cf8f0e88e2dR4-R27)
* [`src/cpp/benders/merge_mps/include/antares-xpansion/benders/merge_mps/MergeMPS.h`](diffhunk://#diff-f8df186d3b07a682ee2f64ddca94670adc233ddbe0d7028c963582afc5c337a9L240-R241): Updated `MergeMPS` constructor to use `std::move` for parameters.

### Introduction of new test doubles:
* [`tests/cpp/TestDoubles/InMemoryWriter.h`](diffhunk://#diff-581b2c221bd7bf2f075edab41e8168640770d524440fcf6c62bfce6849fb80f3R1-R63): Added a new `InMemoryWriter` class for testing purposes.
* [`tests/cpp/TestDoubles/LoggerStub.h`](diffhunk://#diff-dde293831f9c28d20e0f22df76ec2d420124078045c1b121eb0d72542b784e39R9-R81): Introduced `LoggerNOOPStub` class for logging in tests.
* [`tests/cpp/TestDoubles/WriterStub.h`](diffhunk://#diff-000960fa3f240908807b8a51b4e567ceb8f96ced78791f4f6c8d9439e103423fR7-R60): Added `WriterNOOPStub` class for output writing in tests.

### Additional changes:
* [`src/python/antares_xpansion/input_checker.py`](diffhunk://#diff-4b22642bb41a146a8d6749fb31a45bc8da1829f8cb9bf9bd939fce1f0032e355R347-L364): Replaced `str_to_bool` function with `is_bool` for checking boolean strings. [[1]](diffhunk://#diff-4b22642bb41a146a8d6749fb31a45bc8da1829f8cb9bf9bd939fce1f0032e355R347-L364) [[2]](diffhunk://#diff-4b22642bb41a146a8d6749fb31a45bc8da1829f8cb9bf9bd939fce1f0032e355L425-R421)
* [`tests/cpp/CMakeLists.txt`](diffhunk://#diff-66873f80ca7d40e7be54dd3b7354d3e717f28de60536eec9874fb97ef6d9b4c7R29): Added `merge_mps` to the list of subdirectories in the test configuration.