### PR TITLE
Fix version of pip xpress to 9.2.7

### DIFF
--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: |
           export PATH=/root/miniconda3/condabin:$PATH
-          conda install -c fico-xpress "xpress>=9.2,<9.3"
+          conda install -c fico-xpress "xpress==9.2.7"
           XPRESS_DIR=/root/miniconda3/lib/python3.8/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
@@ -235,7 +235,7 @@ jobs:
   upload_asset_to_release:
     if: github.event_name == 'release' && github.event.action == 'created'
     runs-on: ubuntu-latest
-    needs: [build, userguide]
+    needs: [ build, userguide ]
     env:
       ZIP_NAME: ${{needs.build.outputs.zip_name}}
       SINGLEFILE_NAME: ${{needs.build.outputs.singlefile_name}}

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -64,6 +64,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-tests.txt
 
+      #Fix version to 9.2.7.
+      #In 9.2.12 and above, directory structure has changed.
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -67,15 +67,13 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress>=9.2.12,<9.3"
+          python -m pip install "xpress>=9.2.7,<9.3"
           echo ${{ env.pythonLocation }}
           XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
-          XPRESS_LIBS=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpresslibs
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
-          echo "Create symbolic link for XPRESS_LIBS library file because it is missing in the Python installation"
-          mkdir -p $XPRESS_DIR/lib
-          ln -s $XPRESS_LIBS/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
+          echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
+          ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Update alternatives
         #mpicxx  uses "g++" so we need g++ to be symbolic link to g++-10

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress=9.2.7"
+          python -m pip install "xpress==9.2.7"
           echo ${{ env.pythonLocation }}
           XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get install -y ccache
           sudo apt-get install -y g++-10 gcc-10
-      
+
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2.3
@@ -67,13 +67,15 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress>=9.2,<9.3"
+          python -m pip install "xpress>=9.2.12,<9.3"
           echo ${{ env.pythonLocation }}
           XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
+          XPRESS_LIBS=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpresslibs
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
-          echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
-          ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
+          echo "Create symbolic link for XPRESS_LIBS library file because it is missing in the Python installation"
+          mkdir -p $XPRESS/lib
+          ln -s $XPRESS_LIBS/lib/libxprs.so.42 $XPRESS/lib/libxprs.so
 
       - name: Update alternatives
         #mpicxx  uses "g++" so we need g++ to be symbolic link to g++-10

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -75,7 +75,7 @@ jobs:
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS_LIBS library file because it is missing in the Python installation"
           mkdir -p $XPRESS/lib
-          ln -s $XPRESS_LIBS/lib/libxprs.so.42 XPRESS_DIR/lib/libxprs.so
+          ln -s $XPRESS_LIBS/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Update alternatives
         #mpicxx  uses "g++" so we need g++ to be symbolic link to g++-10

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS_LIBS library file because it is missing in the Python installation"
-          mkdir -p XPRESS_DIR/lib
+          mkdir -p $XPRESS_DIR/lib
           ln -s $XPRESS_LIBS/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Update alternatives

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -75,7 +75,7 @@ jobs:
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS_LIBS library file because it is missing in the Python installation"
           mkdir -p $XPRESS/lib
-          ln -s $XPRESS_LIBS/lib/libxprs.so.42 $XPRESS/lib/libxprs.so
+          ln -s $XPRESS_LIBS/lib/libxprs.so.42 XPRESS_DIR/lib/libxprs.so
 
       - name: Update alternatives
         #mpicxx  uses "g++" so we need g++ to be symbolic link to g++-10

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -74,8 +74,8 @@ jobs:
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS_LIBS library file because it is missing in the Python installation"
-          mkdir -p $XPRESS/lib
-          ln -s $XPRESS_DIR/lib/libxprs.so $XPRESS_LIBS/lib/libxprs.so.42
+          mkdir -p XPRESS_DIR/lib
+          ln -s $XPRESS_LIBS/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Update alternatives
         #mpicxx  uses "g++" so we need g++ to be symbolic link to g++-10

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress>=9.2.7,<9.3"
+          python -m pip install "xpress=9.2.7"
           echo ${{ env.pythonLocation }}
           XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -75,7 +75,7 @@ jobs:
           echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS_LIBS library file because it is missing in the Python installation"
           mkdir -p $XPRESS/lib
-          ln -s $XPRESS_LIBS/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
+          ln -s $XPRESS_DIR/lib/libxprs.so $XPRESS_LIBS/lib/libxprs.so.42
 
       - name: Update alternatives
         #mpicxx  uses "g++" so we need g++ to be symbolic link to g++-10

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set-up Xpress with pip
         shell: bash
         run: |
-          python -m pip install --no-cache-dir "xpress>=9.2,<9.3"
+          python -m pip install --no-cache-dir "xpress==9.2.7"
           XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpress"
           cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
           cp $XPRESS_DIR/license/community-xpauth.xpr $XPRESS_DIR/bin/xpauth.xpr
@@ -131,7 +131,7 @@ jobs:
         with:
           #          feature: "features/outer_loop_tests.feature"
           mpi_path: /c/Program Files/Microsoft MPI/Bin
-      
+
       - name: Cache vcpkg binary dir
         if: always()
         id: save-cache-vcpkg-binary
@@ -185,8 +185,8 @@ jobs:
         run: |
           echo "zip_name=${{env.ZIP_NAME}}" >> "$GITHUB_OUTPUT"
           echo "singlefile_name=${{steps.create-single-file.outputs.archive-name}}" >> "$GITHUB_OUTPUT"
-          
-          
+  
+  
 
   userguide:
     runs-on: ubuntu-latest
@@ -268,7 +268,7 @@ jobs:
   upload_asset_to_release:
     if: github.event_name == 'release' && github.event.action == 'created'
     runs-on: ubuntu-latest
-    needs: [build, userguide]
+    needs: [ build, userguide ]
     env:
       ZIP_NAME: ${{needs.build.outputs.zip_name}}
       SINGLEFILE_NAME: ${{needs.build.outputs.singlefile_name}}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress>=9.2,<9.3"
+          python -m pip install "xpress==9.2.7"
           echo ${{ env.pythonLocation }}
           XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/ubuntu-system-deps-build.yml
+++ b/.github/workflows/ubuntu-system-deps-build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress>=9.2,<9.3"
+          python -m pip install "xpress==9.2.7"
           echo ${{ env.pythonLocation }}
           XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/windows-vcpkg-deps-build.yml
+++ b/.github/workflows/windows-vcpkg-deps-build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set-up Xpress with pip
         shell: bash
         run: |
-          python -m pip install --no-cache-dir "xpress>=9.2,<9.3"
+          python -m pip install --no-cache-dir "xpress==9.2.7"
           XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpress"
           cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
           cp $XPRESS_DIR/license/community-xpauth.xpr $XPRESS_DIR/bin/xpauth.xpr

--- a/docker/centos7-system-deps
+++ b/docker/centos7-system-deps
@@ -32,7 +32,7 @@ RUN \
     rm -f Miniconda3-py38_23.5.1-0-Linux-x86_64.sh
 
 RUN export PATH=/root/miniconda3/condabin:$PATH && \
-    conda install -c fico-xpress "xpress>=9.2,<9.3"
+    conda install -c fico-xpress "xpress==9.2.7"
 
 
 # Install CMake


### PR DESCRIPTION
This pull request includes changes to multiple workflow files to fix the version of the `xpress` package to `9.2.7`. This is necessary because versions `9.2.12` and above have a different directory structure.