### PR TITLE
Reclaim memory from Antares Simulation

### DIFF
--- a/src/cpp/lpnamer/main/ProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/ProblemGeneration.cpp
@@ -33,6 +33,7 @@
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 #include "antares-xpansion/xpansion_interfaces/StringManip.h"
 #include "config.h"
+#include "malloc.h"
 
 static const std::string LP_DIRNAME = "lp";
 
@@ -102,7 +103,16 @@ void ProblemGeneration::performAntaresSimulation(const std::filesystem::path& ou
 
     optOptions.ortoolsSolver = solverXpansionToSimulator(solver_config_);
     auto results = Antares::API::PerformSimulation(options_.StudyPath(), output, optOptions);
-    // Add parallel
+
+    /**
+     * Antares simulator allocate a lot of memory
+     * Even if there is no memory leak not all freed memory become available.
+     * Allocator or OS may cache some memory to reuse it
+     * With malloc_trim(0) we free all memory that is not used anymore to be reclaimed by the
+     *program It is nescasssry to avoid allocating Xpansion memory on top of the unavailable memory
+     *from simulator
+     **/
+    malloc_trim(0);
 
     // Handle errors
     if (results.error)

--- a/src/cpp/lpnamer/main/ProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/ProblemGeneration.cpp
@@ -112,7 +112,9 @@ void ProblemGeneration::performAntaresSimulation(const std::filesystem::path& ou
      *program It is nescasssry to avoid allocating Xpansion memory on top of the unavailable memory
      *from simulator
      **/
+#ifndef _WIN32
     malloc_trim(0);
+#endif
 
     // Handle errors
     if (results.error)


### PR DESCRIPTION
Antares simulator allocate a lot of memory
Even if there is no memory leak not all freed memory become available.
Allocator or OS may cache some memory to reuse it with malloc_trim(0) we free all memory that is not used anymore to be reclaimed by the program It is nescasssry to avoid allocating Xpansion memory on top of the unavailable memory from simulator