### PR TITLE
Update xpress to 9.2.12

### DIFF
--- a/.github/workflows/build_centos7.yml
+++ b/.github/workflows/build_centos7.yml
@@ -44,7 +44,7 @@ jobs:
           workdir: docker
           dockerfile: centos7-system-deps
           cache: false
-          tags: 1.1.1
+          tags: 1.1.2
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -92,10 +92,10 @@ jobs:
         run: |
           export PATH=/root/miniconda3/condabin:$PATH
           conda install -c fico-xpress "xpress==9.2.12"
-          SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages/
+          SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
           XPRESS_DIR=$SITE_PACKAGE/xpresslibs
-          ls $XPRESS_DIR
           ls $SITE_SITE_PACKAGE
+          ls $XPRESS_DIR
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -95,6 +95,7 @@ jobs:
           conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
           XPRESS_DIR=$SITE_PACKAGE/xpress
+          ls /root/miniconda3/lib/**
           echo "---"
           ls $SITE_PACKAGE
           echo "---"

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -94,19 +94,11 @@ jobs:
           conda install -c fico-xpress "xpress==9.2.12" "xpresslibs==9.2.12"
           conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
-          XPRESS_DIR=$SITE_PACKAGE/xpress
-          ls /root/miniconda3/lib/**
-          echo "---"
-          ls $SITE_PACKAGE
-          echo "---"
-          ls $SITE_PACKAGE/xpress/**
-          echo "--"
-          ls $SITE_PACKAGE/xpress-9.2.12.dist-info/**
-          ls $XPRESS_DIR
+          XPRESS_DIR=/root/miniconda3/lib
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
-          ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so   
+          ln -s $XPRESS_DIR/libxprs.so.42 $XPRESS_DIR/libxprs.so   
 
       - name: Download pre-compiled librairies
         uses: ./.github/workflows/download-extract-precompiled-libraries-tgz

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -75,10 +75,9 @@ jobs:
       - name: Set up Python
         run: |
           dnf update -y
-          dnf install -y python3 python3-pip python3-dev
+          dnf install -y python3 python3-pip
           pip3 install wheel #Too late to install in requirements.txt
           pip3 install -r requirements-tests.txt
-          pip3 install cmake==3.28
 
       # the default python version (3.6) is too old to download xpress with pip
       # this version of miniconda embeds python3.8
@@ -115,6 +114,7 @@ jobs:
           git config --global safe.directory '*'
           git submodule update --remote --init vcpkg
           pushd vcpkg
+          git fetch --unshallow
           ./bootstrap-vcpkg.sh -disableMetrics
           echo "VCPKG_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
           echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg_cache" >> $GITHUB_ENV

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -75,9 +75,10 @@ jobs:
       - name: Set up Python
         run: |
           dnf update -y
-          dnf install -y python3 python3-pip
+          dnf install -y python3 python3-pip python3-dev
           pip3 install wheel #Too late to install in requirements.txt
           pip3 install -r requirements-tests.txt
+          pip3 install cmake==3.28
 
       # the default python version (3.6) is too old to download xpress with pip
       # this version of miniconda embeds python3.8
@@ -94,11 +95,11 @@ jobs:
           conda install -c fico-xpress "xpress==9.2.12" "xpresslibs==9.2.12"
           conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
-          XPRESS_DIR=/root/miniconda3/lib
+          XPRESS_DIR=/root/miniconda3
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
-          ln -s $XPRESS_DIR/libxprs.so.42 $XPRESS_DIR/libxprs.so   
+          ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Download pre-compiled librairies
         uses: ./.github/workflows/download-extract-precompiled-libraries-tgz
@@ -114,7 +115,6 @@ jobs:
           git config --global safe.directory '*'
           git submodule update --remote --init vcpkg
           pushd vcpkg
-          git fetch --unshallow
           ./bootstrap-vcpkg.sh -disableMetrics
           echo "VCPKG_ROOT=$GITHUB_WORKSPACE/vcpkg" >> $GITHUB_ENV
           echo "VCPKG_CACHE_DIR=$GITHUB_WORKSPACE/vcpkg_cache" >> $GITHUB_ENV

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -92,9 +92,12 @@ jobs:
         run: |
           export PATH=/root/miniconda3/condabin:$PATH
           conda install -c fico-xpress "xpress==9.2.12"
+          conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
           XPRESS_DIR=$SITE_PACKAGE/xpresslibs
+          ls "---"
           ls $SITE_SITE_PACKAGE
+          ls "---"
           ls $XPRESS_DIR
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -96,7 +96,7 @@ jobs:
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
           XPRESS_DIR=$SITE_PACKAGE/xpresslibs
           echo "---"
-          ls $SITE_SITE_PACKAGE
+          ls $SITE_PACKAGE
           echo "---"
           ls $XPRESS_DIR
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -91,10 +91,10 @@ jobs:
         shell: bash
         run: |
           export PATH=/root/miniconda3/condabin:$PATH
-          conda install -c fico-xpress "xpress==9.2.7"
-          XPRESS_DIR=/root/miniconda3/lib/python3.8/site-packages/xpress
+          conda install -c fico-xpress "xpress==9.2.12"
+          XPRESS_DIR=/root/miniconda3/lib/python3.8/site-packages/xpresslibs
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so   
 

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -91,10 +91,10 @@ jobs:
         shell: bash
         run: |
           export PATH=/root/miniconda3/condabin:$PATH
-          conda install -c fico-xpress "xpress==9.2.12"
+          conda install -c fico-xpress "xpress==9.2.12" "xpresslibs==9.2.12"
           conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
-          XPRESS_DIR=$SITE_PACKAGE/xpress
+          XPRESS_DIR=$SITE_PACKAGE/xpresslibs
           echo "---"
           ls $SITE_PACKAGE
           echo "---"

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -94,10 +94,13 @@ jobs:
           conda install -c fico-xpress "xpress==9.2.12" "xpresslibs==9.2.12"
           conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
-          XPRESS_DIR=$SITE_PACKAGE/xpresslibs
+          XPRESS_DIR=$SITE_PACKAGE/xpress
           echo "---"
           ls $SITE_PACKAGE
           echo "---"
+          ls $SITE_PACKAGE/xpress/**
+          echo "--"
+          ls $SITE_PACKAGE/xpress-9.2.12.dist-info/**
           ls $XPRESS_DIR
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -94,7 +94,7 @@ jobs:
           conda install -c fico-xpress "xpress==9.2.12"
           conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
-          XPRESS_DIR=$SITE_PACKAGE/xpresslibs
+          XPRESS_DIR=$SITE_PACKAGE/xpress
           echo "---"
           ls $SITE_PACKAGE
           echo "---"

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -92,9 +92,12 @@ jobs:
         run: |
           export PATH=/root/miniconda3/condabin:$PATH
           conda install -c fico-xpress "xpress==9.2.12"
-          XPRESS_DIR=/root/miniconda3/lib/python3.8/site-packages/xpresslibs
+          SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages/
+          XPRESS_DIR=$SITE_PACKAGE/xpresslibs
+          ls $XPRESS_DIR
+          ls $SITE_SITE_PACKAGE
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/license/community-xpauth.xpr" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so   
 

--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -95,9 +95,9 @@ jobs:
           conda info --all
           SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages
           XPRESS_DIR=$SITE_PACKAGE/xpresslibs
-          ls "---"
+          echo "---"
           ls $SITE_SITE_PACKAGE
-          ls "---"
+          echo "---"
           ls $XPRESS_DIR
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -73,10 +73,6 @@ jobs:
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
-          echo "XPRESS_DIR=$XPRESS_DIR"
-          echo "XPRESSDIR=$XPRESSDIR"
-          ls -l $XPRESS_DIR/lib
-          ls -l $XPAUTH_PATH
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Read antares-solver version

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -65,17 +65,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-tests.txt
 
-      #Fix version to 9.2.7.
-      #In 9.2.12 and above, directory structure has changed.
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress==9.2.7"
-          echo ${{ env.pythonLocation }}
-          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
+          python -m pip install "xpress==9.2.12"
+          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/dist-packages/xpresslibs
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/dist-packages/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
+          echo "XPRESS_DIR=$XPRESS_DIR"
+          echo "XPRESSDIR=$XPRESSDIR"
+          ls -l $XPRESS_DIR/lib
+          ls -l $XPRAUTH_PATH
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Read antares-solver version

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -76,7 +76,7 @@ jobs:
           echo "XPRESS_DIR=$XPRESS_DIR"
           echo "XPRESSDIR=$XPRESSDIR"
           ls -l $XPRESS_DIR/lib
-          ls -l $XPRAUTH_PATH
+          ls -l XPAUTH_PATH
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Read antares-solver version

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -76,7 +76,7 @@ jobs:
           echo "XPRESS_DIR=$XPRESS_DIR"
           echo "XPRESSDIR=$XPRESSDIR"
           ls -l $XPRESS_DIR/lib
-          ls -l XPAUTH_PATH
+          ls -l $XPAUTH_PATH
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 
       - name: Read antares-solver version

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -69,9 +69,9 @@ jobs:
         shell: bash
         run: |
           python -m pip install "xpress==9.2.12"
-          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/dist-packages/xpresslibs
+          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpresslibs
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/dist-packages/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
           echo "XPRESS_DIR=$XPRESS_DIR"
           echo "XPRESSDIR=$XPRESSDIR"

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -115,7 +115,7 @@ jobs:
       - name: run antares
         shell: cmd
         run: |
-          ${{github.workspace}}\rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits\bin\rte-antares-9.2.0-installer-64bits.exe  examples\SmallTestFiveCandidates --solver=xpress
+          "${{github.workspace}}\rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits\bin\rte-antares-9.2.0-installer-64bits.exe"  examples\SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -115,7 +115,7 @@ jobs:
       - name: run antares
         shell: cmd
         run: |
-          ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
+          ${{github.workspace}}\rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits\bin\rte-antares-9.2.0-installer-64bits.exe  examples\SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -115,9 +115,7 @@ jobs:
       - name: run antares
         shell: bash
         run: |
-          ls **
-          ls "${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits"
-          ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
+          ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -116,7 +116,7 @@ jobs:
         shell: bash
         run: |
           cd rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin
-          ./rte-antares-9.2.0-installer-64bits.exe"  ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
+          ./rte-antares-9.2.0-installer-64bits.exe ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -59,11 +59,6 @@ jobs:
           python -m pip install --no-cache-dir "xpress==9.2.12"
           SITE_PACKAGE="${{ env.pythonLocation }}\Lib\site-packages"
           XPRESS_DIR="$SITE_PACKAGE\xpresslibs"
-          ls $SITE_PACKAGE/xpress
-          echo "----"
-          ls $XPRESS_DIR
-            echo "----"
-          ls $XPRESS_DIR/lib
           cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
           mkdir -p $SITE_PACKAGE/xpress/bin
           cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $XPRESS_DIR/bin/xpauth.xpr
@@ -115,13 +110,6 @@ jobs:
           os: ${{matrix.os}}
           ortools-url: ${{env.ORTOOLS_URL}}
           ortools-dir: ${{env.ORTOOLS_DIR}}
-
-      - name: run antares
-        shell: bash
-        run: |
-          cd rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin
-          ls
-          ./antares-solver.exe ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -64,7 +64,7 @@ jobs:
           ls $XPRESS_DIR
             echo "----"
           ls $XPRESS_DIR/lib
-          cp -r $XPRESS_DIR/lib $SITE_PACKAGE/xpress/bin
+          cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
           cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $SITE_PACKAGE/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "$XPRESS_DIR/bin" >> $GITHUB_PATH

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -66,7 +66,7 @@ jobs:
           ls $XPRESS_DIR/lib
           cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
           mkdir -p $SITE_PACKAGE/xpress/bin
-          cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $SITE_PACKAGE/xpress/bin/xpauth.xpr
+          cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $$XPRESS_DIR/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "$XPRESS_DIR/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -65,6 +65,7 @@ jobs:
             echo "----"
           ls $XPRESS_DIR/lib
           cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
+          mkdir -p $SITE_PACKAGE/xpress/bin
           cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $SITE_PACKAGE/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "$XPRESS_DIR/bin" >> $GITHUB_PATH

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -57,9 +57,12 @@ jobs:
         shell: bash
         run: |
           python -m pip install --no-cache-dir "xpress==9.2.12"
-          XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpresslibs"
-          cp -r $XPRESS_DIR/lib ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/bin
-          cp ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/license/community-xpauth.xpr ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/bin/xpauth.xpr
+          SITE_PACKAGE="${{ env.pythonLocation }}\Lib\site-packages"
+          XPRESS_DIR="$SITE_PACKAGE\xpresslibs"
+          ls $SITE_PACKAGE/xpress
+          ls $XPRESS_DIR
+          cp -r $XPRESS_DIR/lib $SITE_PACKAGE/xpress/bin
+          cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $SITE_PACKAGE/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "$XPRESS_DIR/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -56,10 +56,10 @@ jobs:
       - name: Set-up Xpress with pip
         shell: bash
         run: |
-          python -m pip install --no-cache-dir "xpress==9.2.7"
-          XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpress"
-          cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
-          cp $XPRESS_DIR/license/community-xpauth.xpr $XPRESS_DIR/bin/xpauth.xpr
+          python -m pip install --no-cache-dir "xpress==9.2.12"
+          XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpresslibs"
+          cp -r $XPRESS_DIR/lib ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/bin
+          cp ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/license/community-xpauth.xpr ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "$XPRESS_DIR/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -116,6 +116,7 @@ jobs:
         shell: bash
         run: |
           cd rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin
+          ls
           ./rte-antares-9.2.0-installer-64bits.exe ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           cd rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin
           ls
-          ./rte-antares-9.2.0-installer-64bits.exe ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
+          ./antares-solver.exe ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -115,7 +115,8 @@ jobs:
       - name: run antares
         shell: bash
         run: |
-          ls ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits
+          ls **
+          ls "${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits"
           ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -113,9 +113,10 @@ jobs:
           ortools-dir: ${{env.ORTOOLS_DIR}}
 
       - name: run antares
-        shell: cmd
+        shell: bash
         run: |
-          "${{github.workspace}}\rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits\bin\rte-antares-9.2.0-installer-64bits.exe"  examples\SmallTestFiveCandidates --solver=xpress
+          cd ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin
+          ./rte-antares-9.2.0-installer-64bits.exe"  ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -113,9 +113,9 @@ jobs:
           ortools-dir: ${{env.ORTOOLS_DIR}}
 
       - name: run antares
-        shell: bash
+        shell: cmd
         run: >
-          ./${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
+          ${{github.workspace}}\rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits\rte-antares-9.2.0-installer-64bits.exe  examples\SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -115,7 +115,7 @@ jobs:
       - name: run antares
         shell: bash
         run: >
-          ./${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/antares-solver.exe examples/SmallTestFiveCandidates --solver=xpress
+          ./${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -115,7 +115,7 @@ jobs:
       - name: run antares
         shell: bash
         run: |
-          cd ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin
+          cd rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin
           ./rte-antares-9.2.0-installer-64bits.exe"  ${{github.workspace}}/examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -114,8 +114,8 @@ jobs:
 
       - name: run antares
         shell: bash
-        run: >
-          ls ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/
+        run: |
+          ls ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits
           ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -113,9 +113,10 @@ jobs:
           ortools-dir: ${{env.ORTOOLS_DIR}}
 
       - name: run antares
-        shell: cmd
+        shell: bash
         run: >
-          ${{github.workspace}}\rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits\rte-antares-9.2.0-installer-64bits.exe  examples\SmallTestFiveCandidates --solver=xpress
+          ls ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/
+          ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -113,7 +113,7 @@ jobs:
           ortools-dir: ${{env.ORTOOLS_DIR}}
 
       - name: run antares
-        shell: bash
+        shell: cmd
         run: |
           ${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/bin/rte-antares-9.2.0-installer-64bits.exe  examples/SmallTestFiveCandidates --solver=xpress
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -59,8 +59,9 @@ jobs:
           python -m pip install --no-cache-dir "xpress==9.2.12"
           SITE_PACKAGE="${{ env.pythonLocation }}\Lib\site-packages"
           XPRESS_DIR="$SITE_PACKAGE\xpresslibs"
-          ls $SITE_PACKAGE/xpress
-          ls $XPRESS_DIR
+          ls $SITE_PACKAGE/xpress/**
+          echo "----"
+          ls $XPRESS_DIR/**
           cp -r $XPRESS_DIR/lib $SITE_PACKAGE/xpress/bin
           cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $SITE_PACKAGE/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -66,7 +66,7 @@ jobs:
           ls $XPRESS_DIR/lib
           cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
           mkdir -p $SITE_PACKAGE/xpress/bin
-          cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $$XPRESS_DIR/bin/xpauth.xpr
+          cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $XPRESS_DIR/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "$XPRESS_DIR/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -112,6 +112,11 @@ jobs:
           ortools-url: ${{env.ORTOOLS_URL}}
           ortools-dir: ${{env.ORTOOLS_DIR}}
 
+      - name: run antares
+        shell: bash
+        run: >
+          ./${{github.workspace}}/rte-antares-${{steps.antares-version.outputs.result}}-installer-64bits/antares-solver.exe examples/SmallTestFiveCandidates --solver=xpress
+
       - name: Configure
         shell: bash
         run: >
@@ -190,7 +195,7 @@ jobs:
           echo "singlefile_name=${{steps.create-single-file.outputs.archive-name}}" >> "$GITHUB_OUTPUT"
   
   
-
+  
   userguide:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'created'

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -62,6 +62,8 @@ jobs:
           ls $SITE_PACKAGE/xpress
           echo "----"
           ls $XPRESS_DIR
+            echo "----"
+          ls $XPRESS_DIR/lib
           cp -r $XPRESS_DIR/lib $SITE_PACKAGE/xpress/bin
           cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $SITE_PACKAGE/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -59,9 +59,9 @@ jobs:
           python -m pip install --no-cache-dir "xpress==9.2.12"
           SITE_PACKAGE="${{ env.pythonLocation }}\Lib\site-packages"
           XPRESS_DIR="$SITE_PACKAGE\xpresslibs"
-          ls $SITE_PACKAGE/xpress/**
+          ls $SITE_PACKAGE/xpress
           echo "----"
-          ls $XPRESS_DIR/**
+          ls $XPRESS_DIR
           cp -r $XPRESS_DIR/lib $SITE_PACKAGE/xpress/bin
           cp $SITE_PACKAGE/xpress/license/community-xpauth.xpr $SITE_PACKAGE/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV

--- a/.github/workflows/publish_centos_docker.yml
+++ b/.github/workflows/publish_centos_docker.yml
@@ -24,4 +24,4 @@ jobs:
           workdir: docker
           dockerfile: centos7-system-deps
           cache: false
-          tags: latest,1.1.1
+          tags: latest,1.1.2

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -54,11 +54,10 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress==9.2.7"
-          echo ${{ env.pythonLocation }}
-          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
+          python -m pip install "xpress==9.2.12"
+          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpresslibs
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 

--- a/.github/workflows/ubuntu-system-deps-build.yml
+++ b/.github/workflows/ubuntu-system-deps-build.yml
@@ -40,11 +40,10 @@ jobs:
       - name: Set-up Xpress with pip for Ubuntu
         shell: bash
         run: |
-          python -m pip install "xpress==9.2.7"
-          echo ${{ env.pythonLocation }}
-          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress
+          python -m pip install "xpress==9.2.12"
+          XPRESS_DIR=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpresslibs
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
-          echo "XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr" >> $GITHUB_ENV
+          echo "XPAUTH_PATH=${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/license/community-xpauth.xpr" >> $GITHUB_ENV
           echo "Create symbolic link for XPRESS library file because it is missing in the Python installation"
           ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so
 

--- a/.github/workflows/windows-vcpkg-deps-build.yml
+++ b/.github/workflows/windows-vcpkg-deps-build.yml
@@ -43,10 +43,10 @@ jobs:
       - name: Set-up Xpress with pip
         shell: bash
         run: |
-          python -m pip install --no-cache-dir "xpress==9.2.7"
-          XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpress"
-          cp -r $XPRESS_DIR/lib $XPRESS_DIR/bin
-          cp $XPRESS_DIR/license/community-xpauth.xpr $XPRESS_DIR/bin/xpauth.xpr
+          python -m pip install --no-cache-dir "xpress==9.2.12"
+          XPRESS_DIR="${{ env.pythonLocation }}\Lib\site-packages\xpresslibs"
+          cp -r $XPRESS_DIR/lib ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/bin
+          cp ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/license/community-xpauth.xpr ${{ env.pythonLocation }}/lib/python${{ env.PYTHON_VERSION }}/site-packages/xpress/bin/xpauth.xpr
           echo "XPRESSDIR=$XPRESS_DIR" >> $GITHUB_ENV
           echo "$XPRESS_DIR/bin" >> $GITHUB_PATH
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5)
 # ===========================================================================
 
 PROJECT(antaresXpansion VERSION 1.4.0)
-set(ANTARES_XPANSION_RC 4)
+set(ANTARES_XPANSION_RC 5)
 
 # ===========================================================================
 # Default parameters

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -88,7 +88,7 @@ RUN export PATH=/root/miniconda3/condabin:$PATH && \
               export XPRESSDIR=$XPRESS_DIR && \
               export XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr && \
               ls $XPRESSDIR && \
-              ls "----" && \
+              echo "----" && \
               ls $XPAUTH_PATH && \
               echo "Create symbolic link for XPRESS library file because it is missing in the Python installation" && \
               ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so && \

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -82,7 +82,7 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      cmake --build _build --config Release -j${NPROC} &&\
      ccache -s
 # tests
-RUN export PATH=/root/miniconda3/condabin:$PATH && \                                                                                                                                                                                                                               \
+RUN export PATH=/root/miniconda3/condabin:$PATH && \
               SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages && \
               XPRESS_DIR=/root/miniconda3 && \
               export XPRESSDIR=$XPRESS_DIR && \

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -82,7 +82,7 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      cmake --build _build --config Release -j${NPROC} &&\
      ccache -s
 # tests
-RUN export PATH=/root/miniconda3/condabin:$PATH &&                                                                                                                                                                                                                                \
+RUN export PATH=/root/miniconda3/condabin:$PATH && \                                                                                                                                                                                                                               \
               SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages && \
               XPRESS_DIR=/root/miniconda3 && \
               export XPRESSDIR=$XPRESS_DIR && \

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -1,4 +1,4 @@
-FROM antaresrte/xpansion-centos7:1.1.1
+FROM antaresrte/xpansion-centos7:1.1.2
 
 
 
@@ -83,9 +83,9 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      ccache -s
 # tests
 RUN export PATH=/root/miniconda3/condabin:$PATH && \
-              XPRESS_DIR=/root/miniconda3/lib/python3.8/site-packages/xpress && \
+              XPRESS_DIR=/root/miniconda3/lib/python3.8/site-packages/xpresslibs && \
               export XPRESSDIR=$XPRESS_DIR \
-              export XPAUTH_PATH=$XPRESS_DIR/license/community-xpauth.xpr && \
+              export XPAUTH_PATH=/root/miniconda3/lib/python3.8/site-packages/xpress/license/community-xpauth.xpr && \
               echo "Create symbolic link for XPRESS library file because it is missing in the Python installation" && \
               ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so && \
               export PATH="/workspace/antares-xpansion/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH" && \

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -82,14 +82,11 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      cmake --build _build --config Release -j${NPROC} &&\
      ccache -s
 # tests
-RUN export PATH=/root/miniconda3/condabin:$PATH && \
-    SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages && \
-              XPRESS_DIR=$SITE_PACKAGE/xpresslibs && \
+RUN export PATH=/root/miniconda3/condabin:$PATH &&                                                                                                                                                                                                                                \
+              SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages && \
+              XPRESS_DIR=/root/miniconda3 && \
               export XPRESSDIR=$XPRESS_DIR && \
               export XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr && \
-              ls $XPRESSDIR && \
-              echo "----" && \
-              ls $XPAUTH_PATH && \
               echo "Create symbolic link for XPRESS library file because it is missing in the Python installation" && \
               ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so && \
               export PATH="/workspace/antares-xpansion/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH" && \

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -83,9 +83,13 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      ccache -s
 # tests
 RUN export PATH=/root/miniconda3/condabin:$PATH && \
-              XPRESS_DIR=/root/miniconda3/lib/python3.8/site-packages/xpresslibs && \
-              export XPRESSDIR=$XPRESS_DIR \
-              export XPAUTH_PATH=/root/miniconda3/lib/python3.8/site-packages/xpress/license/community-xpauth.xpr && \
+    SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages \
+              XPRESS_DIR=$SITE_PACKAGE/xpresslibs && \
+              export XPRESSDIR=$XPRESS_DIR && \
+              export XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr && \
+              ls $XPRESSDIR && \
+              ls "----" && \
+              ls $XPAUTH_PATH && \
               echo "Create symbolic link for XPRESS library file because it is missing in the Python installation" && \
               ln -s $XPRESS_DIR/lib/libxprs.so.42 $XPRESS_DIR/lib/libxprs.so && \
               export PATH="/workspace/antares-xpansion/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH" && \

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -83,7 +83,7 @@ RUN  source /opt/rh/devtoolset-11/enable && \
      ccache -s
 # tests
 RUN export PATH=/root/miniconda3/condabin:$PATH && \
-    SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages \
+    SITE_PACKAGE=/root/miniconda3/lib/python3.8/site-packages && \
               XPRESS_DIR=$SITE_PACKAGE/xpresslibs && \
               export XPRESSDIR=$XPRESS_DIR && \
               export XPAUTH_PATH=$SITE_PACKAGE/xpress/license/community-xpauth.xpr && \

--- a/docker/centos7-system-deps
+++ b/docker/centos7-system-deps
@@ -32,7 +32,7 @@ RUN \
     rm -f Miniconda3-py38_23.5.1-0-Linux-x86_64.sh
 
 RUN export PATH=/root/miniconda3/condabin:$PATH && \
-    conda install -c fico-xpress "xpress==9.2.7"
+    conda install -c fico-xpress "xpress==9.2.12"
 
 
 # Install CMake

--- a/tests/cpp/sensitivity/SensitivityStudyTest.cpp
+++ b/tests/cpp/sensitivity/SensitivityStudyTest.cpp
@@ -1,539 +1,672 @@
+#include "antares-xpansion/multisolver_interface/SolverFactory.h"
+#include "antares-xpansion/multisolver_interface/environment.h"
 #include "antares-xpansion/sensitivity/SensitivityFileLogger.h"
 #include "antares-xpansion/sensitivity/SensitivityStudy.h"
 #include "gtest/gtest.h"
-#include "antares-xpansion/multisolver_interface/SolverFactory.h"
-#include "antares-xpansion/multisolver_interface/environment.h"
 
-class SensitivityStudyTest : public ::testing::Test {
- public:
-  const std::string coin_name = "CBC";
-  const std::string xpress_name = "XPRESS";
+class SensitivityStudyTest: public ::testing::Test
+{
+public:
+    const std::string coin_name = "CBC";
+    const std::string xpress_name = "XPRESS";
 
-  std::string data_test_dir;
+    std::string data_test_dir;
 
-  const std::string semibase_name = "semibase";
-  const std::string peak_name = "peak";
-  const std::string pv_name = "pv";
-  const std::string battery_name = "battery";
-  const std::string transmission_name = "transmission_line";
+    const std::string semibase_name = "semibase";
+    const std::string peak_name = "peak";
+    const std::string pv_name = "pv";
+    const std::string battery_name = "battery";
+    const std::string transmission_name = "transmission_line";
 
-  std::vector<std::string> candidate_names;
+    std::vector<std::string> candidate_names;
 
-  SolverAbstract::Ptr math_problem;
+    SolverAbstract::Ptr math_problem;
 
-  std::shared_ptr<SensitivityILogger> logger;
-  std::shared_ptr<SensitivityWriter> writer;
+    std::shared_ptr<SensitivityILogger> logger;
+    std::shared_ptr<SensitivityWriter> writer;
 
-  SensitivityInputData input_data;
+    SensitivityInputData input_data;
 
- protected:
-  void SetUp() override {
-    data_test_dir = "data_test/sensitivity";
+protected:
+    void SetUp() override
+    {
+        data_test_dir = "data_test/sensitivity";
 
-    std::string logger_filename = std::tmpnam(nullptr);
-    logger = std::make_shared<SensitivityFileLogger>(logger_filename);
+        std::string logger_filename = std::tmpnam(nullptr);
+        logger = std::make_shared<SensitivityFileLogger>(logger_filename);
 
-    std::string json_filename = std::tmpnam(nullptr);
-    writer = std::make_shared<SensitivityWriter>(json_filename);
-  }
-
-  void init_solver(std::string solver_name, std::string last_master_mps_path) {
-    SolverFactory factory;
-    auto solver_log_manager = SolverLogManager(std::tmpnam(nullptr));
-    math_problem = factory.create_solver(solver_name, solver_log_manager);
-    math_problem->read_prob_mps(last_master_mps_path);
-  }
-
-  std::string prepare_toy_sensitivity_pb(
-      bool capex = true, std::vector<std::string> projection_candidates = {}) {
-    double epsilon = 100;
-    double best_ub = 1390;
-    double benders_capex = 12;
-    std::map<std::string, double> benders_solution = {{peak_name, 14},
-                                                      {semibase_name, 10}};
-
-    std::map<std::string, int> name_to_id = {{peak_name, 0},
-                                             {semibase_name, 1}};
-
-    std::map<std::string, std::pair<double, double>> candidates_bounds = {
-        {peak_name, {0, 3000}}, {semibase_name, {0, 400}}};
-
-    std::string toy_basis_path = data_test_dir + "/toy_basis.bss";
-
-    input_data = {epsilon,        best_ub,
-                  benders_capex,  benders_solution,
-                  name_to_id,     nullptr,
-                  toy_basis_path, candidates_bounds,
-                  capex,          projection_candidates};
-    return data_test_dir + "/toy_last_iteration.mps";
-  }
-
-  std::string prepare_real_sensitivity_pb(
-      bool capex = true, std::vector<std::string> projection_candidates = {}) {
-    double epsilon = 10000;
-    double best_ub = 1440683382.5376825;
-    double benders_capex = 1234;
-    std::map<std::string, double> benders_solution = {{semibase_name, 12},
-                                                      {peak_name, 34},
-                                                      {pv_name, 56},
-                                                      {battery_name, 78},
-                                                      {transmission_name, 90}};
-
-    std::map<std::string, int> name_to_id = {{semibase_name, 3},
-                                             {peak_name, 1},
-                                             {pv_name, 2},
-                                             {battery_name, 0},
-                                             {transmission_name, 4}};
-
-    std::map<std::string, std::pair<double, double>> candidates_bounds = {
-        {peak_name, {0, 2000}},
-        {semibase_name, {0, 2000}},
-        {battery_name, {0, 1000}},
-        {pv_name, {0, 1000}},
-        {transmission_name, {0, 3200}}};
-
-    std::string real_basis_path = data_test_dir + "/real_basis.bss";
-
-    input_data = {epsilon,         best_ub,
-                  benders_capex,   benders_solution,
-                  name_to_id,      nullptr,
-                  real_basis_path, candidates_bounds,
-                  capex,           projection_candidates};
-    return data_test_dir + "/real_last_iteration.mps";
-  }
-
-  void launch_tests(
-      std::string mps_path,
-      std::map<std::string, std::vector<SinglePbData>> expec_output_data_map) {
-    std::vector<std::string> solvers_name = {coin_name};
-    LoadXpress::XpressLoader xpress_loader;
-    if (xpress_loader.XpressIsCorrectlyInstalled()) {
-      solvers_name.push_back(xpress_name);
+        std::string json_filename = std::tmpnam(nullptr);
+        writer = std::make_shared<SensitivityWriter>(json_filename);
     }
 
-    for (auto solver_name : solvers_name) {
-      init_solver(solver_name, mps_path);
-      input_data.last_master = math_problem;
-
-      auto sensitivity_study = SensitivityStudy(input_data, logger, writer);
-      sensitivity_study.launch();
-
-      auto output_data = sensitivity_study.get_output_data();
-      verify_output_data(output_data, expec_output_data_map[solver_name]);
+    void init_solver(std::string solver_name, std::string last_master_mps_path)
+    {
+        SolverFactory factory;
+        auto solver_log_manager = SolverLogManager(std::tmpnam(nullptr));
+        math_problem = factory.create_solver(solver_name, solver_log_manager);
+        math_problem->read_prob_mps(last_master_mps_path);
     }
-  }
 
-  std::stringstream get_single_pb_data_stream(const SinglePbData &pb_data) {
-    std::stringstream ss;
-    ss << std::endl;
-    ss << "The problem data that has found no match is the following :"
-       << std::endl;
-    ss << "Problem type: " << pb_data.str_pb_type << std::endl;
-    ss << "Candidate name: " << pb_data.candidate_name << std::endl;
-    ss << "Optimization direction: " << pb_data.opt_dir << std::endl;
-    ss << "Objective: " << std::fixed << std::setprecision(16)
-       << pb_data.objective << std::endl;
-    ss << "System cost: " << pb_data.system_cost << std::endl;
-    ss << "Solver status: " << pb_data.solver_status << std::endl;
-    ss << "Candidates: " << std::endl;
-    for (auto candidate : pb_data.candidates) {
-      ss << indent_1 << candidate.first << " " << candidate.second << std::endl;
+    std::string prepare_toy_sensitivity_pb(bool capex = true,
+                                           std::vector<std::string> projection_candidates = {})
+    {
+        double epsilon = 100;
+        double best_ub = 1390;
+        double benders_capex = 12;
+        std::map<std::string, double> benders_solution = {{peak_name, 14}, {semibase_name, 10}};
+
+        std::map<std::string, int> name_to_id = {{peak_name, 0}, {semibase_name, 1}};
+
+        std::map<std::string, std::pair<double, double>> candidates_bounds = {{peak_name,
+                                                                               {0, 3000}},
+                                                                              {semibase_name,
+                                                                               {0, 400}}};
+
+        std::string toy_basis_path = data_test_dir + "/toy_basis.bss";
+
+        input_data = {epsilon,
+                      best_ub,
+                      benders_capex,
+                      benders_solution,
+                      name_to_id,
+                      nullptr,
+                      toy_basis_path,
+                      candidates_bounds,
+                      capex,
+                      projection_candidates};
+        return data_test_dir + "/toy_last_iteration.mps";
     }
-    ss << std::endl;
-    return ss;
-  }
 
-  bool areEquals(const Point &left, const Point &right) {
-    if (left.size() != right.size()) return false;
+    std::string prepare_real_sensitivity_pb(bool capex = true,
+                                            std::vector<std::string> projection_candidates = {})
+    {
+        double epsilon = 10000;
+        double best_ub = 1440683382.5376825;
+        double benders_capex = 1234;
+        std::map<std::string, double> benders_solution = {{semibase_name, 12},
+                                                          {peak_name, 34},
+                                                          {pv_name, 56},
+                                                          {battery_name, 78},
+                                                          {transmission_name, 90}};
 
-    for (auto candidate_it = left.begin(), expec_candidate_it = right.begin();
-         candidate_it != left.end(), expec_candidate_it != right.end();
-         candidate_it++, expec_candidate_it++) {
-      if (candidate_it->first != expec_candidate_it->first) return false;
-      if (fabs(candidate_it->second - expec_candidate_it->second) /
-              fabs(expec_candidate_it->second) >
-          1e-6)
-        return false;
+        std::map<std::string, int> name_to_id = {{semibase_name, 3},
+                                                 {peak_name, 1},
+                                                 {pv_name, 2},
+                                                 {battery_name, 0},
+                                                 {transmission_name, 4}};
+
+        std::map<std::string, std::pair<double, double>> candidates_bounds = {
+          {peak_name, {0, 2000}},
+          {semibase_name, {0, 2000}},
+          {battery_name, {0, 1000}},
+          {pv_name, {0, 1000}},
+          {transmission_name, {0, 3200}}};
+
+        std::string real_basis_path = data_test_dir + "/real_basis.bss";
+
+        input_data = {epsilon,
+                      best_ub,
+                      benders_capex,
+                      benders_solution,
+                      name_to_id,
+                      nullptr,
+                      real_basis_path,
+                      candidates_bounds,
+                      capex,
+                      projection_candidates};
+        return data_test_dir + "/real_last_iteration.mps";
     }
-    return true;
-  }
 
-  bool areEquals(const SinglePbData &left, const SinglePbData &right) {
-    return left.pb_type == right.pb_type &&
-           left.str_pb_type == right.str_pb_type &&
-           left.candidate_name == right.candidate_name &&
-           left.opt_dir == right.opt_dir &&
-           fabs(left.objective - right.objective) /
-                   (fabs(right.objective) + 1e-10) <
-               1e-8 &&
-           fabs(left.system_cost - right.system_cost) /
-                   (fabs(right.system_cost) + 1e-10) <
-               1e-8 &&
-           left.solver_status == right.solver_status &&
-           areEquals(left.candidates, right.candidates);
-  }
+    void launch_tests(std::string mps_path,
+                      std::map<std::string, std::vector<SinglePbData>> expec_output_data_map)
+    {
+        std::vector<std::string> solvers_name = {coin_name};
+        LoadXpress::XpressLoader xpress_loader;
+        if (xpress_loader.XpressIsCorrectlyInstalled())
+        {
+            solvers_name.push_back(xpress_name);
+        }
 
-  void verify_output_data(const std::vector<SinglePbData> &pbs_data,
-                          std::vector<SinglePbData> expec_pbs_data) {
-    ASSERT_EQ(pbs_data.size(), expec_pbs_data.size());
+        for (auto solver_name: solvers_name)
+        {
+            init_solver(solver_name, mps_path);
+            input_data.last_master = math_problem;
 
-    for (auto leftMatch : pbs_data) {
-      auto rightMatch =
-          std::find_if(expec_pbs_data.begin(), expec_pbs_data.end(),
-                       [&leftMatch, this](const SinglePbData &data) {
-                         return areEquals(leftMatch, data);
-                       });
-      ASSERT_NE(rightMatch, expec_pbs_data.end())
-          << get_single_pb_data_stream(leftMatch).str();
-      expec_pbs_data.erase(rightMatch);
+            auto sensitivity_study = SensitivityStudy(input_data, logger, writer);
+            sensitivity_study.launch();
+
+            auto output_data = sensitivity_study.get_output_data();
+            verify_output_data(output_data, expec_output_data_map[solver_name]);
+        }
     }
-    ASSERT_EQ(expec_pbs_data.size(), 0);
-  }
 
-  void verify_single_pb_data(const SinglePbData &single_pb_data,
-                             const SinglePbData &expec_single_pb_data) {
-    EXPECT_EQ(single_pb_data.pb_type, expec_single_pb_data.pb_type);
-    EXPECT_EQ(single_pb_data.str_pb_type, expec_single_pb_data.str_pb_type);
-    EXPECT_EQ(single_pb_data.candidate_name,
-              expec_single_pb_data.candidate_name);
-    EXPECT_EQ(single_pb_data.opt_dir, expec_single_pb_data.opt_dir);
-    EXPECT_NEAR(single_pb_data.objective, expec_single_pb_data.objective, 1e-6);
-    EXPECT_NEAR(single_pb_data.system_cost, expec_single_pb_data.system_cost,
-                1e-6);
-    EXPECT_EQ(single_pb_data.solver_status, expec_single_pb_data.solver_status);
-
-    verify_candidates(single_pb_data.candidates,
-                      expec_single_pb_data.candidates);
-  }
-
-  void verify_candidates(const Point &candidates,
-                         const Point &expec_candidates) {
-    ASSERT_EQ(candidates.size(), expec_candidates.size());
-
-    for (auto candidate_it = candidates.begin(),
-              expec_candidate_it = expec_candidates.begin();
-         candidate_it != candidates.end(),
-              expec_candidate_it != expec_candidates.end();
-         candidate_it++, expec_candidate_it++) {
-      EXPECT_EQ(candidate_it->first, expec_candidate_it->first);
-      EXPECT_NEAR(candidate_it->second, expec_candidate_it->second, 1e-6);
+    std::stringstream get_single_pb_data_stream(const SinglePbData& pb_data)
+    {
+        std::stringstream ss;
+        ss << std::endl;
+        ss << "The problem data that has found no match is the following :" << std::endl;
+        ss << "Problem type: " << pb_data.str_pb_type << std::endl;
+        ss << "Candidate name: " << pb_data.candidate_name << std::endl;
+        ss << "Optimization direction: " << pb_data.opt_dir << std::endl;
+        ss << "Objective: " << std::fixed << std::setprecision(16) << pb_data.objective
+           << std::endl;
+        ss << "System cost: " << pb_data.system_cost << std::endl;
+        ss << "Solver status: " << pb_data.solver_status << std::endl;
+        ss << "Candidates: " << std::endl;
+        for (auto candidate: pb_data.candidates)
+        {
+            ss << indent_1 << candidate.first << " " << candidate.second << std::endl;
+        }
+        ss << std::endl;
+        return ss;
     }
-  }
+
+    bool areEquals(const Point& left, const Point& right)
+    {
+        if (left.size() != right.size())
+        {
+            return false;
+        }
+
+        for (auto candidate_it = left.begin(), expec_candidate_it = right.begin();
+             candidate_it != left.end(), expec_candidate_it != right.end();
+             candidate_it++, expec_candidate_it++)
+        {
+            if (candidate_it->first != expec_candidate_it->first)
+            {
+                return false;
+            }
+            if (fabs(candidate_it->second - expec_candidate_it->second)
+                  / fabs(expec_candidate_it->second)
+                > 1e-6)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool areEquals(const SinglePbData& left, const SinglePbData& right)
+    {
+        return left.pb_type == right.pb_type && left.str_pb_type == right.str_pb_type
+               && left.candidate_name == right.candidate_name && left.opt_dir == right.opt_dir
+               && fabs(left.objective - right.objective) / (fabs(right.objective) + 1e-10) < 1e-8
+               && fabs(left.system_cost - right.system_cost) / (fabs(right.system_cost) + 1e-10)
+                    < 1e-8
+               && left.solver_status == right.solver_status
+               && areEquals(left.candidates, right.candidates);
+    }
+
+    void verify_output_data(const std::vector<SinglePbData>& pbs_data,
+                            std::vector<SinglePbData> expec_pbs_data)
+    {
+        ASSERT_EQ(pbs_data.size(), expec_pbs_data.size());
+
+        for (auto leftMatch: pbs_data)
+        {
+            auto rightMatch = std::find_if(expec_pbs_data.begin(),
+                                           expec_pbs_data.end(),
+                                           [&leftMatch, this](const SinglePbData& data)
+                                           { return areEquals(leftMatch, data); });
+            ASSERT_NE(rightMatch, expec_pbs_data.end())
+              << get_single_pb_data_stream(leftMatch).str();
+            expec_pbs_data.erase(rightMatch);
+        }
+        ASSERT_EQ(expec_pbs_data.size(), 0);
+    }
+
+    void verify_single_pb_data(const SinglePbData& single_pb_data,
+                               const SinglePbData& expec_single_pb_data)
+    {
+        EXPECT_EQ(single_pb_data.pb_type, expec_single_pb_data.pb_type);
+        EXPECT_EQ(single_pb_data.str_pb_type, expec_single_pb_data.str_pb_type);
+        EXPECT_EQ(single_pb_data.candidate_name, expec_single_pb_data.candidate_name);
+        EXPECT_EQ(single_pb_data.opt_dir, expec_single_pb_data.opt_dir);
+        EXPECT_NEAR(single_pb_data.objective, expec_single_pb_data.objective, 1e-6);
+        EXPECT_NEAR(single_pb_data.system_cost, expec_single_pb_data.system_cost, 1e-6);
+        EXPECT_EQ(single_pb_data.solver_status, expec_single_pb_data.solver_status);
+
+        verify_candidates(single_pb_data.candidates, expec_single_pb_data.candidates);
+    }
+
+    void verify_candidates(const Point& candidates, const Point& expec_candidates)
+    {
+        ASSERT_EQ(candidates.size(), expec_candidates.size());
+
+        for (auto candidate_it = candidates.begin(), expec_candidate_it = expec_candidates.begin();
+             candidate_it != candidates.end(), expec_candidate_it != expec_candidates.end();
+             candidate_it++, expec_candidate_it++)
+        {
+            EXPECT_EQ(candidate_it->first, expec_candidate_it->first);
+            EXPECT_NEAR(candidate_it->second, expec_candidate_it->second, 1e-6);
+        }
+    }
 };
 
-class SensitivityLogMock : public SensitivityILogger {
- public:
-  SensitivityLogMock() = default;
+class SensitivityLogMock: public SensitivityILogger
+{
+public:
+    SensitivityLogMock() = default;
 
-  std::string displayed_message;
-  bool display_message_called = false;
+    std::string displayed_message;
+    bool display_message_called = false;
 
-  void display_message(const std::string &str) override {
-    displayed_message = str;
-    display_message_called = true;
-  }
-  void log_at_start(const SensitivityInputData &input_data) override {}
-  void log_begin_pb_resolution(const SinglePbData &pb_data) override {}
-  void log_pb_solution(const SinglePbData &pb_data) override {}
-  void log_summary(const SensitivityInputData &input_data,
-                   const std::vector<SinglePbData> &pbs_data) override {}
-  void log_at_ending() override {}
+    void display_message(const std::string& str) override
+    {
+        displayed_message = str;
+        display_message_called = true;
+    }
+
+    void log_at_start(const SensitivityInputData& input_data) override
+    {
+    }
+
+    void log_begin_pb_resolution(const SinglePbData& pb_data) override
+    {
+    }
+
+    void log_pb_solution(const SinglePbData& pb_data) override
+    {
+    }
+
+    void log_summary(const SensitivityInputData& input_data,
+                     const std::vector<SinglePbData>& pbs_data) override
+    {
+    }
+
+    void log_at_ending() override
+    {
+    }
 };
 
-TEST_F(SensitivityStudyTest, EmptyStudy) {
-  input_data.capex = false;
-  input_data.projection = {};
-  auto _logger = std::make_shared<SensitivityLogMock>();
-  auto sensitivity_study = SensitivityStudy(input_data, _logger, writer);
-  sensitivity_study.launch();
+TEST_F(SensitivityStudyTest, EmptyStudy)
+{
+    input_data.capex = false;
+    input_data.projection = {};
+    auto _logger = std::make_shared<SensitivityLogMock>();
+    auto sensitivity_study = SensitivityStudy(input_data, _logger, writer);
+    sensitivity_study.launch();
 
-  std::string message = "Study is empty. No capex or projection provided.";
-  EXPECT_TRUE(_logger->display_message_called);
-  EXPECT_EQ(_logger->displayed_message, message);
+    std::string message = "Study is empty. No capex or projection provided.";
+    EXPECT_TRUE(_logger->display_message_called);
+    EXPECT_EQ(_logger->displayed_message, message);
 }
 
-TEST_F(SensitivityStudyTest, CandidateIgnored) {
-  prepare_toy_sensitivity_pb();
+TEST_F(SensitivityStudyTest, CandidateIgnored)
+{
+    prepare_toy_sensitivity_pb();
 
-  std::string cand_name = "i_am_not_in_the_list";
-  input_data.projection = {cand_name};
-  input_data.capex = false;
+    std::string cand_name = "i_am_not_in_the_list";
+    input_data.projection = {cand_name};
+    input_data.capex = false;
 
-  auto _logger = std::make_shared<SensitivityLogMock>();
-  auto sensitivity_study = SensitivityStudy(input_data, _logger, writer);
-  sensitivity_study.launch();
+    auto _logger = std::make_shared<SensitivityLogMock>();
+    auto sensitivity_study = SensitivityStudy(input_data, _logger, writer);
+    sensitivity_study.launch();
 
-  std::string message = "Warning: " + cand_name +
-                        " ignored as it has not been found in the list "
-                        "of investment candidates";
-  EXPECT_TRUE(_logger->display_message_called);
-  EXPECT_EQ(_logger->displayed_message, message);
+    std::string message = "Warning: " + cand_name
+                          + " ignored as it has not been found in the list "
+                            "of investment candidates";
+    EXPECT_TRUE(_logger->display_message_called);
+    EXPECT_EQ(_logger->displayed_message, message);
 }
 
-TEST_F(SensitivityStudyTest, BasisNonExistent) {
-  std::string mps_path = prepare_toy_sensitivity_pb();
-  init_solver(coin_name, mps_path);
-  input_data.last_master = math_problem;
+TEST_F(SensitivityStudyTest, BasisNonExistent)
+{
+    std::string mps_path = prepare_toy_sensitivity_pb();
+    init_solver(coin_name, mps_path);
+    input_data.last_master = math_problem;
 
-  std::string mock_basis_path = "wrong_path.something";
-  input_data.basis_file_path = mock_basis_path;
+    std::string mock_basis_path = "wrong_path.something";
+    input_data.basis_file_path = mock_basis_path;
 
-  auto _logger = std::make_shared<SensitivityLogMock>();
-  auto sensitivity_study = SensitivityStudy(input_data, _logger, writer);
-  sensitivity_study.launch();
+    auto _logger = std::make_shared<SensitivityLogMock>();
+    auto sensitivity_study = SensitivityStudy(input_data, _logger, writer);
+    sensitivity_study.launch();
 
-  std::string message =
-      "Warning: Basis file " + mock_basis_path + " could not be read.";
-  EXPECT_TRUE(_logger->display_message_called);
-  EXPECT_EQ(_logger->displayed_message, message);
+    std::string message = "Warning: Basis file " + mock_basis_path + " could not be read.";
+    EXPECT_TRUE(_logger->display_message_called);
+    EXPECT_EQ(_logger->displayed_message, message);
 }
 
-TEST_F(SensitivityStudyTest, OutputDataInit) {
-  std::string mps_path = prepare_toy_sensitivity_pb();
-  init_solver(coin_name, mps_path);
+TEST_F(SensitivityStudyTest, OutputDataInit)
+{
+    std::string mps_path = prepare_toy_sensitivity_pb();
+    init_solver(coin_name, mps_path);
 
-  auto sensitivity_study = SensitivityStudy(input_data, logger, writer);
-  std::vector<SinglePbData> expec_output_data = {};
-  auto output_data = sensitivity_study.get_output_data();
+    auto sensitivity_study = SensitivityStudy(input_data, logger, writer);
+    std::vector<SinglePbData> expec_output_data = {};
+    auto output_data = sensitivity_study.get_output_data();
 
-  verify_output_data(output_data, expec_output_data);
+    verify_output_data(output_data, expec_output_data);
 }
 
-TEST_F(SensitivityStudyTest, GetCapexSolutions) {
-  std::string mps_path = prepare_toy_sensitivity_pb(true, {});
+TEST_F(SensitivityStudyTest, GetCapexSolutions)
+{
+    std::string mps_path = prepare_toy_sensitivity_pb(true, {});
 
-  // In this capex test, the cuts do not constrain too much the overall system
-  // cost, which induces differences between solvers.
-  auto capex_min_data = SinglePbData(
-      SensitivityPbType::CAPEX, CAPEX_C, "", MIN_C, 1040, 1390,
-      {{peak_name, 14}, {semibase_name, 10}}, SOLVER_STATUS::OPTIMAL);
+    // In this capex test, the cuts do not constrain too much the overall system
+    // cost, which induces differences between solvers.
+    auto capex_min_data = SinglePbData(SensitivityPbType::CAPEX,
+                                       CAPEX_C,
+                                       "",
+                                       MIN_C,
+                                       1040,
+                                       1390,
+                                       {{peak_name, 14}, {semibase_name, 10}},
+                                       SOLVER_STATUS::OPTIMAL);
 
-  auto capex_max_data = SinglePbData(
-      SensitivityPbType::CAPEX, CAPEX_C, "", MAX_C, 1224.745762711, 1490,
-      {{peak_name, 17.22033898}, {semibase_name, 11.69491525}},
-      SOLVER_STATUS::OPTIMAL);
+    auto capex_max_data = SinglePbData(SensitivityPbType::CAPEX,
+                                       CAPEX_C,
+                                       "",
+                                       MAX_C,
+                                       1224.745762711,
+                                       1490,
+                                       {{peak_name, 17.22033898}, {semibase_name, 11.69491525}},
+                                       SOLVER_STATUS::OPTIMAL);
 
-  std::vector<SinglePbData> pbs_data = {capex_min_data, capex_max_data};
+    std::vector<SinglePbData> pbs_data = {capex_min_data, capex_max_data};
 
-  std::map<std::string, std::vector<SinglePbData>> expec_output_data_map = {
-      {coin_name, pbs_data}, {xpress_name, pbs_data}};
+    std::map<std::string, std::vector<SinglePbData>> expec_output_data_map = {{coin_name, pbs_data},
+                                                                              {xpress_name,
+                                                                               pbs_data}};
 
-  launch_tests(mps_path, expec_output_data_map);
+    launch_tests(mps_path, expec_output_data_map);
 }
 
-TEST_F(SensitivityStudyTest, GetCandidatesProjection) {
-  std::string mps_path =
-      prepare_toy_sensitivity_pb(false, {peak_name, semibase_name});
+TEST_F(SensitivityStudyTest, GetCandidatesProjection)
+{
+    std::string mps_path = prepare_toy_sensitivity_pb(false, {peak_name, semibase_name});
 
-  auto projection_min_peak =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, peak_name,
-                   MIN_C, 13.83050847, 1490,
-                   {{peak_name, 13.83050847}, {semibase_name, 11.694915254}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_min_peak = SinglePbData(SensitivityPbType::PROJECTION,
+                                            PROJECTION_C,
+                                            peak_name,
+                                            MIN_C,
+                                            13.83050847,
+                                            1490,
+                                            {{peak_name, 13.83050847},
+                                             {semibase_name, 11.694915254}},
+                                            SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_peak = SinglePbData(
-      SensitivityPbType::PROJECTION, PROJECTION_C, peak_name, MAX_C, 24, 1490,
-      {{peak_name, 24}, {semibase_name, 10}}, SOLVER_STATUS::OPTIMAL);
+    auto projection_max_peak = SinglePbData(SensitivityPbType::PROJECTION,
+                                            PROJECTION_C,
+                                            peak_name,
+                                            MAX_C,
+                                            24,
+                                            1490,
+                                            {{peak_name, 24}, {semibase_name, 10}},
+                                            SOLVER_STATUS::OPTIMAL);
 
-  auto projection_min_semibase = SinglePbData(
-      SensitivityPbType::PROJECTION, PROJECTION_C, semibase_name, MIN_C, 10,
-      1390, {{peak_name, 14}, {semibase_name, 10}}, SOLVER_STATUS::OPTIMAL);
+    auto projection_min_semibase = SinglePbData(SensitivityPbType::PROJECTION,
+                                                PROJECTION_C,
+                                                semibase_name,
+                                                MIN_C,
+                                                10,
+                                                1390,
+                                                {{peak_name, 14}, {semibase_name, 10}},
+                                                SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_semibase_cbc =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, semibase_name,
-                   MAX_C, 11.694915254, 1490,
-                   {{peak_name, 13.83050847}, {semibase_name, 11.694915254}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_max_semibase_cbc = SinglePbData(SensitivityPbType::PROJECTION,
+                                                    PROJECTION_C,
+                                                    semibase_name,
+                                                    MAX_C,
+                                                    11.694915254,
+                                                    1490,
+                                                    {{peak_name, 13.83050847},
+                                                     {semibase_name, 11.694915254}},
+                                                    SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_semibase_xpress = projection_max_semibase_cbc;
-  projection_max_semibase_xpress.candidates[peak_name] = 17.22033898;
+    auto projection_max_semibase_xpress = projection_max_semibase_cbc;
+    projection_max_semibase_xpress.candidates[peak_name] = 17.22033898;
 
-  std::vector<SinglePbData> pbs_data_cbc = {
-      projection_min_peak, projection_max_peak, projection_min_semibase,
-      projection_max_semibase_cbc};
+    std::vector<SinglePbData> pbs_data_cbc = {projection_min_peak,
+                                              projection_max_peak,
+                                              projection_min_semibase,
+                                              projection_max_semibase_cbc};
 
-  std::vector<SinglePbData> pbs_data_xpress = {
-      projection_min_peak, projection_max_peak, projection_min_semibase,
-      projection_max_semibase_xpress};
+    std::vector<SinglePbData> pbs_data_xpress = {projection_min_peak,
+                                                 projection_max_peak,
+                                                 projection_min_semibase,
+                                                 projection_max_semibase_xpress};
 
-  std::map<std::string, std::vector<SinglePbData>> expec_output_data_map = {
-      {coin_name, pbs_data_cbc}, {xpress_name, pbs_data_xpress}};
+    std::map<std::string, std::vector<SinglePbData>> expec_output_data_map = {{coin_name,
+                                                                               pbs_data_cbc},
+                                                                              {xpress_name,
+                                                                               pbs_data_xpress}};
 
-  launch_tests(mps_path, expec_output_data_map);
+    launch_tests(mps_path, expec_output_data_map);
 }
 
-TEST_F(SensitivityStudyTest, FullSensitivityTest) {
-  std::string mps_path = prepare_real_sensitivity_pb(
+TEST_F(SensitivityStudyTest, FullSensitivityTest)
+{
+    std::string mps_path = prepare_real_sensitivity_pb(
       true,
       {semibase_name, peak_name, pv_name, battery_name, transmission_name});
 
-  auto capex_min_data =
-      SinglePbData(SensitivityPbType::CAPEX, CAPEX_C, "", MIN_C,
-                   299860860.094227, 1440693382.53768253,
-                   {{battery_name, 511.01433490373716},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto capex_min_data = SinglePbData(SensitivityPbType::CAPEX,
+                                       CAPEX_C,
+                                       "",
+                                       MIN_C,
+                                       299860860.094227,
+                                       1440693382.53768253,
+                                       {{battery_name, 511.01433490373716},
+                                        {peak_name, 1500},
+                                        {pv_name, 0},
+                                        {semibase_name, 1200},
+                                        {transmission_name, 2800}},
+                                       SOLVER_STATUS::OPTIMAL);
 
-  auto capex_max_data =
-      SinglePbData(SensitivityPbType::CAPEX, CAPEX_C, "", MAX_C,
-                   300394980.4731960, 1440693382.53768134,
-                   {{battery_name, 519.91634122019002},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto capex_max_data = SinglePbData(SensitivityPbType::CAPEX,
+                                       CAPEX_C,
+                                       "",
+                                       MAX_C,
+                                       300394980.4731960,
+                                       1440693382.53768134,
+                                       {{battery_name, 519.91634122019002},
+                                        {peak_name, 1500},
+                                        {pv_name, 0},
+                                        {semibase_name, 1200},
+                                        {transmission_name, 2800}},
+                                       SOLVER_STATUS::OPTIMAL);
 
-  auto projection_min_semibase =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, semibase_name,
-                   MIN_C, 1200, 1440693382.5376825,
-                   {{battery_name, 519.91634122019059},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_min_semibase = SinglePbData(SensitivityPbType::PROJECTION,
+                                                PROJECTION_C,
+                                                semibase_name,
+                                                MIN_C,
+                                                1200,
+                                                1440693382.5376825,
+                                                {{battery_name, 519.91634122019059},
+                                                 {peak_name, 1500},
+                                                 {pv_name, 0},
+                                                 {semibase_name, 1200},
+                                                 {transmission_name, 2800}},
+                                                SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_semibase =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, semibase_name,
-                   MAX_C, 1200, 1440693382.5376825,
-                   {{battery_name, 519.91634122015228},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_max_semibase = SinglePbData(SensitivityPbType::PROJECTION,
+                                                PROJECTION_C,
+                                                semibase_name,
+                                                MAX_C,
+                                                1200,
+                                                1440693382.5376825,
+                                                {{battery_name, 519.91634122015228},
+                                                 {peak_name, 1500},
+                                                 {pv_name, 0},
+                                                 {semibase_name, 1200},
+                                                 {transmission_name, 2800}},
+                                                SOLVER_STATUS::OPTIMAL);
 
-  auto projection_min_peak =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, peak_name,
-                   MIN_C, 1500, 1440693382.5376825,
-                   {{battery_name, 511.01433490344891},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_min_peak = SinglePbData(SensitivityPbType::PROJECTION,
+                                            PROJECTION_C,
+                                            peak_name,
+                                            MIN_C,
+                                            1500,
+                                            1440693382.5376825,
+                                            {{battery_name, 511.01433490344891},
+                                             {peak_name, 1500},
+                                             {pv_name, 0},
+                                             {semibase_name, 1200},
+                                             {transmission_name, 2800}},
+                                            SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_peak =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, peak_name,
-                   MAX_C, 1500, 1440693382.5376825,
-                   {{battery_name, 519.91634122015932},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_max_peak = SinglePbData(SensitivityPbType::PROJECTION,
+                                            PROJECTION_C,
+                                            peak_name,
+                                            MAX_C,
+                                            1500,
+                                            1440693382.5376825,
+                                            {{battery_name, 519.91634122015932},
+                                             {peak_name, 1500},
+                                             {pv_name, 0},
+                                             {semibase_name, 1200},
+                                             {transmission_name, 2800}},
+                                            SOLVER_STATUS::OPTIMAL);
 
-  auto projection_min_pv =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, pv_name, MIN_C,
-                   0, 1440693382.5376825,
-                   {{battery_name, 519.9163412201425},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_min_pv = SinglePbData(SensitivityPbType::PROJECTION,
+                                          PROJECTION_C,
+                                          pv_name,
+                                          MIN_C,
+                                          0,
+                                          1440693382.5376825,
+                                          {{battery_name, 519.9163412201425},
+                                           {peak_name, 1500},
+                                           {pv_name, 0},
+                                           {semibase_name, 1200},
+                                           {transmission_name, 2800}},
+                                          SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_pv =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, pv_name, MAX_C,
-                   1.2427901705828661, 1440693382.5376825,
-                   {{battery_name, 518},
-                    {peak_name, 1500},
-                    {pv_name, 1.2427901706122959},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_max_pv = SinglePbData(SensitivityPbType::PROJECTION,
+                                          PROJECTION_C,
+                                          pv_name,
+                                          MAX_C,
+                                          1.2427901705828661,
+                                          1440693382.5376825,
+                                          {{battery_name, 518},
+                                           {peak_name, 1500},
+                                           {pv_name, 1.2427901706122959},
+                                           {semibase_name, 1200},
+                                           {transmission_name, 2800}},
+                                          SOLVER_STATUS::OPTIMAL);
 
-  auto projection_min_battery =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, battery_name,
-                   MIN_C, 511.0132577770553, 1440693382.5376825,
-                   {{battery_name, 511.0132577770553},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_min_battery = SinglePbData(SensitivityPbType::PROJECTION,
+                                               PROJECTION_C,
+                                               battery_name,
+                                               MIN_C,
+                                               511.01433490365577,
+                                               1440693382.5376825,
+                                               {{battery_name, 511.01433490365577},
+                                                {peak_name, 1500},
+                                                {pv_name, 0},
+                                                {semibase_name, 1200},
+                                                {transmission_name, 2800}},
+                                               SOLVER_STATUS::OPTIMAL);
 
-  auto projection_min_battery_cbc =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, battery_name,
-                   MIN_C, 511.01433490356368, 1440693382.5376825,
-                   {{battery_name, 511.01433490356368},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_min_battery_cbc = SinglePbData(SensitivityPbType::PROJECTION,
+                                                   PROJECTION_C,
+                                                   battery_name,
+                                                   MIN_C,
+                                                   511.01433490356368,
+                                                   1440693382.5376825,
+                                                   {{battery_name, 511.01433490356368},
+                                                    {peak_name, 1500},
+                                                    {pv_name, 0},
+                                                    {semibase_name, 1200},
+                                                    {transmission_name, 2800}},
+                                                   SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_battery =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C, battery_name,
-                   MAX_C, 519.91634122009395, 1440693382.5376825,
-                   {{battery_name, 519.91634122009395},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_max_battery = SinglePbData(SensitivityPbType::PROJECTION,
+                                               PROJECTION_C,
+                                               battery_name,
+                                               MAX_C,
+                                               519.91634122001938,
+                                               1440693382.5376825,
+                                               {{battery_name, 519.91634122001938},
+                                                {peak_name, 1500},
+                                                {pv_name, 0},
+                                                {semibase_name, 1200},
+                                                {transmission_name, 2800}},
+                                               SOLVER_STATUS::OPTIMAL);
 
-  auto projection_min_transmission =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C,
-                   transmission_name, MIN_C, 2800, 1440693382.5376825,
-                   {{battery_name, 519.91634122015114},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_max_battery_cbc = SinglePbData(SensitivityPbType::PROJECTION,
+                                                   PROJECTION_C,
+                                                   battery_name,
+                                                   MAX_C,
+                                                   519.91634122009395,
+                                                   1440693382.5376825,
+                                                   {{battery_name, 519.91634122009395},
+                                                    {peak_name, 1500},
+                                                    {pv_name, 0},
+                                                    {semibase_name, 1200},
+                                                    {transmission_name, 2800}},
+                                                   SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_transmission =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C,
-                   transmission_name, MAX_C, 2800, 1440693382.5376825,
-                   {{battery_name, 519.91634122015114},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_min_transmission = SinglePbData(SensitivityPbType::PROJECTION,
+                                                    PROJECTION_C,
+                                                    transmission_name,
+                                                    MIN_C,
+                                                    2800,
+                                                    1440693382.5376825,
+                                                    {{battery_name, 519.91634122015114},
+                                                     {peak_name, 1500},
+                                                     {pv_name, 0},
+                                                     {semibase_name, 1200},
+                                                     {transmission_name, 2800}},
+                                                    SOLVER_STATUS::OPTIMAL);
 
-  auto projection_max_transmission_cbc =
-      SinglePbData(SensitivityPbType::PROJECTION, PROJECTION_C,
-                   transmission_name, MAX_C, 2800, 1440683382.5376825,
-                   {{battery_name, 517.99999999999739},
-                    {peak_name, 1500},
-                    {pv_name, 0},
-                    {semibase_name, 1200},
-                    {transmission_name, 2800}},
-                   SOLVER_STATUS::OPTIMAL);
+    auto projection_max_transmission = SinglePbData(SensitivityPbType::PROJECTION,
+                                                    PROJECTION_C,
+                                                    transmission_name,
+                                                    MAX_C,
+                                                    2800,
+                                                    1440693382.5376825,
+                                                    {{battery_name, 519.91634122015114},
+                                                     {peak_name, 1500},
+                                                     {pv_name, 0},
+                                                     {semibase_name, 1200},
+                                                     {transmission_name, 2800}},
+                                                    SOLVER_STATUS::OPTIMAL);
 
-  std::vector<SinglePbData> pbs_data_cbc = {capex_min_data,
-                                            capex_max_data,
-                                            projection_min_semibase,
-                                            projection_max_semibase,
-                                            projection_min_peak,
-                                            projection_max_peak,
-                                            projection_min_pv,
-                                            projection_max_pv,
-                                            projection_min_battery_cbc,
-                                            projection_max_battery,
-                                            projection_min_transmission,
-                                            projection_max_transmission_cbc};
-  std::vector<SinglePbData> pbs_data_xpress = {capex_min_data,
-                                               capex_max_data,
-                                               projection_min_semibase,
-                                               projection_max_semibase,
-                                               projection_min_peak,
-                                               projection_max_peak,
-                                               projection_min_pv,
-                                               projection_max_pv,
-                                               projection_min_battery,
-                                               projection_max_battery,
-                                               projection_min_transmission,
-                                               projection_max_transmission};
+    auto projection_max_transmission_cbc = SinglePbData(SensitivityPbType::PROJECTION,
+                                                        PROJECTION_C,
+                                                        transmission_name,
+                                                        MAX_C,
+                                                        2800,
+                                                        1440683382.5376825,
+                                                        {{battery_name, 517.99999999999739},
+                                                         {peak_name, 1500},
+                                                         {pv_name, 0},
+                                                         {semibase_name, 1200},
+                                                         {transmission_name, 2800}},
+                                                        SOLVER_STATUS::OPTIMAL);
 
-  std::map<std::string, std::vector<SinglePbData>> expec_output_data_map = {
-      {coin_name, pbs_data_cbc}, {xpress_name, pbs_data_xpress}};
+    std::vector<SinglePbData> pbs_data_cbc = {capex_min_data,
+                                              capex_max_data,
+                                              projection_min_semibase,
+                                              projection_max_semibase,
+                                              projection_min_peak,
+                                              projection_max_peak,
+                                              projection_min_pv,
+                                              projection_max_pv,
+                                              projection_min_battery_cbc,
+                                              projection_max_battery_cbc,
+                                              projection_min_transmission,
+                                              projection_max_transmission_cbc};
+    std::vector<SinglePbData> pbs_data_xpress = {capex_min_data,
+                                                 capex_max_data,
+                                                 projection_min_semibase,
+                                                 projection_max_semibase,
+                                                 projection_min_peak,
+                                                 projection_max_peak,
+                                                 projection_min_pv,
+                                                 projection_max_pv,
+                                                 projection_min_battery,
+                                                 projection_max_battery,
+                                                 projection_min_transmission,
+                                                 projection_max_transmission};
 
-  launch_tests(mps_path, expec_output_data_map);
+    std::map<std::string, std::vector<SinglePbData>> expec_output_data_map = {{coin_name,
+                                                                               pbs_data_cbc},
+                                                                              {xpress_name,
+                                                                               pbs_data_xpress}};
+
+    launch_tests(mps_path, expec_output_data_map);
 }


### PR DESCRIPTION
Update xpress to 9.2.12

Xpress 9.2.5 license expired motivating the upgrade.

Xpress pip/Conda package layout changed. From a single package with license and libs it's now two packages
* Xpress for the licence
* Xpresslibs for the libs

CI workflows have been updated to reflect this change.

Some numerical difference were observed in sensitivity but are marginal.