### PR TITLE
[ANT-3641] Update study settings in memory mode during problem generation step

### DIFF
--- a/src/python/antares_xpansion/driver.py
+++ b/src/python/antares_xpansion/driver.py
@@ -115,6 +115,8 @@ class XpansionDriver:
 
         elif self.config_loader.step() == "problem_generation":
             if self.config_loader.memory():
+                # In this case, there has been no antares step beforehand, so we need to update the generaldata settings here 
+                self.update_study_settings(memory_mode=True)
                 self.launch_problem_generation_step_memory()
             else:
                 self.launch_problem_generation_step()


### PR DESCRIPTION
Antares settings were not updated correctly when calling the single step problem generation in memory. Need to add test for the main driver ?