### PR TITLE
Copy solver accept object

### DIFF
--- a/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
+++ b/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
@@ -77,11 +77,6 @@ public:
         solver_abstract_->read_prob_lp(filename);
     }
 
-    void copy_prob(Ptr fictif_solv) override
-    {
-        solver_abstract_->copy_prob(fictif_solv);
-    }
-
     [[nodiscard]] int get_ncols() const override
     {
         return solver_abstract_->get_ncols();

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -261,12 +261,6 @@ void SolverCbc::set_basis(std::span<int> rstatus, std::span<int> cstatus)
     _cbc.solver()->setBasisStatus(rstatus.data(), cstatus.data());
 }
 
-void SolverCbc::copy_prob(const SolverAbstract::Ptr fictif_solv)
-{
-    auto error = LOGLOCATION + "Copy CBC problem : TO DO WHEN NEEDED";
-    throw NotImplementedFeatureSolverException(error);
-}
-
 /*************************************************************************************************
 -----------------------    Get general informations about problem
 ----------------------------

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -26,11 +26,6 @@ SolverCbc::SolverCbc()
     set_output_log_level(0);
 }
 
-SolverCbc::SolverCbc(const std::shared_ptr<const SolverAbstract> toCopy):
-    SolverCbc(*toCopy.get())
-{
-}
-
 SolverCbc::SolverCbc(const SolverAbstract& toCopy):
     SolverCbc()
 {
@@ -57,7 +52,7 @@ SolverCbc::SolverCbc(const SolverAbstract& toCopy):
 SolverCbc::~SolverCbc()
 {
     _NumberOfProblems -= 1;
-    free();
+    SolverCbc::free();
 }
 
 int SolverCbc::get_number_of_instances()

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -27,10 +27,15 @@ SolverCbc::SolverCbc()
 }
 
 SolverCbc::SolverCbc(const std::shared_ptr<const SolverAbstract> toCopy):
+    SolverCbc(*toCopy.get())
+{
+}
+
+SolverCbc::SolverCbc(const SolverAbstract& toCopy):
     SolverCbc()
 {
     // Try to cast the solver in fictif to a SolverCbc
-    if (const auto c = dynamic_cast<const SolverCbc*>(toCopy.get()))
+    if (const auto c = dynamic_cast<const SolverCbc*>(&toCopy))
     {
         _clp_inner_solver = OsiClpSolverInterface(c->_clp_inner_solver);
 
@@ -45,7 +50,7 @@ SolverCbc::SolverCbc(const std::shared_ptr<const SolverAbstract> toCopy):
     else
     {
         _NumberOfProblems -= 1;
-        throw InvalidSolverForCopyException(toCopy->get_solver_name(), name_, LOGLOCATION);
+        throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
 }
 

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -26,10 +26,15 @@ SolverClp::SolverClp()
 }
 
 SolverClp::SolverClp(const std::shared_ptr<const SolverAbstract> toCopy):
+    SolverClp(*toCopy.get())
+{
+}
+
+SolverClp::SolverClp(const SolverAbstract& toCopy):
     SolverClp()
 {
     // Try to cast the solver in fictif to a SolverClp
-    if (const auto c = dynamic_cast<const SolverClp*>(toCopy.get()))
+    if (const auto c = dynamic_cast<const SolverClp*>(&toCopy))
     {
         _clp = ClpSimplex(c->_clp);
         _fp = c->_fp;
@@ -41,7 +46,7 @@ SolverClp::SolverClp(const std::shared_ptr<const SolverAbstract> toCopy):
     else
     {
         _NumberOfProblems -= 1;
-        throw InvalidSolverForCopyException(toCopy->get_solver_name(), name_, LOGLOCATION);
+        throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
 }
 

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -25,11 +25,6 @@ SolverClp::SolverClp()
     set_output_log_level(0);
 }
 
-SolverClp::SolverClp(const std::shared_ptr<const SolverAbstract> toCopy):
-    SolverClp(*toCopy.get())
-{
-}
-
 SolverClp::SolverClp(const SolverAbstract& toCopy):
     SolverClp()
 {
@@ -53,7 +48,7 @@ SolverClp::SolverClp(const SolverAbstract& toCopy):
 SolverClp::~SolverClp()
 {
     _NumberOfProblems -= 1;
-    free();
+    SolverClp::free();
 }
 
 int SolverClp::get_number_of_instances()

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -146,12 +146,6 @@ void SolverClp::set_basis(std::span<int> rstatus, std::span<int> cstatus)
     }
 }
 
-void SolverClp::copy_prob(const SolverAbstract::Ptr fictif_solv)
-{
-    auto error = LOGLOCATION + "Copy Clp problem : TO DO WHEN NEEDED";
-    throw NotImplementedFeatureSolverException(error);
-}
-
 /*************************************************************************************************
 -----------------------    Get general informations about problem
 ----------------------------

--- a/src/cpp/multisolver_interface/SolverFactory.cpp
+++ b/src/cpp/multisolver_interface/SolverFactory.cpp
@@ -235,10 +235,9 @@ SolverAbstract::Ptr SolverFactory::create_solver(const SolverConfig& solver_conf
     return create_solver(solver_config, log_manager);
 }
 
-SolverAbstract::Ptr SolverFactory::copy_solver(
-  const std::shared_ptr<const SolverAbstract>& to_copy) const
+SolverAbstract::Ptr SolverFactory::copy_solver(const SolverAbstract& to_copy) const
 {
-    std::string solver_name = to_copy->get_solver_name();
+    std::string solver_name = to_copy.get_solver_name();
     std::transform(solver_name.begin(), solver_name.end(), solver_name.begin(), ::toupper);
     if (solver_name.empty())
     {
@@ -264,9 +263,9 @@ SolverAbstract::Ptr SolverFactory::copy_solver(
     }
 }
 
-SolverAbstract::Ptr SolverFactory::copy_solver(SolverAbstract::Ptr to_copy) const
+SolverAbstract::Ptr SolverFactory::copy_solver(SolverAbstract& to_copy) const
 {
-    return copy_solver(static_cast<const std::shared_ptr<const SolverAbstract>>(to_copy));
+    return copy_solver(static_cast<const SolverAbstract&>(to_copy));
 }
 
 const std::vector<std::string>& SolverFactory::get_solvers_list() const

--- a/src/cpp/multisolver_interface/SolverFactory.cpp
+++ b/src/cpp/multisolver_interface/SolverFactory.cpp
@@ -263,11 +263,6 @@ SolverAbstract::Ptr SolverFactory::copy_solver(const SolverAbstract& to_copy) co
     }
 }
 
-SolverAbstract::Ptr SolverFactory::copy_solver(SolverAbstract& to_copy) const
-{
-    return copy_solver(static_cast<const SolverAbstract&>(to_copy));
-}
-
 const std::vector<std::string>& SolverFactory::get_solvers_list() const
 {
     return _available_solvers;

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -45,11 +45,6 @@ SolverXpress::SolverXpress()
     _xprs = NULL;
 }
 
-SolverXpress::SolverXpress(const SolverAbstract::Ptr toCopy):
-    SolverXpress(static_cast<const std::shared_ptr<const SolverAbstract>>(toCopy))
-{
-}
-
 SolverXpress::SolverXpress(const SolverAbstract& toCopy):
     SolverXpress()
 {
@@ -74,11 +69,6 @@ SolverXpress::SolverXpress(const SolverAbstract& toCopy):
         SolverXpress::free();
         throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
-}
-
-SolverXpress::SolverXpress(const std::shared_ptr<const SolverAbstract> toCopy):
-    SolverXpress(*toCopy.get())
-{
 }
 
 SolverXpress::~SolverXpress()

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -50,17 +50,17 @@ SolverXpress::SolverXpress(const SolverAbstract::Ptr toCopy):
 {
 }
 
-SolverXpress::SolverXpress(const std::shared_ptr<const SolverAbstract> toCopy):
+SolverXpress::SolverXpress(const SolverAbstract& toCopy):
     SolverXpress()
 {
     SolverXpress::init();
     int status = 0;
 
     // Try to cast the solver in fictif to a SolverXpress
-    if (const SolverXpress* xpSolv = dynamic_cast<const SolverXpress*>(toCopy.get()))
+    if (const auto* xpSolv = dynamic_cast<const SolverXpress*>(&toCopy))
     {
         status = XPRScopyprob(_xprs, xpSolv->_xprs, "");
-        _log_file = toCopy->_log_file;
+        _log_file = toCopy._log_file;
         if (_log_file != "")
         {
             _log_stream.open(_log_file, std::ofstream::out | std::ofstream::app);
@@ -72,8 +72,13 @@ SolverXpress::SolverXpress(const std::shared_ptr<const SolverAbstract> toCopy):
     {
         _NumberOfProblems -= 1;
         SolverXpress::free();
-        throw InvalidSolverForCopyException(toCopy->get_solver_name(), name_, LOGLOCATION);
+        throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
+}
+
+SolverXpress::SolverXpress(const std::shared_ptr<const SolverAbstract> toCopy):
+    SolverXpress(*toCopy.get())
+{
 }
 
 SolverXpress::~SolverXpress()

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -242,12 +242,6 @@ void SolverXpress::set_basis(std::span<int> rstatus, std::span<int> cstatus)
     zero_status_check(status, "set basis", LOGLOCATION);
 }
 
-void SolverXpress::copy_prob(const SolverAbstract::Ptr fictif_solv)
-{
-    auto error = LOGLOCATION + "Copy XPRESS problem : TO DO WHEN NEEDED";
-    throw NotImplementedFeatureSolverException(error);
-}
-
 /*************************************************************************************************
 -----------------------    Get general informations about problem
 ----------------------------

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -395,13 +395,6 @@ public:
 
     virtual void set_basis(std::span<int> rstatus, std::span<int> cstatus) = 0;
 
-    /**
-     * @brief copy an existing problem
-     *
-     * @param prb_to_copy : Ptr to the
-     */
-    virtual void copy_prob(Ptr fictif_solv) = 0;
-
     /*************************************************************************************************
     -----------------------    Get general informations about problem
     ----------------------------

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverFactory.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverFactory.h
@@ -91,7 +91,6 @@ public:
      * @param to_copy : solver to copy
      */
     SolverAbstract::Ptr copy_solver(const SolverAbstract& to_copy) const;
-    SolverAbstract::Ptr copy_solver(SolverAbstract& to_copy) const;
 
     /**
      * @brief Returns a reference to the list of available solvers

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverFactory.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverFactory.h
@@ -90,8 +90,8 @@ public:
      *
      * @param to_copy : solver to copy
      */
-    SolverAbstract::Ptr copy_solver(SolverAbstract::Ptr to_copy) const;
-    SolverAbstract::Ptr copy_solver(const std::shared_ptr<const SolverAbstract>& to_copy) const;
+    SolverAbstract::Ptr copy_solver(const SolverAbstract& to_copy) const;
+    SolverAbstract::Ptr copy_solver(SolverAbstract& to_copy) const;
 
     /**
      * @brief Returns a reference to the list of available solvers

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -40,14 +40,6 @@ public:
     SolverCbc();
     explicit SolverCbc(const SolverLogManager& log_manager);
 
-    /**
-     * @brief Copy constructor of solver, copy the problem toCopy in memory and
-     * name it "name"
-     *
-     * @param toCopy : Pointer to an AbstractSolver object, containing a CBC
-     * solver to copy
-     */
-    explicit SolverCbc(const std::shared_ptr<const SolverAbstract> toCopy);
     explicit SolverCbc(const SolverAbstract& toCopy);
 
     /*SolverCbc ctor accept only std::shared_ptr*/

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -97,8 +97,6 @@ public:
     void read_basis(const std::filesystem::path& filename) override;
     void set_basis(std::span<int> rstatus, std::span<int> cstatus) override;
 
-    void copy_prob(const SolverAbstract::Ptr fictif_solv) override;
-
     /*************************************************************************************************
     -----------------------    Get general informations about problem
     ----------------------------

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -48,6 +48,7 @@ public:
      * solver to copy
      */
     explicit SolverCbc(const std::shared_ptr<const SolverAbstract> toCopy);
+    explicit SolverCbc(const SolverAbstract& toCopy);
 
     /*SolverCbc ctor accept only std::shared_ptr*/
     SolverCbc(const SolverCbc& other) = delete;

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -44,14 +44,6 @@ public:
     SolverClp();
     explicit SolverClp(const SolverLogManager& log_manager);
 
-    /**
-     * @brief Copy constructor of CLP, copy the problem toCopy in memory and name
-     * it "name"
-     *
-     * @param toCopy : Pointer to an AbstractSolver object, containing a CLP
-     * solver to copy
-     */
-    explicit SolverClp(const std::shared_ptr<const SolverAbstract> toCopy);
     explicit SolverClp(const SolverAbstract& toCopy);
 
     /*SolverClp ctor accept only std::shared_ptr*/

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -97,8 +97,6 @@ public:
     void read_basis(const std::filesystem::path& filename) override;
     void set_basis(std::span<int> rstatus, std::span<int> cstatus) override;
 
-    void copy_prob(const SolverAbstract::Ptr fictif_solv) override;
-
     /*************************************************************************************************
     -----------------------    Get general informations about problem
     ----------------------------

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -52,6 +52,7 @@ public:
      * solver to copy
      */
     explicit SolverClp(const std::shared_ptr<const SolverAbstract> toCopy);
+    explicit SolverClp(const SolverAbstract& toCopy);
 
     /*SolverClp ctor accept only std::shared_ptr*/
     SolverClp(const SolverClp& other) = delete;

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -44,6 +44,7 @@ public:
      * solver to copy
      */
     explicit SolverXpress(const SolverAbstract::Ptr toCopy);
+    explicit SolverXpress(const SolverAbstract& toCopy);
     explicit SolverXpress(const std::shared_ptr<const SolverAbstract> toCopy);
 
     /*SolverXpress ctor accept only std::shared_ptr*/

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -36,16 +36,7 @@ public:
     SolverXpress();
     SolverXpress(const SolverLogManager& log_manager);
 
-    /**
-     * @brief Copy constructor of XPRESS, copy the problem toCopy in memory and
-     * name it "name"
-     *
-     * @param toCopy : Pointer to an AbstractSolver object, containing an XPRESS
-     * solver to copy
-     */
-    explicit SolverXpress(const SolverAbstract::Ptr toCopy);
     explicit SolverXpress(const SolverAbstract& toCopy);
-    explicit SolverXpress(const std::shared_ptr<const SolverAbstract> toCopy);
 
     /*SolverXpress ctor accept only std::shared_ptr*/
     SolverXpress(const SolverXpress& other) = delete;

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -90,8 +90,6 @@ public:
     void read_basis(const std::filesystem::path& filename) override;
     void set_basis(std::span<int> rstatus, std::span<int> cstatus) override;
 
-    void copy_prob(const SolverAbstract::Ptr fictif_solv) override;
-
 private:
     void read_prob(const char* prob_name, const char* flags);
 

--- a/src/cpp/sensitivity/SensitivityProblemModifier.cpp
+++ b/src/cpp/sensitivity/SensitivityProblemModifier.cpp
@@ -29,7 +29,7 @@ void change_objective(const SolverAbstract::Ptr& solver_model, const std::vector
 SolverAbstract::Ptr SensitivityProblemModifier::changeProblem(unsigned int nb_candidates) const
 {
     SolverFactory factory;
-    SolverAbstract::Ptr sensitivity_model = factory.copy_solver(last_master);
+    SolverAbstract::Ptr sensitivity_model = factory.copy_solver(*last_master);
     std::vector<double> obj = get_cost_vector(*last_master, nb_candidates);
 
     add_near_optimal_cost_constraint(*(sensitivity_model.get()));

--- a/tests/cpp/solvers_interface/test_reading_problem.cpp
+++ b/tests/cpp/solvers_interface/test_reading_problem.cpp
@@ -1,640 +1,694 @@
 #include <iostream>
 
+#include "antares-xpansion/multisolver_interface/Solver.h"
 #include "catch2.hpp"
 #include "define_datas.hpp"
-#include "antares-xpansion/multisolver_interface/Solver.h"
 
-TEST_CASE("Un objet solveur peut etre cree et detruit", "[read][init]") {
-  AllDatas datas;
-  fill_datas(datas);
+TEST_CASE("Un objet solveur peut etre cree et detruit", "[read][init]")
+{
+    AllDatas datas;
+    fill_datas(datas);
 
-  SolverFactory factory;
+    SolverFactory factory;
 
-  auto inst = GENERATE(MIP_TOY, MULTIKP);
-  SECTION("Construction and destruction") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
+    auto inst = GENERATE(MIP_TOY, MULTIKP);
+    SECTION("Construction and destruction")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
 
-      //========================================================================================
-      // solver declaration
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
+            //========================================================================================
+            // solver declaration
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
 
-      //========================================================================================
-      // solver destruction
-      solver.reset();
-      REQUIRE(solver == nullptr);
+            //========================================================================================
+            // solver destruction
+            solver.reset();
+            REQUIRE(solver == nullptr);
+        }
     }
-  }
 }
 
-TEST_CASE("MPS file can be read and we can get number of columns",
-          "[read][read-cols]") {
-  AllDatas datas;
-  fill_datas(datas);
+TEST_CASE("MPS file can be read and we can get number of columns", "[read][read-cols]")
+{
+    AllDatas datas;
+    fill_datas(datas);
 
-  SolverFactory factory;
+    SolverFactory factory;
 
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    namespace fs = std::filesystem;
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      std::cout << "Current dir " << fs::current_path() << std::endl;
-      std::cout << instance << std::endl;
-      //========================================================================================
-      // Solver declaration
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        namespace fs = std::filesystem;
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            std::cout << "Current dir " << fs::current_path() << std::endl;
+            std::cout << instance << std::endl;
+            //========================================================================================
+            // Solver declaration
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
 
-      //========================================================================================
-      // initalization and read problem
-      
-      solver->read_prob_mps(instance);
+            //========================================================================================
+            // initalization and read problem
 
-      //========================================================================================
-      // Get number of columns
-      REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get number of columns
+            REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+        }
     }
-  }
 }
 
-TEST_CASE("MPS file can be read and we can get number of rows",
-          "[read][read-rows]") {
-  AllDatas datas;
-  fill_datas(datas);
+TEST_CASE("MPS file can be read and we can get number of rows", "[read][read-rows]")
+{
+    AllDatas datas;
+    fill_datas(datas);
 
-  SolverFactory factory;
+    SolverFactory factory;
 
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
 
-      //========================================================================================
-      // Get numer of rows
-      REQUIRE(solver->get_nrows() == datas[inst]._nrows);
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get numer of rows
+            REQUIRE(solver->get_nrows() == datas[inst]._nrows);
+        }
     }
-  }
 }
 
 TEST_CASE("MPS file can be read and we can get number of integer variables",
-          "[read][read-integer-vars]") {
-  AllDatas datas;
-  fill_datas(datas);
+          "[read][read-integer-vars]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
 
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get number of integer variables
-      REQUIRE(solver->get_n_integer_vars() == datas[inst]._nintegervars);
-    }
-  }
-}
-
-TEST_CASE(
-    "MPS file can be read and we can get number of non zero elements in the "
-    "matrix",
-    "[read][read-elements]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get number of non zero elements in matrix
-      REQUIRE(solver->get_nelems() == datas[inst]._nelems);
-    }
-  }
-}
-
-TEST_CASE("MPS file can be read and we can get objective function coefficients",
-          "[read][read-obj]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get objective function
-      int n_vars = solver->get_ncols();
-      REQUIRE(n_vars == datas[inst]._ncols);
-      std::vector<double> obj(n_vars);
-
-      solver->get_obj(obj.data(), 0, n_vars - 1);
-
-      REQUIRE(obj == datas[inst]._obj);
-    }
-  }
-}
-
-TEST_CASE("MPS file can be read and we can get matrix coefficients",
-          "[read][read-rows]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get necessary datas from solver
-      REQUIRE(solver->get_ncols() == datas[inst]._ncols);
-      REQUIRE(solver->get_nrows() == datas[inst]._nrows);
-      REQUIRE(solver->get_nelems() == datas[inst]._nelems);
-
-      //========================================================================================
-      // Get rows
-      int n_elems = solver->get_nelems();
-      int n_cstr = solver->get_nrows();
-
-      std::vector<double> matval(n_elems);
-      std::vector<int> mstart(n_cstr + 1);
-      std::vector<int> mind(n_elems);
-
-      int n_returned(0);
-      solver->get_rows(mstart.data(), mind.data(), matval.data(), n_elems,
-                       &n_returned, 0, n_cstr - 1);
-
-      REQUIRE(n_returned == datas[inst]._nelems);
-      REQUIRE(matval == datas[inst]._matval);
-      REQUIRE(mind == datas[inst]._mind);
-      REQUIRE(mstart == datas[inst]._mstart);
-    }
-  }
-}
-
-TEST_CASE("MPS file can be read and we can get right hand side",
-          "[read][read-rhs]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get Constraints Right Hand Sides
-      int n_cstr = solver->get_nrows();
-      REQUIRE(solver->get_nrows() == datas[inst]._nrows);
-
-      std::vector<double> rhs(n_cstr);
-      if (n_cstr > 0) {
-        solver->get_rhs(rhs.data(), 0, n_cstr - 1);
-      }
-
-      REQUIRE(rhs == datas[inst]._rhs);
-    }
-  }
-}
-
-TEST_CASE("MPS file can be read and we can get row types",
-          "[read][read-rowtypes]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver Declaration
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      REQUIRE(solver->get_nrows() == datas[inst]._nrows);
-      //========================================================================================
-      // Get rowtypes
-      int n_cstr = solver->get_nrows();
-      std::vector<char> rtypes(n_cstr);
-      if (n_cstr > 0) {
-        solver->get_row_type(rtypes.data(), 0, n_cstr - 1);
-      }
-      REQUIRE(rtypes == datas[inst]._rowtypes);
-    }
-  }
-}
-
-TEST_CASE("MPS file can be read and we can get types of columns",
-          "[read][read-coltypes]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver Declaration
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get column types
-      int n_vars = solver->get_ncols();
-      REQUIRE(solver->get_ncols() == datas[inst]._ncols);
-      std::vector<char> coltype(n_vars);
-      solver->get_col_type(coltype.data(), 0, n_vars - 1);
-
-      REQUIRE(coltype == datas[inst]._coltypes);
-    }
-  }
-}
-
-TEST_CASE("MPS file can be read and we can get lower bounds on variables",
-          "[read][read-lb]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get lower bounds on variables
-      int n_vars = solver->get_ncols();
-      REQUIRE(solver->get_ncols() == datas[inst]._ncols);
-      std::vector<double> lb(n_vars);
-      solver->get_lb(lb.data(), 0, n_vars - 1);
-
-      REQUIRE(lb == datas[inst]._lb);
-    }
-  }
-}
-
-TEST_CASE("MPS file can be read and we can get upper bounds on variables",
-          "[read][read-ub]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Get upper bounds on variables
-      int n_vars = solver->get_ncols();
-      REQUIRE(solver->get_ncols() == datas[inst]._ncols);
-      std::vector<double> ub(n_vars);
-      solver->get_ub(ub.data(), 0, n_vars - 1);
-
-      // Hand management of infinites
-      // +infty is set to 1e20
-      for (int i(0); i < solver->get_ncols(); i++) {
-        if (datas[inst]._ub[i] == 1e20 && ub[i] > 1e20) {
-          ub[i] = 1e20;
-        }
-      }
-      REQUIRE(ub == datas[inst]._ub);
-    }
-  }
-}
-
-TEST_CASE(
-    "MPS file can be read and we can get every information about the problem",
-    "[read]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER,
-                       NET_SP1, NET_SP2, SLACKS, REDUCED);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      //========================================================================================
-      // Required datas
-      REQUIRE(solver->get_ncols() == datas[inst]._ncols);
-      REQUIRE(solver->get_nrows() == datas[inst]._nrows);
-      REQUIRE(solver->get_n_integer_vars() == datas[inst]._nintegervars);
-      REQUIRE(solver->get_nelems() == datas[inst]._nelems);
-
-      //========================================================================================
-      // Read objective
-      int n_vars = solver->get_ncols();
-      std::vector<double> obj(n_vars);
-
-      solver->get_obj(obj.data(), 0, n_vars - 1);
-
-      REQUIRE(obj == datas[inst]._obj);
-
-      //========================================================================================
-      // Read constraints
-      int n_elems = solver->get_nelems();
-      int n_cstr = solver->get_nrows();
-
-      std::vector<double> matval(n_elems);
-      std::vector<int> mstart(n_cstr + 1);
-      std::vector<int> mind(n_elems);
-
-      int n_returned(0);
-      solver->get_rows(mstart.data(), mind.data(), matval.data(), n_elems,
-                       &n_returned, 0, n_cstr - 1);
-
-      REQUIRE(n_returned == datas[inst]._nelems);
-      REQUIRE(matval == datas[inst]._matval);
-      REQUIRE(mind == datas[inst]._mind);
-      REQUIRE(mstart == datas[inst]._mstart);
-
-      //========================================================================================
-      // Read constraints RHS
-      n_cstr = solver->get_nrows();
-      std::vector<double> rhs(n_cstr);
-      if (n_cstr > 0) {
-        solver->get_rhs(rhs.data(), 0, n_cstr - 1);
-      }
-
-      REQUIRE(rhs == datas[inst]._rhs);
-
-      //========================================================================================
-      // Read row types
-      n_cstr = solver->get_nrows();
-      std::vector<char> rtypes(n_cstr);
-      if (n_cstr > 0) {
-        solver->get_row_type(rtypes.data(), 0, n_cstr - 1);
-      }
-      REQUIRE(rtypes == datas[inst]._rowtypes);
-
-      //========================================================================================
-      // Read Column types
-      n_vars = solver->get_ncols();
-      std::vector<char> coltype(n_vars);
-      solver->get_col_type(coltype.data(), 0, n_vars - 1);
-
-      REQUIRE(coltype == datas[inst]._coltypes);
-
-      //========================================================================================
-      // Read lower bounds on variables
-      n_vars = solver->get_ncols();
-      std::vector<double> lb(n_vars);
-      solver->get_lb(lb.data(), 0, n_vars - 1);
-
-      REQUIRE(lb == datas[inst]._lb);
-
-      //========================================================================================
-      // Read upper bounds on variables
-      n_vars = solver->get_ncols();
-      std::vector<double> ub(n_vars);
-      solver->get_ub(ub.data(), 0, n_vars - 1);
-
-      for (int i(0); i < solver->get_ncols(); i++) {
-        if (datas[inst]._ub[i] == 1e20 && ub[i] > 1e20) {
-          ub[i] = 1e20;
-        }
-      }
-      REQUIRE(ub == datas[inst]._ub);
-    }
-  }
-}
-
-TEST_CASE(
-    "We can get the names of variables and constraints present in MPS file "
-    "after read",
-    "[read][read-names]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-  int ind = 0;
-  auto inst = GENERATE(MIP_TOY, MULTIKP);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      if (solver_name == "XPRESS") {
-        auto prb_name = std::filesystem::path("test" + ind);
-        solver->write_prob_mps(prb_name);
-        ind++;
-      }
-      //========================================================================================
-      // Get names of columns and rows
-      int n_vars = solver->get_ncols();
-      int n_rows = solver->get_nrows();
-
-      std::vector<std::string> rowNames = solver->get_row_names(0, n_rows - 1);
-      std::vector<std::string> colNames = solver->get_col_names(0, n_vars - 1);
-
-      int ind = 0;
-      std::string cur_name;
-      for (auto const& name : rowNames) {
-        cur_name = datas[inst]._row_names[ind];
-        REQUIRE(name.compare(0, cur_name.size(), cur_name) == 0);
-        ind++;
-      }
-      ind = 0;
-      for (auto const& name : colNames) {
-        cur_name = datas[inst]._col_names[ind];
-        REQUIRE(name.compare(0, cur_name.size(), cur_name) == 0);
-        ind++;
-      }
-    }
-  }
-}
-
-TEST_CASE("We can get the indices of rows and columns by their names",
-          "[read][get-indices]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-  int ind = 0;
-  auto inst = GENERATE(MIP_TOY, MULTIKP);
-  SECTION("Reading instance") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-      //========================================================================================
-      // Solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
-      REQUIRE(solver->get_number_of_instances() == 1);
-      
-      solver->read_prob_mps(instance);
-
-      if (solver_name == "XPRESS") {
-        auto prb_name = std::filesystem::path("test" + ind);
-        solver->write_prob_mps(prb_name);
-        ind++;
-      }
-      //========================================================================================
-      // Get row and columns indices by their names
-
-      int col_index = -1;
-      std::string cur_name;
-      for (int i(0); i < 2; i++) {
-        cur_name = datas[inst]._col_names[i];
-        col_index = solver->get_col_index(cur_name);
-        REQUIRE(col_index == i);
-      }
-
-      int row_index = -1;
-      for (int i(0); i < 2; i++) {
-        cur_name = datas[inst]._row_names[i];
-        row_index = solver->get_row_index(cur_name);
-        REQUIRE(row_index == i);
-      }
-    }
-  }
-}
-
-TEST_CASE("Testing copy constructor", "[init][copy-constructor]") {
-  AllDatas datas;
-  fill_datas(datas);
-
-  SolverFactory factory;
-
-  auto inst = GENERATE(MIP_TOY, MULTIKP);
-  SECTION("Construction and destruction") {
-    for (auto const& solver_name : factory.get_solvers_list()) {
-      std::filesystem::path instance= datas[inst]._path;
-
-      //========================================================================================
-      // Intial solver declaration and read problem
-      SolverAbstract::Ptr solver = factory.create_solver(solver_name);
             solver->read_prob_mps(instance);
-      REQUIRE(solver->get_number_of_instances() == 1);
 
-      REQUIRE(solver->get_ncols() == datas[inst]._ncols);
-      REQUIRE(solver->get_nrows() == datas[inst]._nrows);
-
-      //========================================================================================
-      // Declare copy prob
-      SolverAbstract::Ptr solver2 = factory.copy_solver(solver);
-      REQUIRE(solver2->get_number_of_instances() == 2);
-
-      REQUIRE(solver2->get_ncols() == datas[inst]._ncols);
-      REQUIRE(solver2->get_nrows() == datas[inst]._nrows);
-
-      //========================================================================================
-      // Delete initial solver
-      solver.reset();
-      REQUIRE(solver == nullptr);
-      REQUIRE(solver2->get_number_of_instances() == 1);
-
-      REQUIRE(solver2->get_ncols() == datas[inst]._ncols);
-      REQUIRE(solver2->get_nrows() == datas[inst]._nrows);
-
-      //========================================================================================
-      // Check variable names
-      int ncols_copied = solver2->get_ncols();
-      std::vector<std::string> copiedNames =
-          solver2->get_col_names(0, ncols_copied - 1);
-
-      std::string cur_name = "";
-      for (int i = 0; i < ncols_copied; i++) {
-        cur_name = datas[inst]._col_names[i];
-        REQUIRE(copiedNames[i].compare(0, cur_name.size(), cur_name) == 0);
-      }
-
-      //========================================================================================
-      // solvers destruction
-      solver2.reset();
-      REQUIRE(solver2 == nullptr);
+            //========================================================================================
+            // Get number of integer variables
+            REQUIRE(solver->get_n_integer_vars() == datas[inst]._nintegervars);
+        }
     }
-  }
+}
+
+TEST_CASE("MPS file can be read and we can get number of non zero elements in the "
+          "matrix",
+          "[read][read-elements]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get number of non zero elements in matrix
+            REQUIRE(solver->get_nelems() == datas[inst]._nelems);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get objective function coefficients", "[read][read-obj]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get objective function
+            int n_vars = solver->get_ncols();
+            REQUIRE(n_vars == datas[inst]._ncols);
+            std::vector<double> obj(n_vars);
+
+            solver->get_obj(obj.data(), 0, n_vars - 1);
+
+            REQUIRE(obj == datas[inst]._obj);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get matrix coefficients", "[read][read-rows]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get necessary datas from solver
+            REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+            REQUIRE(solver->get_nrows() == datas[inst]._nrows);
+            REQUIRE(solver->get_nelems() == datas[inst]._nelems);
+
+            //========================================================================================
+            // Get rows
+            int n_elems = solver->get_nelems();
+            int n_cstr = solver->get_nrows();
+
+            std::vector<double> matval(n_elems);
+            std::vector<int> mstart(n_cstr + 1);
+            std::vector<int> mind(n_elems);
+
+            int n_returned(0);
+            solver->get_rows(mstart.data(),
+                             mind.data(),
+                             matval.data(),
+                             n_elems,
+                             &n_returned,
+                             0,
+                             n_cstr - 1);
+
+            REQUIRE(n_returned == datas[inst]._nelems);
+            REQUIRE(matval == datas[inst]._matval);
+            REQUIRE(mind == datas[inst]._mind);
+            REQUIRE(mstart == datas[inst]._mstart);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get right hand side", "[read][read-rhs]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get Constraints Right Hand Sides
+            int n_cstr = solver->get_nrows();
+            REQUIRE(solver->get_nrows() == datas[inst]._nrows);
+
+            std::vector<double> rhs(n_cstr);
+            if (n_cstr > 0)
+            {
+                solver->get_rhs(rhs.data(), 0, n_cstr - 1);
+            }
+
+            REQUIRE(rhs == datas[inst]._rhs);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get row types", "[read][read-rowtypes]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver Declaration
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            REQUIRE(solver->get_nrows() == datas[inst]._nrows);
+            //========================================================================================
+            // Get rowtypes
+            int n_cstr = solver->get_nrows();
+            std::vector<char> rtypes(n_cstr);
+            if (n_cstr > 0)
+            {
+                solver->get_row_type(rtypes.data(), 0, n_cstr - 1);
+            }
+            REQUIRE(rtypes == datas[inst]._rowtypes);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get types of columns", "[read][read-coltypes]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver Declaration
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get column types
+            int n_vars = solver->get_ncols();
+            REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+            std::vector<char> coltype(n_vars);
+            solver->get_col_type(coltype.data(), 0, n_vars - 1);
+
+            REQUIRE(coltype == datas[inst]._coltypes);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get lower bounds on variables", "[read][read-lb]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get lower bounds on variables
+            int n_vars = solver->get_ncols();
+            REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+            std::vector<double> lb(n_vars);
+            solver->get_lb(lb.data(), 0, n_vars - 1);
+
+            REQUIRE(lb == datas[inst]._lb);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get upper bounds on variables", "[read][read-ub]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP, UNBD_PRB, INFEAS_PRB, NET_MASTER, NET_SP1, NET_SP2);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Get upper bounds on variables
+            int n_vars = solver->get_ncols();
+            REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+            std::vector<double> ub(n_vars);
+            solver->get_ub(ub.data(), 0, n_vars - 1);
+
+            // Hand management of infinites
+            // +infty is set to 1e20
+            for (int i(0); i < solver->get_ncols(); i++)
+            {
+                if (datas[inst]._ub[i] == 1e20 && ub[i] > 1e20)
+                {
+                    ub[i] = 1e20;
+                }
+            }
+            REQUIRE(ub == datas[inst]._ub);
+        }
+    }
+}
+
+TEST_CASE("MPS file can be read and we can get every information about the problem", "[read]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY,
+                         MULTIKP,
+                         UNBD_PRB,
+                         INFEAS_PRB,
+                         NET_MASTER,
+                         NET_SP1,
+                         NET_SP2,
+                         SLACKS,
+                         REDUCED);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            //========================================================================================
+            // Required datas
+            REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+            REQUIRE(solver->get_nrows() == datas[inst]._nrows);
+            REQUIRE(solver->get_n_integer_vars() == datas[inst]._nintegervars);
+            REQUIRE(solver->get_nelems() == datas[inst]._nelems);
+
+            //========================================================================================
+            // Read objective
+            int n_vars = solver->get_ncols();
+            std::vector<double> obj(n_vars);
+
+            solver->get_obj(obj.data(), 0, n_vars - 1);
+
+            REQUIRE(obj == datas[inst]._obj);
+
+            //========================================================================================
+            // Read constraints
+            int n_elems = solver->get_nelems();
+            int n_cstr = solver->get_nrows();
+
+            std::vector<double> matval(n_elems);
+            std::vector<int> mstart(n_cstr + 1);
+            std::vector<int> mind(n_elems);
+
+            int n_returned(0);
+            solver->get_rows(mstart.data(),
+                             mind.data(),
+                             matval.data(),
+                             n_elems,
+                             &n_returned,
+                             0,
+                             n_cstr - 1);
+
+            REQUIRE(n_returned == datas[inst]._nelems);
+            REQUIRE(matval == datas[inst]._matval);
+            REQUIRE(mind == datas[inst]._mind);
+            REQUIRE(mstart == datas[inst]._mstart);
+
+            //========================================================================================
+            // Read constraints RHS
+            n_cstr = solver->get_nrows();
+            std::vector<double> rhs(n_cstr);
+            if (n_cstr > 0)
+            {
+                solver->get_rhs(rhs.data(), 0, n_cstr - 1);
+            }
+
+            REQUIRE(rhs == datas[inst]._rhs);
+
+            //========================================================================================
+            // Read row types
+            n_cstr = solver->get_nrows();
+            std::vector<char> rtypes(n_cstr);
+            if (n_cstr > 0)
+            {
+                solver->get_row_type(rtypes.data(), 0, n_cstr - 1);
+            }
+            REQUIRE(rtypes == datas[inst]._rowtypes);
+
+            //========================================================================================
+            // Read Column types
+            n_vars = solver->get_ncols();
+            std::vector<char> coltype(n_vars);
+            solver->get_col_type(coltype.data(), 0, n_vars - 1);
+
+            REQUIRE(coltype == datas[inst]._coltypes);
+
+            //========================================================================================
+            // Read lower bounds on variables
+            n_vars = solver->get_ncols();
+            std::vector<double> lb(n_vars);
+            solver->get_lb(lb.data(), 0, n_vars - 1);
+
+            REQUIRE(lb == datas[inst]._lb);
+
+            //========================================================================================
+            // Read upper bounds on variables
+            n_vars = solver->get_ncols();
+            std::vector<double> ub(n_vars);
+            solver->get_ub(ub.data(), 0, n_vars - 1);
+
+            for (int i(0); i < solver->get_ncols(); i++)
+            {
+                if (datas[inst]._ub[i] == 1e20 && ub[i] > 1e20)
+                {
+                    ub[i] = 1e20;
+                }
+            }
+            REQUIRE(ub == datas[inst]._ub);
+        }
+    }
+}
+
+TEST_CASE("We can get the names of variables and constraints present in MPS file "
+          "after read",
+          "[read][read-names]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+    int ind = 0;
+    auto inst = GENERATE(MIP_TOY, MULTIKP);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            if (solver_name == "XPRESS")
+            {
+                auto prb_name = std::filesystem::path("test" + ind);
+                solver->write_prob_mps(prb_name);
+                ind++;
+            }
+            //========================================================================================
+            // Get names of columns and rows
+            int n_vars = solver->get_ncols();
+            int n_rows = solver->get_nrows();
+
+            std::vector<std::string> rowNames = solver->get_row_names(0, n_rows - 1);
+            std::vector<std::string> colNames = solver->get_col_names(0, n_vars - 1);
+
+            int ind = 0;
+            std::string cur_name;
+            for (const auto& name: rowNames)
+            {
+                cur_name = datas[inst]._row_names[ind];
+                REQUIRE(name.compare(0, cur_name.size(), cur_name) == 0);
+                ind++;
+            }
+            ind = 0;
+            for (const auto& name: colNames)
+            {
+                cur_name = datas[inst]._col_names[ind];
+                REQUIRE(name.compare(0, cur_name.size(), cur_name) == 0);
+                ind++;
+            }
+        }
+    }
+}
+
+TEST_CASE("We can get the indices of rows and columns by their names", "[read][get-indices]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+    int ind = 0;
+    auto inst = GENERATE(MIP_TOY, MULTIKP);
+    SECTION("Reading instance")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+            //========================================================================================
+            // Solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            solver->read_prob_mps(instance);
+
+            if (solver_name == "XPRESS")
+            {
+                auto prb_name = std::filesystem::path("test" + ind);
+                solver->write_prob_mps(prb_name);
+                ind++;
+            }
+            //========================================================================================
+            // Get row and columns indices by their names
+
+            int col_index = -1;
+            std::string cur_name;
+            for (int i(0); i < 2; i++)
+            {
+                cur_name = datas[inst]._col_names[i];
+                col_index = solver->get_col_index(cur_name);
+                REQUIRE(col_index == i);
+            }
+
+            int row_index = -1;
+            for (int i(0); i < 2; i++)
+            {
+                cur_name = datas[inst]._row_names[i];
+                row_index = solver->get_row_index(cur_name);
+                REQUIRE(row_index == i);
+            }
+        }
+    }
+}
+
+TEST_CASE("Testing copy constructor", "[init][copy-constructor]")
+{
+    AllDatas datas;
+    fill_datas(datas);
+
+    SolverFactory factory;
+
+    auto inst = GENERATE(MIP_TOY, MULTIKP);
+    SECTION("Construction and destruction")
+    {
+        for (const auto& solver_name: factory.get_solvers_list())
+        {
+            std::filesystem::path instance = datas[inst]._path;
+
+            //========================================================================================
+            // Intial solver declaration and read problem
+            SolverAbstract::Ptr solver = factory.create_solver(solver_name);
+            solver->read_prob_mps(instance);
+            REQUIRE(solver->get_number_of_instances() == 1);
+
+            REQUIRE(solver->get_ncols() == datas[inst]._ncols);
+            REQUIRE(solver->get_nrows() == datas[inst]._nrows);
+
+            //========================================================================================
+            // Declare copy prob
+            SolverAbstract::Ptr solver2 = factory.copy_solver(*solver);
+            REQUIRE(solver2->get_number_of_instances() == 2);
+
+            REQUIRE(solver2->get_ncols() == datas[inst]._ncols);
+            REQUIRE(solver2->get_nrows() == datas[inst]._nrows);
+
+            //========================================================================================
+            // Delete initial solver
+            solver.reset();
+            REQUIRE(solver == nullptr);
+            REQUIRE(solver2->get_number_of_instances() == 1);
+
+            REQUIRE(solver2->get_ncols() == datas[inst]._ncols);
+            REQUIRE(solver2->get_nrows() == datas[inst]._nrows);
+
+            //========================================================================================
+            // Check variable names
+            int ncols_copied = solver2->get_ncols();
+            std::vector<std::string> copiedNames = solver2->get_col_names(0, ncols_copied - 1);
+
+            std::string cur_name = "";
+            for (int i = 0; i < ncols_copied; i++)
+            {
+                cur_name = datas[inst]._col_names[i];
+                REQUIRE(copiedNames[i].compare(0, cur_name.size(), cur_name) == 0);
+            }
+
+            //========================================================================================
+            // solvers destruction
+            solver2.reset();
+            REQUIRE(solver2 == nullptr);
+        }
+    }
 }

--- a/tests/cpp/tests_utils/NOOPSolver.h
+++ b/tests/cpp/tests_utils/NOOPSolver.h
@@ -6,104 +6,295 @@
 #define ANTARESXPANSION_TESTS_CPP_LP_NAMER_NOOPSOLVER_H_
 
 #include "antares-xpansion/multisolver_interface/SolverAbstract.h"
-class NOOPSolver : public SolverAbstract {
- public:
-  int get_number_of_instances() override { return 0; }
-  std::string get_solver_name() const override { return std::string(); }
-  void init() override {}
-  void free() override {}
-  void write_prob_mps(const std::filesystem::path &filename) override {}
-  void write_prob_lp(const std::filesystem::path &filename) override {}
-  void read_prob_mps(const std::filesystem::path &filename) override {}
-  void read_prob_lp(const std::filesystem::path &filename) override {}
-  void copy_prob(Ptr fictif_solv) override {}
-  int get_ncols() const override { return 0; }
-  int get_nrows() const override { return 0; }
-  int get_nelems() const override { return 0; }
-  int get_n_integer_vars() const override { return 0; }
-  void get_obj(double *obj, int first, int last) const override {}
-  void set_obj_to_zero() override {}
-  void set_obj(const double *obj, int first, int last) override {}
-  void get_rows(int *mstart, int *mclind, double *dmatval, int size,
-                        int *nels, int first, int last) const override {}
-  void get_row_type(char *qrtype, int first, int last) const override {}
-  void get_rhs(double *rhs, int first, int last) const override {}
-  void get_rhs_range(double *range, int first,
-                             int last) const override {}
-  void get_col_type(char *coltype, int first, int last) const override {
 
-  }
-  void get_lb(double *lb, int fisrt, int last) const override {}
-  void get_ub(double *ub, int fisrt, int last) const override {}
-  int get_row_index(const std::string &name) override { return 0; }
-  int get_col_index(const std::string &name) override { return 0; }
-  std::vector<std::string> get_row_names(int first, int last) override {
-    return std::vector<std::string>();
-  }
-  std::vector<std::string> get_row_names() override {
-    return std::vector<std::string>();
-  }
-  std::vector<std::string> get_col_names(int first, int last) override {
-    return std::vector<std::string>();
-  }
-  std::vector<std::string> get_col_names() override {
-    return std::vector<std::string>();
-  }
-  void del_rows(int first, int last) override {}
-  void del_cols(int first, int last) override {}
-  void add_rows(int newrows, int newnz, const char *qrtype,
-                        const double *rhs, const double *range,
-                        const int *mstart, const int *mclind,
-                        const double *dmatval,
-                        const std::vector<std::string> &row_names) override {}
-  void add_cols(int newcol, int newnz, const double *objx,
-                        const int *mstart, const int *mrwind,
-                        const double *dmatval, const double *bdl,
-                        const double *bdu,
-                        const std::vector<std::string> &col_names) override {}
-  void add_name(int type, const char *cnames, int indice) override {}
-  void add_names(int type, const std::vector<std::string> &cnames,
-                         int first, int end) override {}
-  void chg_obj(const std::vector<int> &mindex,
-                       const std::vector<double> &obj) override {}
-  void chg_obj_direction(const bool minimize) override {}
-  void chg_bounds(const std::vector<int> &mindex,
-                          const std::vector<char> &qbtype,
-                          const std::vector<double> &bnd) override {}
-  void chg_col_type(const std::vector<int> &mindex,
-                            const std::vector<char> &qctype) override {}
-  void chg_rhs(int id_row, double val) override {}
-  void chg_coef(int id_row, int id_col, double val) override {}
-  void chg_row_name(int id_row, const std::string &name) override {}
-  void chg_col_name(int id_col, const std::string &name) override {}
-  int solve_lp() override { return 0; }
-  int solve_mip() override { return 0; }
-  void get_basis(int *rstatus, int *cstatus) const override {}
-  double get_mip_value() const override { return 0; }
-  double get_lp_value() const override { return 0; }
-  int get_splex_num_of_ite_last() const override { return 0; }
-  void get_lp_sol(double *primals, double *duals,
-                          double *reduced_costs) const override {}
-  void get_mip_sol(double *primals) override {}
-  void set_output_log_level(int loglevel) override {}
-  void set_algorithm(const std::string &algo) override {}
-  void set_threads(int n_threads) override {}
-  void set_optimality_gap(double gap) override {}
-  void set_simplex_iter(int iter) override {}
-  void write_basis(const std::filesystem::path &filename) override {}
-  void read_basis(const std::filesystem::path &filename) override {}
-  void set_basis(std::span<int> rstatus, std::span<int> cstatus) override {};
-  void save_prob(const std::filesystem::path &filename) override {}
-  void restore_prob(const std::filesystem::path &filename) override {}
+class NOOPSolver: public SolverAbstract
+{
+public:
+    int get_number_of_instances() override
+    {
+        return 0;
+    }
+
+    std::string get_solver_name() const override
+    {
+        return std::string();
+    }
+
+    void init() override
+    {
+    }
+
+    void free() override
+    {
+    }
+
+    void write_prob_mps(const std::filesystem::path& filename) override
+    {
+    }
+
+    void write_prob_lp(const std::filesystem::path& filename) override
+    {
+    }
+
+    void read_prob_mps(const std::filesystem::path& filename) override
+    {
+    }
+
+    void read_prob_lp(const std::filesystem::path& filename) override
+    {
+    }
+
+    int get_ncols() const override
+    {
+        return 0;
+    }
+
+    int get_nrows() const override
+    {
+        return 0;
+    }
+
+    int get_nelems() const override
+    {
+        return 0;
+    }
+
+    int get_n_integer_vars() const override
+    {
+        return 0;
+    }
+
+    void get_obj(double* obj, int first, int last) const override
+    {
+    }
+
+    void set_obj_to_zero() override
+    {
+    }
+
+    void set_obj(const double* obj, int first, int last) override
+    {
+    }
+
+    void get_rows(int* mstart,
+                  int* mclind,
+                  double* dmatval,
+                  int size,
+                  int* nels,
+                  int first,
+                  int last) const override
+    {
+    }
+
+    void get_row_type(char* qrtype, int first, int last) const override
+    {
+    }
+
+    void get_rhs(double* rhs, int first, int last) const override
+    {
+    }
+
+    void get_rhs_range(double* range, int first, int last) const override
+    {
+    }
+
+    void get_col_type(char* coltype, int first, int last) const override
+    {
+    }
+
+    void get_lb(double* lb, int fisrt, int last) const override
+    {
+    }
+
+    void get_ub(double* ub, int fisrt, int last) const override
+    {
+    }
+
+    int get_row_index(const std::string& name) override
+    {
+        return 0;
+    }
+
+    int get_col_index(const std::string& name) override
+    {
+        return 0;
+    }
+
+    std::vector<std::string> get_row_names(int first, int last) override
+    {
+        return std::vector<std::string>();
+    }
+
+    std::vector<std::string> get_row_names() override
+    {
+        return std::vector<std::string>();
+    }
+
+    std::vector<std::string> get_col_names(int first, int last) override
+    {
+        return std::vector<std::string>();
+    }
+
+    std::vector<std::string> get_col_names() override
+    {
+        return std::vector<std::string>();
+    }
+
+    void del_rows(int first, int last) override
+    {
+    }
+
+    void del_cols(int first, int last) override
+    {
+    }
+
+    void add_rows(int newrows,
+                  int newnz,
+                  const char* qrtype,
+                  const double* rhs,
+                  const double* range,
+                  const int* mstart,
+                  const int* mclind,
+                  const double* dmatval,
+                  const std::vector<std::string>& row_names) override
+    {
+    }
+
+    void add_cols(int newcol,
+                  int newnz,
+                  const double* objx,
+                  const int* mstart,
+                  const int* mrwind,
+                  const double* dmatval,
+                  const double* bdl,
+                  const double* bdu,
+                  const std::vector<std::string>& col_names) override
+    {
+    }
+
+    void add_name(int type, const char* cnames, int indice) override
+    {
+    }
+
+    void add_names(int type, const std::vector<std::string>& cnames, int first, int end) override
+    {
+    }
+
+    void chg_obj(const std::vector<int>& mindex, const std::vector<double>& obj) override
+    {
+    }
+
+    void chg_obj_direction(const bool minimize) override
+    {
+    }
+
+    void chg_bounds(const std::vector<int>& mindex,
+                    const std::vector<char>& qbtype,
+                    const std::vector<double>& bnd) override
+    {
+    }
+
+    void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) override
+    {
+    }
+
+    void chg_rhs(int id_row, double val) override
+    {
+    }
+
+    void chg_coef(int id_row, int id_col, double val) override
+    {
+    }
+
+    void chg_row_name(int id_row, const std::string& name) override
+    {
+    }
+
+    void chg_col_name(int id_col, const std::string& name) override
+    {
+    }
+
+    int solve_lp() override
+    {
+        return 0;
+    }
+
+    int solve_mip() override
+    {
+        return 0;
+    }
+
+    void get_basis(int* rstatus, int* cstatus) const override
+    {
+    }
+
+    double get_mip_value() const override
+    {
+        return 0;
+    }
+
+    double get_lp_value() const override
+    {
+        return 0;
+    }
+
+    int get_splex_num_of_ite_last() const override
+    {
+        return 0;
+    }
+
+    void get_lp_sol(double* primals, double* duals, double* reduced_costs) const override
+    {
+    }
+
+    void get_mip_sol(double* primals) override
+    {
+    }
+
+    void set_output_log_level(int loglevel) override
+    {
+    }
+
+    void set_algorithm(const std::string& algo) override
+    {
+    }
+
+    void set_threads(int n_threads) override
+    {
+    }
+
+    void set_optimality_gap(double gap) override
+    {
+    }
+
+    void set_simplex_iter(int iter) override
+    {
+    }
+
+    void write_basis(const std::filesystem::path& filename) override
+    {
+    }
+
+    void read_basis(const std::filesystem::path& filename) override
+    {
+    }
+
+    void set_basis(std::span<int> rstatus, std::span<int> cstatus) override {};
+
+    void save_prob(const std::filesystem::path& filename) override
+    {
+    }
+
+    void restore_prob(const std::filesystem::path& filename) override
+    {
+    }
 };
 
-#endif  // ANTARESXPANSION_TESTS_CPP_LP_NAMER_NOOPSOLVER_H_
-
+#endif // ANTARESXPANSION_TESTS_CPP_LP_NAMER_NOOPSOLVER_H_
 
 class NOOPSolverForWorker: public NOOPSolver
 {
 public:
-
     void get_col_type(char* coltype, int begin, int end) const override
     {
         std::copy_n(col_types.begin(), end - begin + 1, coltype);


### PR DESCRIPTION
### Remove shared_ptr constructors in solver

Currently if we have a SolverAbstract-kind object on the stack it's not possible to call copy constructors. They require shared_ptr. Declaring copy constructors with const T& parameters use proper semantic for copy constructor, allow copy of stack object, does not prevent copy of managed heap objects


### Remove unused method copy_prob