### PR TITLE
Use atomic for multi thread protection

### DIFF
--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -55,7 +55,7 @@ SolverCbc::SolverCbc(const SolverAbstract& toCopy):
     else
     {
         number_of_problems_counter() -= 1;
-        throw InvalidSolverForCopyException(toCopy->get_solver_name(), name_, LOGLOCATION);
+        throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
 }
 

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -7,7 +7,7 @@ namespace
 {
 std::atomic<int>& number_of_problems_counter()
 {
-    static std::atomic<int> counter;
+    static std::atomic<int> counter{0};
     return counter;
 }
 } // namespace
@@ -53,7 +53,7 @@ SolverCbc::SolverCbc(const SolverAbstract& toCopy):
     else
     {
         number_of_problems_counter() -= 1;
-        throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
+        throw InvalidSolverForCopyException(toCopy->get_solver_name(), name_, LOGLOCATION);
     }
 }
 

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -5,9 +5,9 @@ using namespace std::literals;
 
 namespace
 {
-static ThreadSafeCounter& number_of_problems_counter()
+std::atomic<int>& number_of_problems_counter()
 {
-    static ThreadSafeCounter counter;
+    static std::atomic<int> counter;
     return counter;
 }
 } // namespace
@@ -65,7 +65,7 @@ SolverCbc::~SolverCbc()
 
 int SolverCbc::get_number_of_instances()
 {
-    return *number_of_problems_counter();
+    return number_of_problems_counter();
 }
 
 void SolverCbc::defineCbcModelFromInnerSolver()

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -1,5 +1,7 @@
 #include "SolverCbc.h"
 
+#include <atomic>
+
 #include "COIN_common_functions.h"
 using namespace std::literals;
 

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -3,11 +3,19 @@
 #include "COIN_common_functions.h"
 using namespace std::literals;
 
+namespace
+{
+static ThreadSafeCounter& number_of_problems_counter()
+{
+    static ThreadSafeCounter counter;
+    return counter;
+}
+} // namespace
+
 /*************************************************************************************************
 -----------------------------------    Constructor/Desctructor
 --------------------------------
 *************************************************************************************************/
-ThreadSafeCounter SolverCbc::_NumberOfProblems;
 
 SolverCbc::SolverCbc(const SolverLogManager& log_manager):
     SolverCbc()
@@ -22,7 +30,7 @@ SolverCbc::SolverCbc(const SolverLogManager& log_manager):
 
 SolverCbc::SolverCbc()
 {
-    _NumberOfProblems += 1;
+    number_of_problems_counter() += 1;
     set_output_log_level(0);
 }
 
@@ -44,20 +52,20 @@ SolverCbc::SolverCbc(const SolverAbstract& toCopy):
     }
     else
     {
-        _NumberOfProblems -= 1;
+        number_of_problems_counter() -= 1;
         throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
 }
 
 SolverCbc::~SolverCbc()
 {
-    _NumberOfProblems -= 1;
-    SolverCbc::free();
+    number_of_problems_counter() -= 1;
+    free();
 }
 
 int SolverCbc::get_number_of_instances()
 {
-    return *_NumberOfProblems;
+    return *number_of_problems_counter();
 }
 
 void SolverCbc::defineCbcModelFromInnerSolver()

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -7,7 +7,7 @@ using namespace std::literals;
 -----------------------------------    Constructor/Desctructor
 --------------------------------
 *************************************************************************************************/
-int SolverCbc::_NumberOfProblems = 0;
+ThreadSafeCounter SolverCbc::_NumberOfProblems;
 
 SolverCbc::SolverCbc(const SolverLogManager& log_manager):
     SolverCbc()
@@ -57,7 +57,7 @@ SolverCbc::~SolverCbc()
 
 int SolverCbc::get_number_of_instances()
 {
-    return _NumberOfProblems;
+    return *_NumberOfProblems;
 }
 
 void SolverCbc::defineCbcModelFromInnerSolver()

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -51,7 +51,7 @@ SolverClp::SolverClp(const SolverAbstract& toCopy):
     else
     {
         number_of_problems_counter() -= 1;
-        throw InvalidSolverForCopyException(toCopy->get_solver_name(), name_, LOGLOCATION);
+        throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
 }
 

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -3,11 +3,19 @@
 #include "COIN_common_functions.h"
 using namespace std::literals;
 
+namespace
+{
+static ThreadSafeCounter& number_of_problems_counter()
+{
+    static ThreadSafeCounter counter;
+    return counter;
+}
+} // namespace
+
 /*************************************************************************************************
 -----------------------------------    Constructor/Desctructor
 --------------------------------
 *************************************************************************************************/
-ThreadSafeCounter SolverClp::_NumberOfProblems;
 
 SolverClp::SolverClp(const SolverLogManager& log_manager):
     SolverClp()
@@ -21,7 +29,7 @@ SolverClp::SolverClp(const SolverLogManager& log_manager):
 
 SolverClp::SolverClp()
 {
-    _NumberOfProblems += 1;
+    number_of_problems_counter() += 1;
     set_output_log_level(0);
 }
 
@@ -40,20 +48,20 @@ SolverClp::SolverClp(const SolverAbstract& toCopy):
     }
     else
     {
-        _NumberOfProblems -= 1;
+        number_of_problems_counter() -= 1;
         throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
 }
 
 SolverClp::~SolverClp()
 {
-    _NumberOfProblems -= 1;
+    number_of_problems_counter() -= 1;
     SolverClp::free();
 }
 
 int SolverClp::get_number_of_instances()
 {
-    return *_NumberOfProblems;
+    return *number_of_problems_counter();
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -7,7 +7,7 @@ using namespace std::literals;
 -----------------------------------    Constructor/Desctructor
 --------------------------------
 *************************************************************************************************/
-int SolverClp::_NumberOfProblems = 0;
+ThreadSafeCounter SolverClp::_NumberOfProblems;
 
 SolverClp::SolverClp(const SolverLogManager& log_manager):
     SolverClp()
@@ -53,7 +53,7 @@ SolverClp::~SolverClp()
 
 int SolverClp::get_number_of_instances()
 {
-    return _NumberOfProblems;
+    return *_NumberOfProblems;
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -1,5 +1,7 @@
 #include "SolverClp.h"
 
+#include <atomic>
+
 #include "COIN_common_functions.h"
 using namespace std::literals;
 

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -7,7 +7,7 @@ namespace
 {
 std::atomic<int>& number_of_problems_counter()
 {
-    static std::atomic<int> counter;
+    static std::atomic<int> counter{0};
     return counter;
 }
 } // namespace
@@ -49,7 +49,7 @@ SolverClp::SolverClp(const SolverAbstract& toCopy):
     else
     {
         number_of_problems_counter() -= 1;
-        throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
+        throw InvalidSolverForCopyException(toCopy->get_solver_name(), name_, LOGLOCATION);
     }
 }
 

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -5,9 +5,9 @@ using namespace std::literals;
 
 namespace
 {
-static ThreadSafeCounter& number_of_problems_counter()
+std::atomic<int>& number_of_problems_counter()
 {
-    static ThreadSafeCounter counter;
+    static std::atomic<int> counter;
     return counter;
 }
 } // namespace
@@ -61,7 +61,7 @@ SolverClp::~SolverClp()
 
 int SolverClp::get_number_of_instances()
 {
-    return *number_of_problems_counter();
+    return number_of_problems_counter();
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -13,9 +13,17 @@ using namespace std::literals;
 -----------------------------------    Constructor/Desctructor
 --------------------------------
 *************************************************************************************************/
-ThreadSafeCounter SolverXpress::_NumberOfProblems;
 std::mutex SolverXpress::license_guard;
 const std::map<int, std::string> TYPETONAME = {{1, "rows"}, {2, "columns"}};
+
+namespace
+{
+static ThreadSafeCounter& number_of_problems_counter()
+{
+    static ThreadSafeCounter counter;
+    return counter;
+}
+} // namespace
 
 SolverXpress::SolverXpress(const SolverLogManager& log_manager):
     SolverXpress()
@@ -32,7 +40,7 @@ SolverXpress::SolverXpress()
 {
     std::lock_guard<std::mutex> guard(license_guard);
     int status = 0;
-    if (*_NumberOfProblems == 0)
+    if (*number_of_problems_counter() == 0)
     {
         LoadXpress::XpressLoader xpress_loader;
         xpress_loader.initXpressEnv();
@@ -40,7 +48,7 @@ SolverXpress::SolverXpress()
         zero_status_check(status, "initialize XPRESS environment", LOGLOCATION);
     }
 
-    _NumberOfProblems += 1;
+    number_of_problems_counter() += 1;
 
     _xprs = NULL;
 }
@@ -65,7 +73,7 @@ SolverXpress::SolverXpress(const SolverAbstract& toCopy):
     }
     else
     {
-        _NumberOfProblems -= 1;
+        number_of_problems_counter() -= 1;
         SolverXpress::free();
         throw InvalidSolverForCopyException(toCopy.get_solver_name(), name_, LOGLOCATION);
     }
@@ -75,10 +83,10 @@ SolverXpress::~SolverXpress()
 {
     { // Scope guard
         std::lock_guard<std::mutex> guard(license_guard);
-        _NumberOfProblems -= 1;
+        number_of_problems_counter() -= 1;
         SolverXpress::free();
 
-        if (*_NumberOfProblems == 0)
+        if (*number_of_problems_counter() == 0)
         {
             int status = XPRSfree();
             if (status)
@@ -99,7 +107,7 @@ SolverXpress::~SolverXpress()
 
 int SolverXpress::get_number_of_instances()
 {
-    return *_NumberOfProblems;
+    return *number_of_problems_counter();
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -1,5 +1,6 @@
 #include "SolverXpress.h"
 
+#include <atomic>
 #include <cassert>
 #include <cstring>
 #include <map>

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -18,9 +18,9 @@ const std::map<int, std::string> TYPETONAME = {{1, "rows"}, {2, "columns"}};
 
 namespace
 {
-static ThreadSafeCounter& number_of_problems_counter()
+std::atomic<int>& number_of_problems_counter()
 {
-    static ThreadSafeCounter counter;
+    static std::atomic<int> counter;
     return counter;
 }
 } // namespace
@@ -40,7 +40,7 @@ SolverXpress::SolverXpress()
 {
     std::lock_guard<std::mutex> guard(license_guard);
     int status = 0;
-    if (*number_of_problems_counter() == 0)
+    if (number_of_problems_counter() == 0)
     {
         LoadXpress::XpressLoader xpress_loader;
         xpress_loader.initXpressEnv();
@@ -86,7 +86,7 @@ SolverXpress::~SolverXpress()
         number_of_problems_counter() -= 1;
         SolverXpress::free();
 
-        if (*number_of_problems_counter() == 0)
+        if (number_of_problems_counter() == 0)
         {
             int status = XPRSfree();
             if (status)
@@ -107,7 +107,7 @@ SolverXpress::~SolverXpress()
 
 int SolverXpress::get_number_of_instances()
 {
-    return *number_of_problems_counter();
+    return number_of_problems_counter();
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -13,7 +13,7 @@ using namespace std::literals;
 -----------------------------------    Constructor/Desctructor
 --------------------------------
 *************************************************************************************************/
-int SolverXpress::_NumberOfProblems = 0;
+ThreadSafeCounter SolverXpress::_NumberOfProblems;
 std::mutex SolverXpress::license_guard;
 const std::map<int, std::string> TYPETONAME = {{1, "rows"}, {2, "columns"}};
 
@@ -32,7 +32,7 @@ SolverXpress::SolverXpress()
 {
     std::lock_guard<std::mutex> guard(license_guard);
     int status = 0;
-    if (_NumberOfProblems == 0)
+    if (*_NumberOfProblems == 0)
     {
         LoadXpress::XpressLoader xpress_loader;
         xpress_loader.initXpressEnv();
@@ -78,7 +78,7 @@ SolverXpress::~SolverXpress()
         _NumberOfProblems -= 1;
         SolverXpress::free();
 
-        if (_NumberOfProblems == 0)
+        if (*_NumberOfProblems == 0)
         {
             int status = XPRSfree();
             if (status)
@@ -99,7 +99,7 @@ SolverXpress::~SolverXpress()
 
 int SolverXpress::get_number_of_instances()
 {
-    return _NumberOfProblems;
+    return *_NumberOfProblems;
 }
 
 /*************************************************************************************************

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -20,7 +20,7 @@ namespace
 {
 std::atomic<int>& number_of_problems_counter()
 {
-    static std::atomic<int> counter;
+    static std::atomic<int> counter{0};
     return counter;
 }
 } // namespace

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <list>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <span>
 #include <sstream>
 #include <stdexcept>
@@ -191,6 +193,63 @@ enum SOLVER_STATUS
     UNBOUNDED,
     INForUNBOUND,
     UNKNOWN,
+};
+
+class ThreadSafeCounter
+{
+public:
+    int get() const noexcept
+    {
+        std::shared_lock lock(mutex_);
+        return value_;
+    }
+
+    int operator*() const noexcept
+    {
+        return get();
+    }
+
+    int operator++() noexcept
+    {
+        std::unique_lock lock(mutex_);
+        return ++value_;
+    }
+
+    int operator++(int) noexcept
+    {
+        std::unique_lock lock(mutex_);
+        return value_++;
+    }
+
+    int operator--() noexcept
+    {
+        std::unique_lock lock(mutex_);
+        return --value_;
+    }
+
+    int operator--(int) noexcept
+    {
+        std::unique_lock lock(mutex_);
+        return value_--;
+    }
+
+    int operator+=(int v) noexcept
+    {
+        std::unique_lock lock(mutex_);
+        value_ += v;
+        return value_;
+    }
+
+    int operator-=(int v) noexcept
+    {
+        std::unique_lock lock(mutex_);
+        value_ -= v;
+        return value_;
+    }
+
+private:
+    int value_ = 0;
+    mutable std::shared_mutex mutex_;
 };
 
 /*!

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -195,63 +195,6 @@ enum SOLVER_STATUS
     UNKNOWN,
 };
 
-class ThreadSafeCounter
-{
-public:
-    int get() const noexcept
-    {
-        std::shared_lock lock(mutex_);
-        return value_;
-    }
-
-    int operator*() const noexcept
-    {
-        return get();
-    }
-
-    int operator++() noexcept
-    {
-        std::unique_lock lock(mutex_);
-        return ++value_;
-    }
-
-    int operator++(int) noexcept
-    {
-        std::unique_lock lock(mutex_);
-        return value_++;
-    }
-
-    int operator--() noexcept
-    {
-        std::unique_lock lock(mutex_);
-        return --value_;
-    }
-
-    int operator--(int) noexcept
-    {
-        std::unique_lock lock(mutex_);
-        return value_--;
-    }
-
-    int operator+=(int v) noexcept
-    {
-        std::unique_lock lock(mutex_);
-        value_ += v;
-        return value_;
-    }
-
-    int operator-=(int v) noexcept
-    {
-        std::unique_lock lock(mutex_);
-        value_ -= v;
-        return value_;
-    }
-
-private:
-    int value_ = 0;
-    mutable std::shared_mutex mutex_;
-};
-
 /*!
  * \class class SolverAbstract
  * \brief Virtual class to implement solvers methods

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -6,8 +6,6 @@
 #include <iostream>
 #include <list>
 #include <memory>
-#include <mutex>
-#include <shared_mutex>
 #include <span>
 #include <sstream>
 #include <stdexcept>

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -18,7 +18,7 @@ class SolverCbc: public SolverAbstract
     ----------------------------------------    ATTRIBUTES
     ---------------------------------------
     *************************************************************************************************/
-    static int _NumberOfProblems; /*!< Counter of the total number of Cplex
+    static ThreadSafeCounter _NumberOfProblems; /*!< Counter of the total number of Cplex
                                      problems declared to set or end the
                                      environment */
 

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -14,14 +14,6 @@
  */
 class SolverCbc: public SolverAbstract
 {
-    /*************************************************************************************************
-    ----------------------------------------    ATTRIBUTES
-    ---------------------------------------
-    *************************************************************************************************/
-    static ThreadSafeCounter _NumberOfProblems; /*!< Counter of the total number of Cplex
-                                     problems declared to set or end the
-                                     environment */
-
 public:
     const std::string name_ = "CBC";
     OsiClpSolverInterface _clp_inner_solver;

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -20,14 +20,6 @@ enum CLP_STATUS
  */
 class SolverClp: public SolverAbstract
 {
-    /*************************************************************************************************
-    ----------------------------------------    ATTRIBUTES
-    ---------------------------------------
-    *************************************************************************************************/
-    static ThreadSafeCounter _NumberOfProblems; /*!< Counter of the total number of
-                                     problems declared to set or end the
-                                     environment */
-
 public:
     ClpSimplex _clp;
     const std::string name_ = "CLP";

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -24,7 +24,7 @@ class SolverClp: public SolverAbstract
     ----------------------------------------    ATTRIBUTES
     ---------------------------------------
     *************************************************************************************************/
-    static int _NumberOfProblems; /*!< Counter of the total number of
+    static ThreadSafeCounter _NumberOfProblems; /*!< Counter of the total number of
                                      problems declared to set or end the
                                      environment */
 

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -16,8 +16,6 @@ class SolverXpress: public SolverAbstract
     ----------------------------------------    ATTRIBUTES
     ---------------------------------------
     *************************************************************************************************/
-    static ThreadSafeCounter _NumberOfProblems; /*!< Counter of the total number of Cplex problems
-                                  declared to set or end the environment */
     static std::mutex license_guard;
 
 public:

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -16,7 +16,7 @@ class SolverXpress: public SolverAbstract
     ----------------------------------------    ATTRIBUTES
     ---------------------------------------
     *************************************************************************************************/
-    static int _NumberOfProblems; /*!< Counter of the total number of Cplex problems
+    static ThreadSafeCounter _NumberOfProblems; /*!< Counter of the total number of Cplex problems
                                   declared to set or end the environment */
     static std::mutex license_guard;
 


### PR DESCRIPTION
Change static variable at global scope for atomic static variable at function scope.
* Prevent static initialization fiasco
* Protect multithreading access