### PR TITLE
Keep Xpress context alive

### DIFF
--- a/src/cpp/multisolver_interface/SolverFactory.cpp
+++ b/src/cpp/multisolver_interface/SolverFactory.cpp
@@ -29,6 +29,7 @@ void GetAvailableSolversInternal(std::shared_ptr<ILoggerXpansion> logger)
 {
     if (available_solvers.empty())
     {
+        static XpressManager xpress_manager;
         LoadXpress::XpressLoader xpress_loader(std::move(logger));
         if (xpress_loader.XpressIsCorrectlyInstalled(true))
         {

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -14,7 +14,6 @@ using namespace std::literals;
 -----------------------------------    Constructor/Desctructor
 --------------------------------
 *************************************************************************************************/
-std::mutex SolverXpress::license_guard;
 const std::map<int, std::string> TYPETONAME = {{1, "rows"}, {2, "columns"}};
 
 namespace
@@ -37,21 +36,30 @@ SolverXpress::SolverXpress(const SolverLogManager& log_manager):
     }
 }
 
-SolverXpress::SolverXpress()
+XpressManager::XpressManager()
 {
     std::lock_guard<std::mutex> guard(license_guard);
-    int status = 0;
-    if (number_of_problems_counter() == 0)
+    LoadXpress::XpressLoader xpress_loader;
+    xpress_loader.initXpressEnv();
+    int status = XPRSinit(nullptr);
+    SolverAbstract::zero_status_check(status, "initialize XPRESS environment", LOGLOCATION);
+}
+
+XpressManager::~XpressManager()
+{
+    std::lock_guard<std::mutex> guard(license_guard);
+
+    if (int status = XPRSfree())
     {
-        LoadXpress::XpressLoader xpress_loader;
-        xpress_loader.initXpressEnv();
-        status = XPRSinit(NULL);
-        zero_status_check(status, "initialize XPRESS environment", LOGLOCATION);
+        std::cerr << "Failed to free XPRESS environment with status: " << status << " "
+                  << LOGLOCATION << std::endl;
     }
+}
 
-    number_of_problems_counter() += 1;
-
-    _xprs = NULL;
+SolverXpress::SolverXpress()
+{
+    _NumberOfProblems += 1;
+    _xprs = nullptr;
 }
 
 SolverXpress::SolverXpress(const SolverAbstract& toCopy):
@@ -82,24 +90,9 @@ SolverXpress::SolverXpress(const SolverAbstract& toCopy):
 
 SolverXpress::~SolverXpress()
 {
-    { // Scope guard
-        std::lock_guard<std::mutex> guard(license_guard);
-        number_of_problems_counter() -= 1;
-        SolverXpress::free();
+    _NumberOfProblems -= 1;
+    SolverXpress::free();
 
-        if (number_of_problems_counter() == 0)
-        {
-            int status = XPRSfree();
-            if (status)
-            {
-                for (auto& stream: get_stream())
-                {
-                    *stream << "Failed to free XPRESS environment with status: " << status
-                            << LOGLOCATION;
-                }
-            }
-        }
-    }
     if (_log_stream.is_open())
     {
         _log_stream.close();

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -47,8 +47,7 @@ std::mutex& instance_guard()
 
 XpressManager::XpressManager()
 {
-    std::lock_guard<std::mutex> guard(instance_guard());
-    _loader.initXpressEnv();
+    std::lock_guard guard(instance_guard());
     if (_loader.XpressIsCorrectlyInstalled())
     {
         int status = XPRSinit(nullptr);

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -41,7 +41,7 @@ SolverXpress* SolverXpress::clone() const
     return new SolverXpress(*this);
 }
 
-SolverXpress::SolverXpress()
+namespace
 {
 std::mutex& instance_guard()
 {

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -65,6 +65,8 @@ SolverXpress::SolverXpress()
 SolverXpress::SolverXpress(const SolverAbstract& toCopy):
     SolverXpress()
 {
+    XpressLoader loader;
+    loader.XpressIsCorrectlyInstalled();
     SolverXpress::init();
     int status = 0;
 

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -58,7 +58,7 @@ XpressManager::XpressManager()
 
 XpressManager::~XpressManager()
 {
-    std::lock_guard<std::mutex> guard(instance_guard());
+    std::lock_guard guard(instance_guard());
 
     if (_loader.XpressIsCorrectlyInstalled())
     {

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -36,19 +36,25 @@ SolverXpress::SolverXpress(const SolverLogManager& log_manager):
     }
 }
 
-std::mutex& XpressManager::instance_guard()
+namespace
+{
+std::mutex& instance_guard()
 {
     static std::mutex license_guard;
     return license_guard;
 }
+} // namespace
 
 XpressManager::XpressManager()
 {
     std::lock_guard<std::mutex> guard(instance_guard());
     LoadXpress::XpressLoader xpress_loader;
     xpress_loader.initXpressEnv();
-    int status = XPRSinit(nullptr);
-    SolverAbstract::zero_status_check(status, "initialize XPRESS environment", LOGLOCATION);
+    if (xpress_loader.XpressIsCorrectlyInstalled())
+    {
+        int status = XPRSinit(nullptr);
+        SolverAbstract::zero_status_check(status, "initialize XPRESS environment", LOGLOCATION);
+    }
 }
 
 XpressManager::~XpressManager()

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -48,9 +48,8 @@ std::mutex& instance_guard()
 XpressManager::XpressManager()
 {
     std::lock_guard<std::mutex> guard(instance_guard());
-    LoadXpress::XpressLoader xpress_loader;
-    xpress_loader.initXpressEnv();
-    if (xpress_loader.XpressIsCorrectlyInstalled())
+    _loader.initXpressEnv();
+    if (_loader.XpressIsCorrectlyInstalled())
     {
         int status = XPRSinit(nullptr);
         SolverAbstract::zero_status_check(status, "initialize XPRESS environment", LOGLOCATION);
@@ -61,10 +60,13 @@ XpressManager::~XpressManager()
 {
     std::lock_guard<std::mutex> guard(instance_guard());
 
-    if (int status = XPRSfree())
+    if (_loader.XpressIsCorrectlyInstalled())
     {
-        std::cerr << "Failed to free XPRESS environment with status: " << status << " "
-                  << LOGLOCATION << std::endl;
+        if (int status = XPRSfree())
+        {
+            std::cerr << "Failed to free XPRESS environment with status: " << status << " "
+                      << LOGLOCATION << std::endl;
+        }
     }
 }
 

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -36,9 +36,15 @@ SolverXpress::SolverXpress(const SolverLogManager& log_manager):
     }
 }
 
+std::mutex& XpressManager::instance_guard()
+{
+    static std::mutex license_guard;
+    return license_guard;
+}
+
 XpressManager::XpressManager()
 {
-    std::lock_guard<std::mutex> guard(license_guard);
+    std::lock_guard<std::mutex> guard(instance_guard());
     LoadXpress::XpressLoader xpress_loader;
     xpress_loader.initXpressEnv();
     int status = XPRSinit(nullptr);
@@ -47,7 +53,7 @@ XpressManager::XpressManager()
 
 XpressManager::~XpressManager()
 {
-    std::lock_guard<std::mutex> guard(license_guard);
+    std::lock_guard<std::mutex> guard(instance_guard());
 
     if (int status = XPRSfree())
     {
@@ -58,7 +64,7 @@ XpressManager::~XpressManager()
 
 SolverXpress::SolverXpress()
 {
-    _NumberOfProblems += 1;
+    number_of_problems_counter() += 1;
     _xprs = nullptr;
 }
 
@@ -92,7 +98,7 @@ SolverXpress::SolverXpress(const SolverAbstract& toCopy):
 
 SolverXpress::~SolverXpress()
 {
-    _NumberOfProblems -= 1;
+    number_of_problems_counter() -= 1;
     SolverXpress::free();
 
     if (_log_stream.is_open())

--- a/src/cpp/multisolver_interface/environment.cc
+++ b/src/cpp/multisolver_interface/environment.cc
@@ -561,13 +561,9 @@ bool XpressLoader::initXpressEnv(bool verbose, int xpress_oem_license_key)
     }
 }
 
-bool XpressLoader::XpressIsCorrectlyInstalled(bool verbose)
+bool XpressLoader::XpressIsCorrectlyInstalled(bool verbose, bool do_init)
 {
     bool correctlyInstalled = initXpressEnv(verbose);
-    if (correctlyInstalled)
-    {
-        XPRSfree();
-    }
     return correctlyInstalled;
 }
 

--- a/src/cpp/multisolver_interface/environment.cc
+++ b/src/cpp/multisolver_interface/environment.cc
@@ -561,7 +561,7 @@ bool XpressLoader::initXpressEnv(bool verbose, int xpress_oem_license_key)
     }
 }
 
-bool XpressLoader::XpressIsCorrectlyInstalled(bool verbose, bool do_init)
+bool XpressLoader::XpressIsCorrectlyInstalled(bool verbose)
 {
     bool correctlyInstalled = initXpressEnv(verbose);
     return correctlyInstalled;

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -277,9 +277,9 @@ public:
     * @param action_failed  : action which returned the non zero status code,
                             used to print the error message.
     */
-    void zero_status_check(int status,
-                           const std::string& action_failed,
-                           const std::string& log_location) const
+    static void zero_status_check(int status,
+                                  const std::string& action_failed,
+                                  const std::string& log_location)
     {
         if (status != 0)
         {

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/environment.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/environment.h
@@ -47,7 +47,7 @@ public:
      * \brief return true is Xpress is correctly installed (libs and licence
      * found)
      */
-    bool XpressIsCorrectlyInstalled(bool verbose = false, bool do_init = true);
+    bool XpressIsCorrectlyInstalled(bool verbose = false);
 
 private:
     // clang-format off

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/environment.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/environment.h
@@ -47,7 +47,7 @@ public:
      * \brief return true is Xpress is correctly installed (libs and licence
      * found)
      */
-    bool XpressIsCorrectlyInstalled(bool verbose = false);
+    bool XpressIsCorrectlyInstalled(bool verbose = false, bool do_init = true);
 
 private:
     // clang-format off

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -8,8 +8,6 @@
 
 class XpressManager
 {
-    std::mutex& instance_guard();
-
 public:
     XpressManager();
     ~XpressManager();

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -8,6 +8,8 @@
 
 class XpressManager
 {
+    LoadXpress::XpressLoader _loader;
+
 public:
     XpressManager();
     ~XpressManager();

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -6,6 +6,15 @@
 #include "antares-xpansion/multisolver_interface/SolverAbstract.h"
 #include "antares-xpansion/multisolver_interface/environment.h"
 
+class XpressManager
+{
+    std::mutex license_guard;
+
+public:
+    XpressManager();
+    ~XpressManager();
+};
+
 /*!
  * \class class SolverXpress
  * \brief Daughter class of AsbtractSolver implementing solver XPRESS FICO
@@ -16,7 +25,8 @@ class SolverXpress: public SolverAbstract
     ----------------------------------------    ATTRIBUTES
     ---------------------------------------
     *************************************************************************************************/
-    static std::mutex license_guard;
+    static int _NumberOfProblems; /*!< Counter of the total number of Cplex problems
+                                  declared to set or end the environment */
 
 public:
     XPRSprob _xprs; /*!< Problem in XPRESS */
@@ -32,7 +42,7 @@ public:
      * @brief Default constructor of a XPRESS solver
      */
     SolverXpress();
-    SolverXpress(const SolverLogManager& log_manager);
+    explicit SolverXpress(const SolverLogManager& log_manager);
 
     explicit SolverXpress(const SolverAbstract& toCopy);
 
@@ -40,7 +50,7 @@ public:
     SolverXpress(const SolverXpress& other) = delete;
     SolverXpress& operator=(const SolverXpress& other) = delete;
 
-    ~SolverXpress();
+    ~SolverXpress() override;
     int get_number_of_instances() override;
 
     std::string get_solver_name() const override

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -8,7 +8,7 @@
 
 class XpressManager
 {
-    static std::mutex license_guard;
+    std::mutex& instance_guard();
 
 public:
     XpressManager();
@@ -21,13 +21,6 @@ public:
  */
 class SolverXpress: public SolverAbstract
 {
-    /*************************************************************************************************
-    ----------------------------------------    ATTRIBUTES
-    ---------------------------------------
-    *************************************************************************************************/
-    static int _NumberOfProblems; /*!< Counter of the total number of Cplex problems
-                                  declared to set or end the environment */
-
 public:
     XPRSprob _xprs; /*!< Problem in XPRESS */
     const std::string name_ = "XPRESS";

--- a/src/cpp/multisolver_interface/private/SolverXpress.h
+++ b/src/cpp/multisolver_interface/private/SolverXpress.h
@@ -8,7 +8,7 @@
 
 class XpressManager
 {
-    std::mutex license_guard;
+    static std::mutex license_guard;
 
 public:
     XpressManager();


### PR DESCRIPTION
Instead of freeing Xpress context every time the number of solver reach 0, we keep the context alive for the program duration