### PR TITLE
Fix mpi cache mode

### DIFF
--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -195,7 +195,7 @@ void BendersBase::update_best_ub()
         _data.x_in = _data.x_cut;
         _data.best_ub = _data.ub;
         _data.best_it = _data.it;
-        FillWorkerMasterData(relevantIterationData_.best);
+        relevantIterationData_.best = FillWorkerMasterData();
         _data.criteria_current_iteration_data.max_criterion_best_it
           = _data.criteria_current_iteration_data.max_criterion;
         _data.criteria_current_iteration_data.max_criterion_area_best_it
@@ -249,8 +249,9 @@ bool BendersBase::ShouldBendersStop()
            && !_data.is_in_initial_relaxation;
 }
 
-void BendersBase::FillWorkerMasterData(WorkerMasterData& worker_master_data)
+WorkerMasterData BendersBase::FillWorkerMasterData() const
 {
+    WorkerMasterData worker_master_data;
     worker_master_data._lb = _data.lb;
     worker_master_data._ub = _data.ub;
     worker_master_data._best_ub = _data.best_ub;
@@ -264,6 +265,7 @@ void BendersBase::FillWorkerMasterData(WorkerMasterData& worker_master_data)
     worker_master_data._invest_cost = _data.invest_cost;
     worker_master_data._operational_cost = _data.subproblem_cost;
     worker_master_data._valid = true;
+    return worker_master_data;
 }
 
 /*!
@@ -273,7 +275,7 @@ void BendersBase::FillWorkerMasterData(WorkerMasterData& worker_master_data)
  */
 void BendersBase::UpdateTrace()
 {
-    FillWorkerMasterData(relevantIterationData_.last);
+    relevantIterationData_.last = FillWorkerMasterData();
     // TODO Outer loop --> de-comment for general case
     // workerMasterDataVect_.push_back(relevantIterationData_.last);
 }
@@ -570,6 +572,10 @@ void BendersBase::GetSubproblemCutCache(SubProblemDataMap& subproblem_data_map)
                             std::lock_guard guard(m);
                             subproblem_data_map[name] = subproblem_data;
                             basiss_[name] = std::make_pair(rstatus, cstatus);
+                            std::call_once(
+                              variable_indice_once_flag,
+                              [&](const auto& worker_) { SetSubproblemVariablesIndices(worker_); },
+                              *worker);
                         });
       },
       shouldParallelize());
@@ -592,6 +598,12 @@ void BendersBase::SolveSubproblem(PlainData::SubProblemData& subproblem_data,
     subproblem_data.subproblem_timer = subproblem_timer.elapsed();
 }
 
+void BendersBase::SetSubproblemVariablesIndices(const SubproblemWorker& subproblem)
+{
+    auto&& col_names = subproblem._solver->get_col_names();
+    criterion_computation_.SearchVariables(col_names);
+}
+
 // Search for variables in sub problems that satisfy patterns
 // var_indices is a vector(for each patterns p) of vector (var indices related
 // to p)
@@ -600,8 +612,7 @@ void BendersBase::SetSubproblemsVariablesIndices()
     if (!subproblem_map.empty())
     {
         auto subproblem = subproblem_map.begin();
-
-        criterion_computation_.SearchVariables(subproblem->second->_solver->get_col_names());
+        SetSubproblemVariablesIndices(*subproblem->second);
     }
 }
 

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -2,6 +2,7 @@
 
 #include <execution>
 #include <filesystem>
+#include <mutex>
 #include <regex>
 #include <tbb/tbb.h>
 
@@ -134,6 +135,7 @@ public:
     Logger _logger;
     std::shared_ptr<Output::OutputWriter> _writer;
     std::shared_ptr<MathLoggerDriver> mathLoggerDriver_;
+    std::once_flag variable_indice_once_flag;
     void setCriterionComputationInputs(
       const Benders::Criterion::CriterionInputData& criterion_input_data);
 
@@ -294,6 +296,7 @@ protected:
     virtual void SolveSubproblem(PlainData::SubProblemData& subproblem_data,
                                  const std::string& name,
                                  const std::shared_ptr<SubproblemWorker>& worker);
+    void SetSubproblemVariablesIndices(const SubproblemWorker& subproblem);
 
     Benders::Criterion::CriterionComputation criterion_computation_;
     /**
@@ -330,7 +333,7 @@ private:
     [[nodiscard]] virtual bool shouldParallelize() const = 0;
     Output::Iteration iteration(const WorkerMasterData& masterDataPtr_l) const;
     LogData FinalLogData() const;
-    void FillWorkerMasterData(WorkerMasterData& workerMasterData);
+    WorkerMasterData FillWorkerMasterData() const;
     bool master_is_empty_ = true;
     int _totalNbProblems = 0;
     WorkerMasterPtr _master;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemCut.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemCut.h
@@ -27,6 +27,7 @@ struct SubProblemData
         ar & subproblem_cost;
         ar & var_name_and_subgradient;
         ar & criteria;
+        ar & patterns_values;
         ar & single_subpb_costs_under_approx;
         ar & subproblem_timer;
         ar & simplex_iter;


### PR DESCRIPTION
In "cache" mode there is an issue of using reduce on empty vectors.
VarIndices is empty so Reduce is called on empty criteria_per_sub_problem_per_pattern
VarIndices is empty because BroadCastVariablesIndices is called with empty subproblemMap
SubproblemMap is empty in cache mode by design.

The proposed fix is to have each worker build criterion_computation_ once