### PR TITLE
fix: Missing Xpress loading log in benders

### DIFF
--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -10,7 +10,7 @@
 #include "antares-xpansion/helpers/Timer.h"
 
 BendersMpi::BendersMpi(const BendersBaseOptions& options,
-                       Logger logger,
+                       std::shared_ptr<ILogger> logger,
                        std::shared_ptr<Output::OutputWriter> writer,
                        mpi::environment& env,
                        mpi::communicator& world,

--- a/src/cpp/benders/benders_mpi/include/antares-xpansion/benders/benders_mpi/BendersMPI.h
+++ b/src/cpp/benders/benders_mpi/include/antares-xpansion/benders/benders_mpi/BendersMPI.h
@@ -21,7 +21,7 @@ class BendersMpi: public BendersBase
 public:
     ~BendersMpi() override = default;
     BendersMpi(const BendersBaseOptions& options,
-               Logger logger,
+               std::shared_ptr<ILogger> logger,
                std::shared_ptr<Output::OutputWriter> writer,
                mpi::environment& env,
                mpi::communicator& world,

--- a/src/cpp/benders/logger/include/antares-xpansion/benders/logger/UserFile.h
+++ b/src/cpp/benders/logger/include/antares-xpansion/benders/logger/UserFile.h
@@ -18,7 +18,7 @@ class UserFile: public ILogger
 {
 public:
     explicit UserFile(const std::filesystem::path& filename);
-    ~UserFile();
+    ~UserFile() override;
 
     void display_message(const std::string& str) override;
     void display_message(const std::string& str,

--- a/src/cpp/multisolver_interface/SolverFactory.cpp
+++ b/src/cpp/multisolver_interface/SolverFactory.cpp
@@ -28,7 +28,7 @@ void GetAvailableSolversInternal(std::shared_ptr<ILoggerXpansion> logger)
 {
     if (available_solvers.empty())
     {
-        static XpressManager xpress_manager;
+        static XpressManager xpress_manager(logger);
         LoadXpress::XpressLoader xpress_loader(std::move(logger));
         if (xpress_loader.XpressIsCorrectlyInstalled(true))
         {

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <numeric>
 #include <set>
+#include <utility>
 
 #include "antares-xpansion/xpansion_interfaces/StringManip.h"
 
@@ -51,10 +52,12 @@ std::mutex& instance_guard()
 }
 } // namespace
 
-XpressManager::XpressManager()
+XpressManager::XpressManager(std::shared_ptr<ILoggerXpansion> logger):
+    logger_(logger),
+    loader_(logger)
 {
     std::lock_guard guard(instance_guard());
-    if (_loader.XpressIsCorrectlyInstalled())
+    if (loader_.XpressIsCorrectlyInstalled())
     {
         int status = XPRSinit(nullptr);
         SolverAbstract::zero_status_check(status, "initialize XPRESS environment", LOGLOCATION);
@@ -65,7 +68,7 @@ XpressManager::~XpressManager()
 {
     std::lock_guard guard(instance_guard());
 
-    if (_loader.XpressIsCorrectlyInstalled())
+    if (loader_.XpressIsCorrectlyInstalled())
     {
         if (int status = XPRSfree())
         {

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverXpress.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverXpress.h
@@ -8,10 +8,11 @@
 
 class XpressManager
 {
-    LoadXpress::XpressLoader _loader;
+    LoadXpress::XpressLoader loader_;
+    std::shared_ptr<ILoggerXpansion> logger_;
 
 public:
-    XpressManager();
+    explicit XpressManager(std::shared_ptr<ILoggerXpansion> logger);
     ~XpressManager();
 };
 


### PR DESCRIPTION
Log for Xpress loading are missing when running Benders making it difficult to see what went wrong when Xpress is not recognized as an available Solver.

This PR fix this issue by passing a proper logger to the object in charge of loading Xpress