### PR TITLE
fix: clang build

### DIFF
--- a/tests/cpp/lp_namer/CMakeLists.txt
+++ b/tests/cpp/lp_namer/CMakeLists.txt
@@ -59,10 +59,10 @@ target_link_libraries(lp_namer_tests PRIVATE
 
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(unit_tests PUBLIC -Wno-global-constructors)
-    target_compile_options(unit_tests PUBLIC -Wno-exit-time-destructors)
-    target_compile_options(unit_tests PUBLIC -Wno-weak-vtables)
-    target_compile_options(unit_tests PUBLIC -Wno-covered-switch-default)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-global-constructors)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-exit-time-destructors)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-weak-vtables)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-covered-switch-default)
 endif ()
 
 add_test(NAME unit_lpnamer COMMAND lp_namer_tests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/tests/cpp/multisolver_interface/CMakeLists.txt
+++ b/tests/cpp/multisolver_interface/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(GTest REQUIRED)
 # unit tests
 # --------------------------------------------------------------------------
 add_executable(test_multisolver
-  test_multisolver.cpp
+        test_multisolver.cpp
 )
 
 target_link_libraries(test_multisolver PRIVATE
@@ -20,10 +20,10 @@ target_link_libraries(test_multisolver PRIVATE
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(unit_tests PUBLIC -Wno-global-constructors)
-    target_compile_options(unit_tests PUBLIC -Wno-exit-time-destructors)
-    target_compile_options(unit_tests PUBLIC -Wno-weak-vtables)
-    target_compile_options(unit_tests PUBLIC -Wno-covered-switch-default)
+    target_compile_options(test_multisolver PUBLIC -Wno-global-constructors)
+    target_compile_options(test_multisolver PUBLIC -Wno-exit-time-destructors)
+    target_compile_options(test_multisolver PUBLIC -Wno-weak-vtables)
+    target_compile_options(test_multisolver PUBLIC -Wno-covered-switch-default)
 endif ()
 
 add_test(NAME test_multisolver COMMAND test_multisolver WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Fix error:
> Cannot specify compile options for target "unit_tests" which is not built