### PR TITLE
fix: update coinutils

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "coinutils",
-      "version": "2.11.6"
+      "version": "2.11.12"
     }
   ]
 }


### PR DESCRIPTION
Update coinutils to fix the following error on recent clang version :

> error: ISO C++17 does not allow 'register' storage class specifier [-Wregister]