### PR TITLE
fix: When output already exists create a new one

### DIFF
--- a/src/cpp/lpnamer/main/ConfigurationManager.cpp
+++ b/src/cpp/lpnamer/main/ConfigurationManager.cpp
@@ -13,6 +13,10 @@ ConfigurationManager::ConfigurationManager(ProblemGenerationOptions& options):
 
 auto ConfigurationManager::Directories() const -> ConfigDirectories
 {
+    if (directories_)
+    {
+        return *directories_;
+    }
     Mode();
     std::filesystem::path xpansion_output_dir;
     std::filesystem::path simulation_dir_;
@@ -49,10 +53,11 @@ auto ConfigurationManager::Directories() const -> ConfigDirectories
     {
         xpansion_output_dir = simulation_dir_;
     }
-    return {.xpansion_output_dir = xpansion_output_dir,
-            .study_dir = study_dir,
-            .simulation_dir = simulation_dir_,
-            .archive_path = archive_path};
+    directories_ = ConfigDirectories{.xpansion_output_dir = xpansion_output_dir,
+                                     .study_dir = study_dir,
+                                     .simulation_dir = simulation_dir_,
+                                     .archive_path = archive_path};
+    return *directories_;
 }
 
 auto ConfigurationManager::Mode() const -> SimulationInputMode
@@ -120,10 +125,10 @@ std::filesystem::path ConfigurationManager::generateOutputName(
         std::filesystem::path new_name;
         do
         {
-            new_name = study / "output" / (getCurrentTimestamp() + "_" + std::to_string(counter));
+            new_name = name.concat("_" + std::to_string(counter));
             counter++;
         } while (std::filesystem::exists(new_name));
         return new_name;
     }
-    return study / "output" / getCurrentTimestamp();
+    return name;
 }

--- a/src/cpp/lpnamer/main/ConfigurationManager.cpp
+++ b/src/cpp/lpnamer/main/ConfigurationManager.cpp
@@ -113,5 +113,17 @@ std::string getCurrentTimestamp()
 std::filesystem::path ConfigurationManager::generateOutputName(
   const std::filesystem::path& study) const
 {
+    auto name = study / "output" / getCurrentTimestamp();
+    if (std::filesystem::exists(name))
+    {
+        int counter = 1;
+        std::filesystem::path new_name;
+        do
+        {
+            new_name = study / "output" / (getCurrentTimestamp() + "_" + std::to_string(counter));
+            counter++;
+        } while (std::filesystem::exists(new_name));
+        return new_name;
+    }
     return study / "output" / getCurrentTimestamp();
 }

--- a/src/cpp/lpnamer/main/include/antares-xpansion/lpnamer/main/ConfigurationManager.h
+++ b/src/cpp/lpnamer/main/include/antares-xpansion/lpnamer/main/ConfigurationManager.h
@@ -28,4 +28,5 @@ public:
 private:
     mutable std::optional<SimulationInputMode> input_mode_;
     ProblemsFormat format_{ProblemsFormat::OPTIMIZED};
+    mutable std::optional<ConfigDirectories> directories_;
 };

--- a/tests/cpp/lp_namer/CMakeLists.txt
+++ b/tests/cpp/lp_namer/CMakeLists.txt
@@ -59,10 +59,10 @@ target_link_libraries(lp_namer_tests PRIVATE
 
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(unit_tests PUBLIC -Wno-global-constructors)
-    target_compile_options(unit_tests PUBLIC -Wno-exit-time-destructors)
-    target_compile_options(unit_tests PUBLIC -Wno-weak-vtables)
-    target_compile_options(unit_tests PUBLIC -Wno-covered-switch-default)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-global-constructors)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-exit-time-destructors)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-weak-vtables)
+    target_compile_options(lp_namer_tests PUBLIC -Wno-covered-switch-default)
 endif ()
 
 add_test(NAME unit_lpnamer COMMAND lp_namer_tests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/tests/cpp/multisolver_interface/CMakeLists.txt
+++ b/tests/cpp/multisolver_interface/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(GTest REQUIRED)
 # unit tests
 # --------------------------------------------------------------------------
 add_executable(test_multisolver
-  test_multisolver.cpp
+        test_multisolver.cpp
 )
 
 target_link_libraries(test_multisolver PRIVATE
@@ -20,10 +20,10 @@ target_link_libraries(test_multisolver PRIVATE
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    target_compile_options(unit_tests PUBLIC -Wno-global-constructors)
-    target_compile_options(unit_tests PUBLIC -Wno-exit-time-destructors)
-    target_compile_options(unit_tests PUBLIC -Wno-weak-vtables)
-    target_compile_options(unit_tests PUBLIC -Wno-covered-switch-default)
+    target_compile_options(test_multisolver PUBLIC -Wno-global-constructors)
+    target_compile_options(test_multisolver PUBLIC -Wno-exit-time-destructors)
+    target_compile_options(test_multisolver PUBLIC -Wno-weak-vtables)
+    target_compile_options(test_multisolver PUBLIC -Wno-covered-switch-default)
 endif ()
 
 add_test(NAME test_multisolver COMMAND test_multisolver WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "coinutils",
-      "version": "2.11.6"
+      "version": "2.11.12"
     }
   ]
 }


### PR DESCRIPTION
When launching two in memory workflows at the same minute, the second one fails obscurely. This is because both simulations have the same output directory and it should not be the case