### PR TITLE
Poc plugin benders

### DIFF
--- a/src/cpp/benders/CMakeLists.txt
+++ b/src/cpp/benders/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/outer_loop")
 
 add_subdirectory ("${CMAKE_CURRENT_SOURCE_DIR}/benders_mpi")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/factories")
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/plugins")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/output")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/merge_mps")
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/merge_master_mps")

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -22,6 +22,7 @@ BendersBase::BendersBase(BendersBaseOptions options,
     _options(std::move(options)),
     _csv_file_path(std::filesystem::path(_options.OUTPUTROOT) / (_options.CSV_NAME + ".csv"))
 {
+    benders_plugin_ = nullptr ;
 }
 
 /*!
@@ -102,6 +103,12 @@ void BendersBase::PrintCurrentIterationCsv()
                              relevantIterationData_.last,
                              x_cut);
     }
+}
+
+void BendersBase::SetPlugin(std::shared_ptr<BendersPlugin> benders_plugin) 
+{
+    // std::cout<<"setting plugin on benders "<<std::end ; 
+    benders_plugin_ = benders_plugin ; 
 }
 
 /*!

--- a/src/cpp/benders/benders_core/CMakeLists.txt
+++ b/src/cpp/benders/benders_core/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(benders_core
         ${JSONCPP_LIB}
         antaresXpansion::outer_loop_lib
         antaresXpansion::core
+        antaresXpansion::plugins
         fmt::fmt
 )
 

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -354,6 +354,9 @@ private:
     Timer benders_timer;
     Output::SolutionData outer_loop_solution_data_;
     std::unordered_map<std::string, std::pair<std::vector<int>, std::vector<int>>> basiss_;
+
+public:
+    std::function<void()> onIterationEndCallback_;
 };
 
 using pBendersBase = std::shared_ptr<BendersBase>;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -14,6 +14,7 @@
 #include "WorkerMaster.h"
 #include "antares-xpansion/helpers/Timer.h"
 #include "antares-xpansion/xpansion_interfaces/ILogger.h"
+#include "antares-xpansion/benders/plugins/BendersPlugin.h"
 #include "common.h"
 
 /**
@@ -58,6 +59,8 @@ public:
     void MasterChangeRhs(int id_row, double val) const;
     // for test
     void MasterGetRhs(double& rhs, int id_row) const;
+    
+    void SetPlugin(std::shared_ptr<BendersPlugin> benders_plugin) ; 
 
     const VariableMap& MasterVariables() const
     {
@@ -151,7 +154,8 @@ protected:
     bool init_problems_ = true;
     bool free_problems_ = true;
     BendersBaseOptions _options;
-
+    
+    std::shared_ptr<BendersPlugin> benders_plugin_ ; 
     std::vector<std::vector<double>> criteria_vector_for_each_iteration_;
     bool is_bilevel_check_all_ = false;
 

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -432,6 +432,7 @@ void BendersMpi::Run()
             mathLoggerDriver_->Print(_data);
             SaveCurrentBendersData();
         }
+        onIterationEndCallback_();
     }
     if (_world.rank() == rank_0)
     {

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -391,6 +391,8 @@ void BendersMpi::free()
  */
 void BendersMpi::Run()
 {
+    if (benders_plugin_) 
+        benders_plugin_->OnBendersStart() ; 
     if (init_data_)
     {
         PreRunInitialization();
@@ -401,7 +403,10 @@ void BendersMpi::Run()
         _data.stop = false;
     }
     _data.number_of_subproblem_solved = _data.nsubproblem;
-
+    // if (benders_plugin_) 
+    // {
+    //     std::cout<<"benders plugin set correctly "<<std::endl ; 
+    // }
     while (!_data.stop)
     {
         ++_data.it;
@@ -409,6 +414,9 @@ void BendersMpi::Run()
 
         /*Solve Master problem, get optimal value and cost and send it to
          * process*/
+        if (benders_plugin_) 
+            benders_plugin_->OnBendersMasterIterationStart() ; 
+
         step_1_solve_master();
 
         /*Gather cut from each subproblem in master thread and add them to Master
@@ -432,7 +440,9 @@ void BendersMpi::Run()
             mathLoggerDriver_->Print(_data);
             SaveCurrentBendersData();
         }
-        onIterationEndCallback_();
+        
+        if (benders_plugin_) 
+            benders_plugin_->OnBendersMasterIterationEnd() ; 
     }
     if (_world.rank() == rank_0)
     {
@@ -441,6 +451,8 @@ void BendersMpi::Run()
         write_basis();
     }
     _world.barrier();
+    if (benders_plugin_) 
+        benders_plugin_->OnBendersStart() ; 
 }
 
 void BendersMpi::PreRunInitialization()

--- a/src/cpp/benders/factories/BendersApp.cpp
+++ b/src/cpp/benders/factories/BendersApp.cpp
@@ -2,6 +2,7 @@
 #include "antares-xpansion/benders/factories/BendersApp.h"
 
 #include <antares-xpansion/benders/factories/BendersFactory.h>
+#include <dlfcn.h>
 #include <filesystem>
 #include <fmt/format.h>
 
@@ -75,6 +76,68 @@ void BendersApp::AddCriterionOutputs()
                                  &CriteriaCurrentIterationData::patterns_values);
 }
 
+// Returns the absolute path of the executable
+// https://gist.github.com/Jacob-Tate/7b326a086cf3f9d46e32315841101109
+// Thanks to Jacob Tate
+std::filesystem::path abs_exe_path()
+{
+#if defined(_MSC_VER)
+    wchar_t path[FILENAME_MAX] = {0};
+    GetModuleFileNameW(nullptr, path, FILENAME_MAX);
+    return std::filesystem::path(path);
+#else
+    char path[FILENAME_MAX];
+    ssize_t count = readlink("/proc/self/exe", path, FILENAME_MAX);
+    return std::filesystem::path(std::string(path, (count > 0) ? count : 0));
+#endif
+}
+
+std::filesystem::path abs_exe_directory()
+{
+#if defined(_MSC_VER)
+    wchar_t path[FILENAME_MAX] = {0};
+    GetModuleFileNameW(nullptr, path, FILENAME_MAX);
+    return std::filesystem::path(path).parent_path().string();
+#else
+    char path[FILENAME_MAX];
+    ssize_t count = readlink("/proc/self/exe", path, FILENAME_MAX);
+    return std::filesystem::path(std::string(path, (count > 0) ? count : 0)).parent_path().string();
+#endif
+}
+
+void BendersApp::LoadPlugin()
+{
+    // Assume plugin.so is in the same directory as the executable
+    // Need to know where the current executable is located
+    if (auto handle = dlopen((abs_exe_directory() / "plugin.so").c_str(), RTLD_NOW))
+    {
+        std::ostringstream msg;
+        msg << "Message: Plugin loaded: " << dlerror() << std::endl;
+        benders_loggers_.display_message(msg.str());
+        // Load functions
+        // Functions should be declared as extern "C" in the plugin code to avoid name mangling
+        if (auto callback = dlsym(handle, "onIterationEnd"))
+        {
+            std::ostringstream msg;
+            msg << "Message: Callback OK: " << dlerror() << std::endl;
+            benders_loggers_.display_message(msg.str());
+            benders_->onIterationEndCallback_ = reinterpret_cast<void (*)()>(callback);
+        }
+        else
+        {
+            std::ostringstream msg;
+            msg << "Warning: Could not load symbol onIterationEnd: " << dlerror() << std::endl;
+            benders_loggers_.display_message(msg.str());
+        }
+    }
+    else
+    {
+        std::ostringstream msg;
+        msg << "Warning: Could not load plugin.so: " << dlerror() << std::endl;
+        benders_loggers_.display_message(msg.str());
+    }
+}
+
 int BendersApp::RunBenders()
 {
     try
@@ -107,11 +170,13 @@ int BendersApp::RunBenders()
             if (benders_)
             {
                 StartMessage();
+                LoadPlugin();
                 benders_->launch();
                 EndMessage(benders_->execution_time());
             }
         }
     }
+
     catch (std::exception& e)
     {
         std::ostringstream msg;
@@ -119,6 +184,7 @@ int BendersApp::RunBenders()
         benders_loggers_.display_message(msg.str());
         mpi::environment::abort(1);
     }
+
     catch (...)
     {
         std::ostringstream msg;
@@ -126,6 +192,7 @@ int BendersApp::RunBenders()
         benders_loggers_.display_message(msg.str());
         mpi::environment::abort(1);
     }
+
     return 0;
 }
 

--- a/src/cpp/benders/factories/BendersFactory.cpp
+++ b/src/cpp/benders/factories/BendersFactory.cpp
@@ -28,6 +28,7 @@ BendersFactory::BendersFactory(const SimulationOptions& options,
     world_{world},
     benders_loggers_{benders_loggers}
 {
+    benders_plugin_factory_ = std::make_shared<BendersPluginFactory>() ; 
 }
 
 BENDERSMETHOD DeduceBendersMethod(size_t coupling_map_size, size_t batch_size, bool outer_loop)
@@ -131,6 +132,10 @@ auto BendersFactory::ConfigureBenders(const BendersBaseOptions& benders_options,
                                                    *world_,
                                                    math_log_driver_);
         break;
+
+        std::shared_ptr<BendersPlugin> benders_plugin(benders_plugin_factory_->CreatePlugin()) ; 
+        benders->SetPlugin(benders_plugin) ; 
+
     }
 
     benders->set_input_map(coupling_map);

--- a/src/cpp/benders/factories/BendersPluginFactory.cpp
+++ b/src/cpp/benders/factories/BendersPluginFactory.cpp
@@ -1,0 +1,40 @@
+#include "antares-xpansion/benders/factories/BendersPluginFactory.h"
+#include "antares-xpansion/benders/plugins/BendersPluginTST.h"
+
+
+BendersPluginFactory::BendersPluginFactory() 
+                    
+{
+    std::cout<<"BendersPluginFactory Constructor"<<std::endl ; 
+    library_path_ = "" ; 
+}
+
+
+BendersPlugin* BendersPluginFactory::CreatePlugin() 
+{
+    BendersPlugin* plugin = new BendersPluginTST() ; 
+   #if 0
+    void* handle = dlopen(library_path_.c_str(),RTLD_LAZY)  ; 
+   
+   if (!handle) 
+   {
+       std::cout<<"cannot find the library file"<<std::endl;  
+       dlclose(handle) ; 
+       return nullptr ; 
+   }
+
+   auto createPlugin = (CreatePluginFunc) dlsym(handle,"CreatePlugin") ; 
+   if (!createPlugin) 
+   {
+        std::cout<<"can't find CreatePlugin in the external library"<<std::endl ; 
+        dlclose(handle) ; 
+        return nullptr ; 
+   }
+
+    BendersPlugin* plugin = createPlugin() ; 
+    dlclose(handle) ; 
+#endif 
+   return plugin; 
+
+}
+

--- a/src/cpp/benders/factories/CMakeLists.txt
+++ b/src/cpp/benders/factories/CMakeLists.txt
@@ -4,8 +4,10 @@ target_sources(factories PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/factories/BendersFactory.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/factories/LoggerFactories.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/factories/WriterFactories.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/factories/BendersPluginFactory.h
         BendersApp.cpp
         BendersFactory.cpp
+        BendersPluginFactory.cpp
         LoggerFactories.cpp
         WriterFactories.cpp
 )
@@ -19,6 +21,7 @@ target_link_libraries(factories
         antaresXpansion::logger_lib
         ${PROJECT_NAME}::benders_mpi_core
         antaresXpansion::outer_loop_lib
+        antaresXpansion::plugins
 )
 
 target_include_directories(factories

--- a/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersApp.h
+++ b/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersApp.h
@@ -27,6 +27,7 @@ class BendersApp
     static constexpr const char* const LOLD_FILE = "LOLD.txt";
 
     [[nodiscard]] int RunExternalLoop();
+    void LoadPlugin();
     [[nodiscard]] int RunBenders();
     [[nodiscard]] std::shared_ptr<MathLoggerDriver> BuildMathLogger(bool benders_log_console) const;
     void StartMessage();

--- a/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersFactory.h
+++ b/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersFactory.h
@@ -2,6 +2,8 @@
 #include <antares-xpansion/benders/benders_core/BendersMethod.h>
 #include <antares-xpansion/benders/benders_core/CriterionInputDataReader.h>
 #include <antares-xpansion/benders/benders_core/common.h>
+#include <antares-xpansion/benders/factories/BendersPluginFactory.h>
+#include <antares-xpansion/benders/plugins/BendersPlugin.h>
 #include <memory>
 #include <optional>
 #include <variant>
@@ -56,6 +58,7 @@ private:
     std::set<std::string> ReadAreaFile();
     void ConfigureSolverLog(BendersBase* benders);
 
+    std::shared_ptr<BendersPluginFactory> benders_plugin_factory_ ; 
     const SimulationOptions& options_;
     std::shared_ptr<ILogger> logger_;
     std::shared_ptr<Output::OutputWriter> writer_;

--- a/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersPluginFactory.h
+++ b/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersPluginFactory.h
@@ -1,0 +1,26 @@
+#pragma once
+
+
+#include <filesystem>
+#include <memory>
+#include "antares-xpansion/benders/plugins/BendersPlugin.h"
+#include <dlfcn.h>
+#include <iostream>
+
+
+class BendersPluginFactory 
+{
+    public : 
+    
+        BendersPluginFactory( ) ;
+        BendersPlugin* CreatePlugin() ;
+
+    private :
+        
+        std::filesystem::path library_path_ ; 
+
+
+
+};
+
+typedef BendersPlugin* (*CreatePluginFunc)() ; 

--- a/src/cpp/benders/plugins/BendersPluginTST.cpp
+++ b/src/cpp/benders/plugins/BendersPluginTST.cpp
@@ -1,0 +1,43 @@
+#include "antares-xpansion/benders/plugins/BendersPluginTST.h"
+#include <iostream>
+
+
+BendersPluginTST::BendersPluginTST()
+{
+    std::cout<<"building BendersPluginTST object "<<std::endl ; 
+}
+
+BendersPluginTST::~BendersPluginTST()
+{
+    std::cout<<"destroying BendersPluginTST object"<<std::endl ;
+}
+
+void BendersPluginTST::OnBendersStart() 
+{
+    std::cout<<"OnBendersStart from BendersPluginTST"<<std::endl ; 
+}
+
+void BendersPluginTST::OnBendersEnd() 
+{
+    std::cout<<"OnBendersEnd from BendersPluginTST"<<std::endl ; 
+}
+
+void BendersPluginTST::OnBendersMasterIterationStart() 
+{
+    std::cout<<"OnBendersMasterIterationStart from BendersPluginTST"<<std::endl; 
+}
+
+void BendersPluginTST::OnBendersMasterIterationEnd() 
+{
+    std::cout<<"OnBendersMasterIterationEnd from BendersPluginTST "<<std::endl; 
+}
+
+void BendersPluginTST::OnBendersMicroIterationStart() 
+{
+    std::cout<<"OnBendersMicroIterationStart from BendersPluginTST "<<std::endl ; 
+}
+
+void BendersPluginTST::OnBendersMicroIterationEnd() 
+{
+    std::cout<<"OnBendersMicroIterationEnd from BendersPluginTST "<<std::endl; 
+}

--- a/src/cpp/benders/plugins/CMakeLists.txt
+++ b/src/cpp/benders/plugins/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(plugins)
+target_sources(plugins PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/plugins/BendersPlugin.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/plugins/BendersPluginTST.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/BendersPluginTST.cpp
+
+)
+target_link_libraries(plugins
+            PUBLIC 
+            antaresXpansion::benders_core
+)
+
+target_include_directories(plugins
+        PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+add_library(${PROJECT_NAME}::plugins ALIAS plugins)
+install(DIRECTORY include/antares-xpansion
+        DESTINATION "include"
+)

--- a/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/BendersPlugin.h
+++ b/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/BendersPlugin.h
@@ -1,0 +1,16 @@
+#pragma once
+
+
+
+
+class BendersPlugin 
+{
+    public : 
+        virtual ~BendersPlugin() = default ;
+        virtual void OnBendersStart() = 0 ; 
+        virtual void OnBendersEnd() = 0 ;  
+        virtual void OnBendersMasterIterationStart() = 0 ;  
+        virtual void OnBendersMasterIterationEnd() = 0 ;  
+        virtual void OnBendersMicroIterationStart() = 0 ; 
+        virtual void OnBendersMicroIterationEnd() = 0 ; 
+};

--- a/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/BendersPluginTST.h
+++ b/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/BendersPluginTST.h
@@ -1,0 +1,16 @@
+#pragma once 
+
+#include "antares-xpansion/benders/plugins/BendersPlugin.h"
+
+class BendersPluginTST : public BendersPlugin
+{
+    public : 
+        BendersPluginTST() ; 
+        virtual ~BendersPluginTST() ;
+        virtual void OnBendersStart()  ; 
+        virtual void OnBendersEnd()  ;  
+        virtual void OnBendersMasterIterationStart()  ;  
+        virtual void OnBendersMasterIterationEnd()  ;  
+        virtual void OnBendersMicroIterationStart()  ; 
+        virtual void OnBendersMicroIterationEnd()  ; 
+};


### PR DESCRIPTION
### PoC demonstrating how to use plugins in benders

#### Why ?

Create extension points in benders where users can plugin dynamically without having to open issue, pull request, rebuild or wait for release.

#### How ?

Users need to build a plugin in the form of a shared library. Here is a plugin example : https://github.com/JasonMarechal25/benders_plugin_exemple

The library must be named "plugin.so" and copied next to benders executable

Benders will try to load the library and the symbol "onIterationEnd". To avoid issues, the function should be declared in extern "C" scope in the plugin

#### Result

In my example, onIterationEnd calls on HelloWorld and display "Hello, wold!" in standard outpout. 

[Benders][INFO 06-01-2026 09:45:28]                          Lower Bound =    15532.81 Me
[Benders][INFO 06-01-2026 09:45:28]                         Absolute gap = 2.05922e+07 e
[Benders][INFO 06-01-2026 09:45:28]                         Relative gap = 1.32397e-03
Hello, World!
[Benders][INFO 06-01-2026 09:45:28] ITERATION 11:
[Benders][INFO 06-01-2026 09:45:28]     Solving master...


