### PR TITLE
replacing aggregation

### DIFF
--- a/data_test/test_cut_aggregation_ieee96_10inc/options.json
+++ b/data_test/test_cut_aggregation_ieee96_10inc/options.json
@@ -3,7 +3,7 @@
     "ABSOLUTE_GAP": 1e-06,
     "RELATIVE_GAP": 1e-06,
     "RELAXED_GAP": 0.001,
-    "AGGREGATION": 0,
+    "NB_CUTS_PER_ITER": 0,
     "OUTPUTROOT": ".",
     "TRACE": true,
     "SLAVE_WEIGHT": "CONSTANT",

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -749,17 +749,23 @@ std::vector<SubProblemNamesInCut> BendersBase::split_subproblem_data_pairs(
 
 int BendersBase::SetAggregation(int max_aggregation) const
 {
-    if (max_aggregation < _options.AGGREGATION || _options.AGGREGATION <= 0)
+    if (max_aggregation < _options.NB_CUTS_PER_ITER )
     {
-        std::string logging_str = "AGGREGATION : " + std::to_string(_options.AGGREGATION)
+        std::string logging_str = "NB_CUTS_PER_ITER : " + std::to_string(_options.NB_CUTS_PER_ITER)
                                   + " is larger than the number of subproblems solved at this "
                                     "iteration : "
-                                  + std::to_string(max_aggregation) + "setting AGGREGATION to "
+                                  + std::to_string(max_aggregation) + " setting NB_CUTS_PER_ITER to "
                                   + std::to_string(max_aggregation);
         _logger->display_message(logging_str);
         return max_aggregation;
     }
-    return _options.AGGREGATION;
+    else if (_options.NB_CUTS_PER_ITER <= 0)
+    {
+        std::string logging_str = "NB_CUTS_PER_ITER is <= 0. By default it will be equal to : " + std::to_string(max_aggregation) ; 
+        _logger->display_message(logging_str);
+        return max_aggregation;
+    }
+    return _options.NB_CUTS_PER_ITER;
 }
 
 /*!
@@ -770,7 +776,7 @@ int BendersBase::SetAggregation(int max_aggregation) const
 void BendersBase::BuildCutFull(const SubProblemDataMap& subproblem_data_map)
 {
     check_status(subproblem_data_map);
-    if (_options.AGGREGATION)
+    if (_options.NB_CUTS_PER_ITER)
     {
         compute_cut_aggregate(subproblem_data_map);
     }

--- a/src/cpp/benders/benders_core/SimulationOptions.cpp
+++ b/src/cpp/benders/benders_core/SimulationOptions.cpp
@@ -195,7 +195,7 @@ BendersBaseOptions SimulationOptions::get_benders_options() const
     result.SEPARATION_PARAM = SEPARATION_PARAM;
 
     result.RESUME = RESUME;
-    result.AGGREGATION = AGGREGATION;
+    result.NB_CUTS_PER_ITER = NB_CUTS_PER_ITER;
     result.TRACE = TRACE;
     result.BOUND_ALPHA = BOUND_ALPHA;
     result.CACHE_PROBLEMS = CACHE_PROBLEMS;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
@@ -20,7 +20,7 @@ BENDERS_OPTIONS_MACRO(SEPARATION_PARAM, double, 0.5, asDouble())
 BENDERS_OPTIONS_MACRO(MASTER_FORMULATION, std::string, "integer", asString())
 
 // Integer between 0 and +inf
-BENDERS_OPTIONS_MACRO(AGGREGATION, int, 0, asInt())
+BENDERS_OPTIONS_MACRO(NB_CUTS_PER_ITER, int, 0, asInt())
 
 // Path to the folder where output files should be printed
 BENDERS_OPTIONS_MACRO(OUTPUTROOT, std::string, ".", asString())

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -219,7 +219,7 @@ struct BendersBaseOptions: public SolverBaseOptions
     double CUT_COEFFICIENT_TOLERANCE = 5e-3;
 
     bool RESUME = false;
-    int AGGREGATION = 0;
+    int NB_CUTS_PER_ITER = 0;
     bool TRACE = false;
     bool BOUND_ALPHA = false;
     bool CACHE_PROBLEMS = false;

--- a/tests/cpp/benders/BendersBaseTest.cpp
+++ b/tests/cpp/benders/BendersBaseTest.cpp
@@ -149,7 +149,7 @@ protected:
         options.SEPARATION_PARAM = sep_param;
         options.MASTER_FORMULATION = MasterFormulation::RELAXED;
         options.RESUME = false;
-        options.AGGREGATION = false;
+        options.NB_CUTS_PER_ITER = false;
         options.TRACE = false;
         options.BOUND_ALPHA = true;
         options.MASTER_SOLUTION_TOLERANCE = 0.1;

--- a/tests/cpp/benders/benders_sequential_test.cpp
+++ b/tests/cpp/benders/benders_sequential_test.cpp
@@ -244,7 +244,7 @@ protected:
         options.MASTER_FORMULATION = master_formulation;
 
         options.RESUME = false;
-        options.AGGREGATION = false;
+        options.NB_CUTS_PER_ITER = false;
         options.TRACE = false;
         options.BOUND_ALPHA = true;
 

--- a/tests/cpp/study_updater/JsonXpansionReaderTest.cc
+++ b/tests/cpp/study_updater/JsonXpansionReaderTest.cc
@@ -121,7 +121,7 @@ class JsonXpansionReaderTest : public ::testing::Test {
 	"options" : 
 	{
 		"ACTIVECUTS" : false,
-		"AGGREGATION" : false,
+		"NB_CUTS_PER_ITER" : false,
 		"BASIS" : true,
 		"BOUND_ALPHA" : true,
 		"CSV_NAME" : "benders_output_trace",

--- a/tests/end_to_end/cucumber/features/benders_aggreg_cuts.feature
+++ b/tests/end_to_end/cucumber/features/benders_aggreg_cuts.feature
@@ -1,4 +1,4 @@
-Feature: AGGREGATION in options.json file sets the number cuts to add to the master problem at every iteration. We test that we converge to the right overall cost and with the correct solution
+Feature: NB_CUTS_PER_ITER in options.json file sets the number cuts to add to the master problem at every iteration. We test that we converge to the right overall cost and with the correct solution
 	
 	@short @full-launch
 	Scenario: Classical Benders with 1 proc


### PR DESCRIPTION
This PR has for a goal the substitution of the variable name AGGREGEATION in options.json (the number of cut to add to the master problem at each benders iteration) by NB_CUTS_PER_ITER

