### PR TITLE
Fix lp_namer command-line parsing error message

### DIFF
--- a/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp
+++ b/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp
@@ -61,7 +61,7 @@ void ProblemGenerationExeOptions::checkMandatoryOptions(const std::string& log_l
     auto count = std::ranges::count_if(args, notEmpty);
     if (count > 1)
     {
-        auto msg = "Only one of --output, --archive, --study parameters are accepted"s;
+        auto msg = "Only one of --output, --archive, --study parameters is accepted"s;
         throw ProblemGenerationOptions::ConflictingParameters(msg, log_location);
     }
     if (count == 0)

--- a/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp
+++ b/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp
@@ -61,12 +61,12 @@ void ProblemGenerationExeOptions::checkMandatoryOptions(const std::string& log_l
     auto count = std::ranges::count_if(args, notEmpty);
     if (count > 1)
     {
-        auto msg = "Only one of [archive, output, study] parameters is accepted"s;
+        auto msg = "Only one of --output, --archive, --study parameters are accepted"s;
         throw ProblemGenerationOptions::ConflictingParameters(msg, log_location);
     }
     if (count == 0)
     {
-        auto msg = "Need to give at least on of [OutputDir, Archive, Study] options"s;
+        auto msg = "Need at least one of --output, --archive, --study"s;
         throw ProblemGenerationOptions::MissingParameters(msg, log_location);
     }
 }


### PR DESCRIPTION
Make these messages more explicit to the user, so they don't need to invoke `lp_namer --help` to figure out what to do.

# Before
## Missing arguments
```
~/xpansion$ ~/xpansion/build-debug/lp_namer
error: Logged from function 'Parse' in file '/home/omnesflo/xpansion/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp' at line 42.
Need to give at least on of [OutputDir, Archive, Study] options
```
## Too many arguments
```
~/xpansion$ ~/xpansion/build-debug/lp_namer --study . --archive .
error: Logged from function 'Parse' in file '/home/omnesflo/xpansion/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp' at line 42.
Only one of [archive, output, study] parameters is accepted
```

# After
## Missing arguments
```
~/xpansion$ ~/xpansion/build-debug/lp_namer .
error: Logged from function 'Parse' in file '/home/omnesflo/xpansion/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp' at line 42.
Need at least one of --output, --archive, --study
```
## Too many arguments
```
~/xpansion$ ~/xpansion/build-debug/lp_namer --study . --archive .
error: Logged from function 'Parse' in file '/home/omnesflo/xpansion/src/cpp/lpnamer/main/ProblemGenerationExeOptions.cpp' at line 42.
Only one of --output, --archive, --study parameters is accepted
```
