### PR TITLE
Better error handling for invalid variable/constraint names [ANT-4313]

### DIFF
--- a/src/cpp/lpnamer/helper/ProblemGenerationLogger.cpp
+++ b/src/cpp/lpnamer/helper/ProblemGenerationLogger.cpp
@@ -1,7 +1,5 @@
 #include "antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h"
 
-#include "antares-xpansion/xpansion_interfaces/Clock.h"
-
 namespace ProblemGenerationLog
 {
 ProblemGenerationFileLogger::ProblemGenerationFileLogger(const std::filesystem::path& logFilePath):

--- a/src/cpp/lpnamer/helper/include/antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h
+++ b/src/cpp/lpnamer/helper/include/antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h
@@ -1,12 +1,13 @@
 #ifndef __PROBLEMGENERATIONLOGGER_H__
 #define __PROBLEMGENERATIONLOGGER_H__
-#include <chrono>
+
 #include <ctime>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <ostream>
 #include <set>
 #include <string>
@@ -117,13 +118,23 @@ public:
 
     const std::string& getContext() const;
 
-    ProblemGenerationLogger& operator()(const LogUtils::LOGLEVEL log_level)
+    ProblemGenerationLogger& operator()(const LogUtils::LOGLEVEL log_level, bool lock = false)
     {
+        std::unique_lock ulck(write_mutex_, std::defer_lock);
+        if (lock)
+        {
+            ulck.lock();
+        }
         return (*this) << log_level;
     }
 
-    ProblemGenerationLogger& operator()()
+    ProblemGenerationLogger& operator()(bool lock = false)
     {
+        std::unique_lock ulck(write_mutex_, std::defer_lock);
+        if (lock)
+        {
+            ulck.lock();
+        }
         return (*this) << PrefixMessage(log_level_, context_);
     }
 
@@ -140,6 +151,7 @@ public:
     ProblemGenerationLogger& operator<<(const T& t);
 
 private:
+    std::mutex write_mutex_;
     std::list<ProblemGenerationILoggerSharedPointer> loggers_;
     std::set<ProblemGenerationILoggerSharedPointer> enabled_loggers_;
     void update_enabled_logger();

--- a/src/cpp/lpnamer/main/ProblemGeneration.cpp
+++ b/src/cpp/lpnamer/main/ProblemGeneration.cpp
@@ -11,7 +11,6 @@
 #include "Version.h"
 #include "antares-xpansion/helpers/Timer.h"
 #include "antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h"
-#include "antares-xpansion/lpnamer/input_reader/GeneralDataReader.h"
 #include "antares-xpansion/lpnamer/input_reader/LpFilesExtractor.h"
 #include "antares-xpansion/lpnamer/input_reader/SettingsReader.h"
 #include "antares-xpansion/lpnamer/model/ActiveLinks.h"
@@ -28,7 +27,6 @@
 #include "antares-xpansion/lpnamer/problem_modifier/XpansionProblemsFromAntaresProvider.h"
 #include "antares-xpansion/lpnamer/problem_modifier/ZipProblemsProviderAdapter.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
-#include "antares-xpansion/xpansion_interfaces/StringManip.h"
 #include "config.h"
 #ifndef _WIN32
 #include "malloc.h"
@@ -349,10 +347,16 @@ void ProblemGeneration::RunProblemGeneration(
           [&](const auto& weeklyDataByYearWeek)
           {
               auto&& [year_week, data] = weeklyDataByYearWeek;
-              XpansionProblemsFromAntaresProvider adapter(lps_);
+              XpansionProblemsFromAntaresProvider adapter(lps_, logger.get());
               auto problem = adapter.provideProblem(solver_config_.Name(),
                                                     solver_log_manager,
                                                     year_week);
+              if (!problem)
+              {
+                  (*logger)(LogUtils::LOGLEVEL::ERR)
+                    << "No problem for year " << year_week.year << ", week " << year_week.week;
+                  return;
+              }
               {
                   std::lock_guard guard(mutex);
                   lps_.weeklyProblems.erase(year_week); // Clear data to save memory
@@ -360,10 +364,10 @@ void ProblemGeneration::RunProblemGeneration(
                   // Need to be done before treat because it will update problem name with the full
                   // path
               }
-              std::shared_ptr<IProblemVariablesProviderPort>
-                variables_provider = std::make_shared<ProblemVariablesFromProblemAdapter>(problem,
-                                                                                          links,
-                                                                                          logger);
+              auto variables_provider = std::make_shared<ProblemVariablesFromProblemAdapter>(
+                problem,
+                links,
+                logger);
 
               linkProblemsGenerator.treat(problem->_name,
                                           couplings,

--- a/src/cpp/lpnamer/problem_modifier/AntaresProblemToXpansionProblemTranslator.cpp
+++ b/src/cpp/lpnamer/problem_modifier/AntaresProblemToXpansionProblemTranslator.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 
+#include "antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h"
 #include "antares-xpansion/multisolver_interface/SolverFactory.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 #include "include/antares-xpansion/lpnamer/problem_modifier/RenameUtils.h"
@@ -14,12 +15,14 @@ namespace AntaresProblemToXpansionProblemTranslator
  * @Note: In case of performance issue we can accept non-const lps and work on
  * references to constant and hebdo parts
  */
-std::shared_ptr<Problem> translateToXpansionProblem(const Antares::Solver::LpsFromAntares& lps,
-                                                    unsigned int year,
-                                                    unsigned int week,
-                                                    const std::string& solver_name,
-                                                    const SolverLogManager& solver_log_manager,
-                                                    const RenameUtils& renameUtils)
+std::shared_ptr<Problem> translateToXpansionProblem(
+  const Antares::Solver::LpsFromAntares& lps,
+  unsigned int year,
+  unsigned int week,
+  const std::string& solver_name,
+  const SolverLogManager& solver_log_manager,
+  const RenameUtils& renameUtils,
+  ProblemGenerationLog::ProblemGenerationLogger* logger)
 {
     SolverFactory factory;
     auto problem = std::make_shared<Problem>(
@@ -36,10 +39,22 @@ std::shared_ptr<Problem> translateToXpansionProblem(const Antares::Solver::LpsFr
      * index from hour 0 to hour 167. We need to rename them to
      * correspond to the current week.
      */
-    const auto& [variables, constraints] = renameUtils.rename_week_names(
-      week,
-      constant.VariablesMeaning,
-      constant.ConstraintsMeaning);
+    auto renamed_result = renameUtils.rename_week_names(week,
+                                                        constant.VariablesMeaning,
+                                                        constant.ConstraintsMeaning,
+                                                        logger);
+
+    if (!renamed_result)
+    {
+        if (logger)
+        {
+            (*logger)(LogUtils::LOGLEVEL::ERR)
+              << "Failed to rename week " << week << " in year " << year << std::endl;
+        }
+        return nullptr;
+    }
+
+    const auto& [variables, constraints] = *renamed_result;
 
     problem->add_cols(constant.VariablesCount,
                       0,

--- a/src/cpp/lpnamer/problem_modifier/RenameUtils.cpp
+++ b/src/cpp/lpnamer/problem_modifier/RenameUtils.cpp
@@ -1,10 +1,8 @@
 #include "antares-xpansion/lpnamer/problem_modifier/RenameUtils.h"
 
-#include <algorithm>
 #include <charconv>
 #include <mutex>
 #include <optional>
-#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -120,8 +118,9 @@ bool RenameUtils::rename_week_names(
             {
                 if (logger)
                 {
-                    (*logger)(LogUtils::LOGLEVEL::ERR) << "Failed to rename variable/constraint '"
-                                                       << n << "' for week " << week << std::endl;
+                    (*logger)(LogUtils::LOGLEVEL::ERR, true)
+                      << "Failed to rename variable/constraint '" << n << "' for week " << week
+                      << std::endl;
                 }
                 return false;
             }

--- a/src/cpp/lpnamer/problem_modifier/RenameUtils.cpp
+++ b/src/cpp/lpnamer/problem_modifier/RenameUtils.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <charconv>
 #include <mutex>
+#include <optional>
 #include <ranges>
 #include <stdexcept>
 #include <string>
@@ -10,6 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
 constexpr unsigned int HOURS_IN_A_WEEK = 168;
@@ -58,15 +60,16 @@ bool RenameUtils::try_replace_first_token(const std::string& name,
     return true;
 }
 
-std::string RenameUtils::replace_time_step_in_name(const std::string& name, unsigned int week)
+std::optional<std::string> RenameUtils::replace_time_step_in_name(const std::string& name,
+                                                                  unsigned int week)
 {
     if (week == 0)
     {
-        throw std::invalid_argument(LOGLOCATION + std::string("week must be >= 1"));
+        return std::nullopt;
     }
 
     std::string out;
-    if (try_replace_first_token(name, "hour<", week, HOURS_IN_A_WEEK, false, out))
+    if (try_replace_first_token(name, "hour<~", week, HOURS_IN_A_WEEK, false, out))
     {
         return out;
     }
@@ -79,34 +82,53 @@ std::string RenameUtils::replace_time_step_in_name(const std::string& name, unsi
         return out;
     }
 
-    throw std::runtime_error(LOGLOCATION + std::string("No [hour|day|week]<...> pattern found in ")
-                             + name);
+    return std::nullopt;
 }
 
-std::pair<const std::vector<std::string>&, const std::vector<std::string>&>
+std::optional<std::pair<const std::vector<std::string>&, const std::vector<std::string>&>>
 RenameUtils::rename_week_names(unsigned int week,
                                const std::vector<std::string>& variables,
-                               const std::vector<std::string>& constraints) const
+                               const std::vector<std::string>& constraints,
+                               ProblemGenerationLog::ProblemGenerationLogger* logger) const
 {
-    rename_week_names(week, variables, variables_names_);
-    rename_week_names(week, constraints, constraints_names_);
-    return {variables_names_.at(week), constraints_names_.at(week)};
+    if (!rename_week_names(week, variables, variables_names_, logger))
+    {
+        return std::nullopt;
+    }
+    if (!rename_week_names(week, constraints, constraints_names_, logger))
+    {
+        return std::nullopt;
+    }
+    return std::make_pair(std::ref(variables_names_.at(week)),
+                          std::ref(constraints_names_.at(week)));
 }
 
-void RenameUtils::rename_week_names(
+bool RenameUtils::rename_week_names(
   unsigned int week,
   const std::vector<std::string>& names,
-  std::unordered_map<int, std::vector<std::string>>& container_names) const
+  std::unordered_map<int, std::vector<std::string>>& container_names,
+  ProblemGenerationLog::ProblemGenerationLogger* logger) const
 {
     if (!container_names.contains(week))
     {
         std::vector<std::string> renamed_variables;
         renamed_variables.reserve(names.size());
-        std::ranges::transform(names,
-                               std::back_inserter(renamed_variables),
-                               [&week](const auto& n)
-                               { return replace_time_step_in_name(n, week); });
+        for (const auto& n: names)
+        {
+            auto renamed = replace_time_step_in_name(n, week);
+            if (!renamed)
+            {
+                if (logger)
+                {
+                    (*logger)(LogUtils::LOGLEVEL::ERR) << "Failed to rename variable/constraint '"
+                                                       << n << "' for week " << week << std::endl;
+                }
+                return false;
+            }
+            renamed_variables.push_back(*renamed);
+        }
         std::lock_guard guard(rename_mutex_);
         container_names.emplace(week, renamed_variables);
     }
+    return true;
 }

--- a/src/cpp/lpnamer/problem_modifier/RenameUtils.cpp
+++ b/src/cpp/lpnamer/problem_modifier/RenameUtils.cpp
@@ -69,7 +69,7 @@ std::optional<std::string> RenameUtils::replace_time_step_in_name(const std::str
     }
 
     std::string out;
-    if (try_replace_first_token(name, "hour<~", week, HOURS_IN_A_WEEK, false, out))
+    if (try_replace_first_token(name, "hour<", week, HOURS_IN_A_WEEK, false, out))
     {
         return out;
     }

--- a/src/cpp/lpnamer/problem_modifier/XpansionProblemsFromAntaresProvider.cpp
+++ b/src/cpp/lpnamer/problem_modifier/XpansionProblemsFromAntaresProvider.cpp
@@ -10,15 +10,17 @@
 #include "antares-xpansion/lpnamer/problem_modifier/AntaresProblemToXpansionProblemTranslator.h"
 
 XpansionProblemsFromAntaresProvider::XpansionProblemsFromAntaresProvider(
-  const Antares::Solver::LpsFromAntares& lps):
-    antares_hebdo_problems{lps}
+  const Antares::Solver::LpsFromAntares& lps,
+  ProblemGenerationLog::ProblemGenerationLogger* logger):
+    antares_hebdo_problems{lps},
+    logger_{logger}
 {
 }
 
-auto XpansionProblemsFromAntaresProvider::provideProblem(
+std::shared_ptr<Problem> XpansionProblemsFromAntaresProvider::provideProblem(
   const std::string& solver_name,
   SolverLogManager& solver_log_manager,
-  const Antares::Solver::WeeklyProblemId& problem_id) const -> std::shared_ptr<Problem>
+  const Antares::Solver::WeeklyProblemId& problem_id) const
 {
     auto problem = AntaresProblemToXpansionProblemTranslator::translateToXpansionProblem(
       antares_hebdo_problems,
@@ -26,7 +28,8 @@ auto XpansionProblemsFromAntaresProvider::provideProblem(
       problem_id.week,
       solver_name,
       solver_log_manager,
-      rename_utils_);
+      rename_utils_,
+      logger_);
     return problem;
 }
 

--- a/src/cpp/lpnamer/problem_modifier/include/antares-xpansion/lpnamer/problem_modifier/AntaresProblemToXpansionProblemTranslator.h
+++ b/src/cpp/lpnamer/problem_modifier/include/antares-xpansion/lpnamer/problem_modifier/AntaresProblemToXpansionProblemTranslator.h
@@ -5,10 +5,12 @@
 #pragma once
 
 #include <span>
+#include <string>
 #include <unordered_map>
 
 #include <antares/solver/lps/LpsFromAntares.h>
 
+#include "antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h"
 #include "antares-xpansion/lpnamer/model/Problem.h"
 
 class RenameUtils;
@@ -21,6 +23,8 @@ namespace AntaresProblemToXpansionProblemTranslator
   unsigned int week,
   const std::string& solver_name,
   const SolverLogManager& solver_log_manager,
-  const RenameUtils& renameUtils);
+  const RenameUtils& renameUtils,
+  ProblemGenerationLog::ProblemGenerationLogger* logger = nullptr);
+
 std::vector<char> convertSignToLEG(std::span<const char> data);
 } // namespace AntaresProblemToXpansionProblemTranslator

--- a/src/cpp/lpnamer/problem_modifier/include/antares-xpansion/lpnamer/problem_modifier/RenameUtils.h
+++ b/src/cpp/lpnamer/problem_modifier/include/antares-xpansion/lpnamer/problem_modifier/RenameUtils.h
@@ -1,9 +1,15 @@
 #pragma once
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+
+namespace ProblemGenerationLog
+{
+class ProblemGenerationLogger;
+}
 
 class RenameUtils
 {
@@ -15,17 +21,19 @@ public:
                                         bool ignore_value,
                                         std::string& out);
 
-    static std::string replace_time_step_in_name(const std::string& name, unsigned int week);
-    std::pair<const std::vector<std::string>&, const std::vector<std::string>&> rename_week_names(
-      unsigned int week,
-      const std::vector<std::string>& variables,
-      const std::vector<std::string>& contraintes) const;
+    static std::optional<std::string> replace_time_step_in_name(const std::string& name,
+                                                                unsigned int week);
+    std::optional<std::pair<const std::vector<std::string>&, const std::vector<std::string>&>>
+    rename_week_names(unsigned int week,
+                      const std::vector<std::string>& variables,
+                      const std::vector<std::string>& contraintes,
+                      ProblemGenerationLog::ProblemGenerationLogger* logger) const;
 
 private:
-    void rename_week_names(
-      unsigned int week,
-      const std::vector<std::string>& names,
-      std::unordered_map<int, std::vector<std::string>>& container_names) const;
+    bool rename_week_names(unsigned int week,
+                           const std::vector<std::string>& names,
+                           std::unordered_map<int, std::vector<std::string>>& container_names,
+                           ProblemGenerationLog::ProblemGenerationLogger* logger) const;
 
     using NamesByWeek = std::unordered_map<int, std::vector<std::string>>;
     mutable NamesByWeek variables_names_;

--- a/src/cpp/lpnamer/problem_modifier/include/antares-xpansion/lpnamer/problem_modifier/XpansionProblemsFromAntaresProvider.h
+++ b/src/cpp/lpnamer/problem_modifier/include/antares-xpansion/lpnamer/problem_modifier/XpansionProblemsFromAntaresProvider.h
@@ -4,21 +4,25 @@
 
 #include "IXpansionProblemsProvider.h"
 #include "RenameUtils.h"
+#include "antares-xpansion/lpnamer/helper/ProblemGenerationLogger.h"
 #include "antares-xpansion/lpnamer/model/Problem.h"
 
 class XpansionProblemsFromAntaresProvider: public IXpansionProblemsProvider
 {
 public:
-    explicit XpansionProblemsFromAntaresProvider(const Antares::Solver::LpsFromAntares& lps);
-    auto provideProblem(const std::string& solver_name,
-                        SolverLogManager& solver_log_manager,
-                        const Antares::Solver::WeeklyProblemId& problem_id) const
-      -> std::shared_ptr<Problem>;
+    explicit XpansionProblemsFromAntaresProvider(
+      const Antares::Solver::LpsFromAntares& lps,
+      ProblemGenerationLog::ProblemGenerationLogger* logger = nullptr);
+    std::shared_ptr<Problem> provideProblem(
+      const std::string& solver_name,
+      SolverLogManager& solver_log_manager,
+      const Antares::Solver::WeeklyProblemId& problem_id) const;
     [[nodiscard]] std::vector<std::shared_ptr<Problem>> provideProblems(
       const std::string& solver_name,
       SolverLogManager& solver_log_manager) const override;
     const Antares::Solver::LpsFromAntares& antares_hebdo_problems;
 
 private:
+    ProblemGenerationLog::ProblemGenerationLogger* logger_;
     RenameUtils rename_utils_;
 };

--- a/tests/cpp/lp_namer/AntaresProblemToXpansionProblemTranslatorTest.cpp
+++ b/tests/cpp/lp_namer/AntaresProblemToXpansionProblemTranslatorTest.cpp
@@ -35,7 +35,9 @@ TEST(RenameWeekNames, HourWeek1)
     std::vector<std::string> vnames = {"vhour<1>"};
     std::vector<std::string> cnames = {"chour<1>"};
     RenameUtils rename_utils;
-    const auto& [variables, constraints] = rename_utils.rename_week_names(1, vnames, cnames);
+    auto result = rename_utils.rename_week_names(1, vnames, cnames, nullptr);
+    ASSERT_TRUE(result.has_value());
+    const auto& [variables, constraints] = *result;
     ASSERT_EQ(variables.at(0), std::string("vhour<1>"));
     ASSERT_EQ(constraints.at(0), std::string("chour<1>"));
 }
@@ -45,7 +47,9 @@ TEST(RenameWeekNames, HourWeek2)
     std::vector<std::string> vnames = {"hour<1>"};
     std::vector<std::string> cnames; // vide, comme dans HourWeek1
     RenameUtils rename_utils;
-    const auto& [variables, constraints] = rename_utils.rename_week_names(2, vnames, cnames);
+    auto result = rename_utils.rename_week_names(2, vnames, cnames, nullptr);
+    ASSERT_TRUE(result.has_value());
+    const auto& [variables, constraints] = *result;
     ASSERT_EQ(variables.at(0), std::string("hour<169>")); // 168 + 1
 }
 
@@ -54,7 +58,9 @@ TEST(RenameWeekNames, DayWeek3)
     std::vector<std::string> vnames = {"day<3>"};
     std::vector<std::string> cnames;
     RenameUtils rename_utils;
-    const auto& [variables, constraints] = rename_utils.rename_week_names(3, vnames, cnames);
+    auto result = rename_utils.rename_week_names(3, vnames, cnames, nullptr);
+    ASSERT_TRUE(result.has_value());
+    const auto& [variables, constraints] = *result;
     ASSERT_EQ(variables.at(0), std::string("day<17>")); // (3-1)*7 + 3 = 17
 }
 
@@ -63,7 +69,9 @@ TEST(RenameWeekNames, WeekTokenNormalized)
     std::vector<std::string> vnames = {"week<5>"};
     std::vector<std::string> cnames;
     RenameUtils rename_utils;
-    const auto& [variables, constraints] = rename_utils.rename_week_names(3, vnames, cnames);
+    auto result = rename_utils.rename_week_names(3, vnames, cnames, nullptr);
+    ASSERT_TRUE(result.has_value());
+    const auto& [variables, constraints] = *result;
     ASSERT_EQ(variables.at(0), std::string("week<2>")); // week normalisé à l'index 0
 }
 
@@ -72,7 +80,9 @@ TEST(RenameWeekNames, OnlyFirstOccurrenceReplaced)
     std::vector<std::string> vnames = {"hour<1>_hour<2>"};
     std::vector<std::string> cnames;
     RenameUtils rename_utils;
-    const auto& [variables, constraints] = rename_utils.rename_week_names(2, vnames, cnames);
+    auto result = rename_utils.rename_week_names(2, vnames, cnames, nullptr);
+    ASSERT_TRUE(result.has_value());
+    const auto& [variables, constraints] = *result;
     ASSERT_EQ(variables.at(0), std::string("hour<169>_hour<2>"));
 }
 
@@ -81,7 +91,9 @@ TEST(RenameWeekNames, MultipleNames)
     std::vector<std::string> vnames = {"hour<1>", "day<1>", "week<1>"};
     std::vector<std::string> cnames = {"hour<1>", "day<1>", "week<1>"};
     RenameUtils rename_utils;
-    const auto& [variables, constraints] = rename_utils.rename_week_names(2, vnames, cnames);
+    auto result = rename_utils.rename_week_names(2, vnames, cnames, nullptr);
+    ASSERT_TRUE(result.has_value());
+    const auto& [variables, constraints] = *result;
     ASSERT_EQ(variables.at(0), std::string("hour<169>"));
     ASSERT_EQ(variables.at(1), std::string("day<8>"));
     ASSERT_EQ(variables.at(2), std::string("week<1>"));
@@ -90,16 +102,18 @@ TEST(RenameWeekNames, MultipleNames)
     ASSERT_EQ(constraints.at(2), std::string("week<1>"));
 }
 
-TEST(RenameWeekNames, NoTokenThrows)
+TEST(RenameWeekNames, NoTokenReturnsNullopt)
 {
     std::vector<std::string> vnames = {"foo"};
     std::vector<std::string> cnames;
-    EXPECT_THROW(RenameUtils().rename_week_names(1, vnames, cnames), std::runtime_error);
+    auto result = RenameUtils().rename_week_names(1, vnames, cnames, nullptr);
+    EXPECT_FALSE(result.has_value());
 }
 
-TEST(RenameWeekNames, WeekZeroThrows)
+TEST(RenameWeekNames, WeekZeroReturnsNullopt)
 {
     std::vector<std::string> vnames = {"hour<1>"};
     std::vector<std::string> cnames;
-    EXPECT_THROW(RenameUtils().rename_week_names(0, vnames, cnames), std::invalid_argument);
+    auto result = RenameUtils().rename_week_names(0, vnames, cnames, nullptr);
+    EXPECT_FALSE(result.has_value());
 }


### PR DESCRIPTION
Before in release mode there was no error message then a segfault

Now we have an error message then still a segfault related to the logger, probably because it's not thread-safe
```
 Xpress banner :
FICO Xpress Solver 64bit v9.8.0 Oct 22 2025
(c) Copyright Fair Isaac Corporation 1983-2025. All rights reserved

Warning: Optimizer version: 46.01.01 (Antares-Xpansion use Xpress interface version 41).

[Problem Generation][INFO 21-01-2026 09:50:19] rename problems: false
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename variable/constraint 'NTCDirect::link<area1$$area2>::hour<0>' for week 1
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename week 1 in year 1
[Problem Generation][ERROR 21-01-2026 09:50:19] No problem for year 1, week 1[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename variable/constraint 'NTCDirect::link<area1$$area2>::hour<0>' for week 2
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename week 2 in year 1
[Problem Generation][ERROR 21-01-2026 09:50:19] No problem for year 1, week 2[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename variable/constraint 'NTCDirect::link<area1$$area2>::hour<0>' for week 27
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename variable/constraint 'NTCDirect::link<area1$$area2>::hour<0>' for week 3
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename week 3 in year 1
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename week 27 in year 2
[Problem Generation][ERROR 21-01-2026 09:50:19] No problem for year 1, week 3[Problem Generation][ERROR 21-01-2026 09:50:19] No problem for year 2, week 27[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename variable/constraint 'NTCDirect::link<area1$$area2>::hour<0>' for week 4
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename week 4 in year 1
free(): double free detected in tcache 2
[Problem Generation][ERROR 21-01-2026 09:50:19] Failed to rename variable/constraint 'NTCDirect::link<area1$$area2>::hour<0>' for week 14
Erreur de segmentation (core dumped)
```

Also, remove a few useless headers inclusions.