### PR TITLE
ci(release): update release action to use gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
-          prerelease: ${{ contains(github.ref, '-rc') }}
+        run: gh release create ${{ github.ref_name }} --prerelease=${{ contains(github.ref, '-rc') }} --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Replace softprops/action-gh-release with gh release command
Currently there is an issue where release fail.
https://github.com/softprops/action-gh-release/issues/704

Remove third party dependency