### PR TITLE
Adjust cut coefficient tolerance to weights

### DIFF
--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -565,8 +565,7 @@ std::shared_ptr<SubproblemWorker> BendersBase::makeSubproblemWorker(
                                               solver_log_manager_,
                                               _logger,
                                               _options.PROBLEMS_FORMAT,
-                                              benders_problem_provider.get(),
-                                              _options.CUT_COEFFICIENT_TOLERANCE);
+                                              benders_problem_provider.get());
 }
 
 void BendersBase::SetBasisForSubproblem(const std::string& name,
@@ -1098,8 +1097,7 @@ void BendersBase::AddSubproblem(const std::pair<std::string, VariableMap>& kvp)
       solver_log_manager_,
       _logger,
       _options.PROBLEMS_FORMAT,
-      benders_problem_provider.get(),
-      _options.CUT_COEFFICIENT_TOLERANCE);
+      benders_problem_provider.get());
 }
 
 void BendersBase::free_subproblems()

--- a/src/cpp/benders/benders_core/SubproblemWorker.cpp
+++ b/src/cpp/benders/benders_core/SubproblemWorker.cpp
@@ -19,9 +19,8 @@ SubproblemWorker::SubproblemWorker(const VariableMap& variable_map,
                                    const SolverLogManager& solver_log_manager,
                                    Logger logger,
                                    ProblemsFormat format,
-                                   IBendersProblemProvider* benders_problem_provider,
-                                   double cut_coefficient_tolerance):
-    Worker(variable_map, std::move(logger), cut_coefficient_tolerance)
+                                   IBendersProblemProvider* benders_problem_provider):
+    Worker(variable_map, std::move(logger))
 {
     init(solver_name, log_level, solver_log_manager, format, benders_problem_provider);
 
@@ -75,14 +74,6 @@ void SubproblemWorker::get_subgradient(Point& subgradient) const
     subgradient.clear();
     std::vector<double> ptr(_solver->get_ncols());
     solver_getlpreducedcost(_solver, ptr);
-
-    // If subgradients are numerically small, round to zero so that cuts generated later on are
-    // clean
-    // We only round the values for the candidates. relies on the assumption that they have
-    // successive ids in the problem
-    roundIfWithinTolerance(ptr,
-                           _id_to_name.begin()->first,
-                           _id_to_name.begin()->first + _id_to_name.size());
 
     for (const auto& kvp: _id_to_name)
     {

--- a/src/cpp/benders/benders_core/Worker.cpp
+++ b/src/cpp/benders/benders_core/Worker.cpp
@@ -181,23 +181,13 @@ std::shared_ptr<SolverAbstract> Worker::solver() const
     return _solver;
 }
 
-Worker::Worker(VariableMap variable_map, Logger logger, double cut_coefficient_tolerance):
+Worker::Worker(VariableMap variable_map, Logger logger):
     _name_to_id{std::move(variable_map)},
-    logger_{std::move(logger)},
-    cut_coefficient_tolerance_{cut_coefficient_tolerance}
+    logger_{std::move(logger)}
 {
 }
 
 void Worker::writeProb(const std::filesystem::path& out) const
 {
     solver_io_.write(_solver.get(), out);
-}
-
-void Worker::roundIfWithinTolerance(std::vector<double>& values, int first, int last) const
-{
-    std::transform(values.begin() + first,
-                   values.begin() + last,
-                   values.begin() + first,
-                   [this](double value)
-                   { return std::abs(value) < cut_coefficient_tolerance_ ? 0 : value; });
 }

--- a/src/cpp/benders/benders_core/WorkerMaster.cpp
+++ b/src/cpp/benders/benders_core/WorkerMaster.cpp
@@ -312,7 +312,8 @@ void WorkerMaster::addSubproblemCut(int i,
     std::vector<int> subproblem_ids = {i};
     define_matval_mclind_for_index(subproblem_ids, subgradient, matval, mclind);
 
-    // Round numerically small rhs ant coefficients to zero to get clean cuts and avoid numerical artifacts
+    // Round numerically small rhs ant coefficients to zero to get clean cuts and avoid numerical
+    // artifacts
     roundIfWithinTolerance(rowrhs, 0, rowrhs.size(), subproblem_ids);
     roundIfWithinTolerance(matval, 0, matval.size(), subproblem_ids);
 
@@ -524,7 +525,8 @@ void WorkerMaster::roundIfWithinTolerance(std::vector<double>& values,
                                           const std::vector<int>& subproblem_ids) const
 {
     double cut_coefficient_tolerance = 0.0;
-    for (int sb_id : subproblem_ids) {
+    for (int sb_id: subproblem_ids)
+    {
         cut_coefficient_tolerance += _subproblem_tolerance.find(sb_id)->second;
     }
 
@@ -533,8 +535,5 @@ void WorkerMaster::roundIfWithinTolerance(std::vector<double>& values,
     std::transform(values.begin() + first,
                    values.begin() + last,
                    values.begin() + first,
-                   [tolerance](double value)
-                   {
-                       return std::abs(value) < tolerance ? 0.0 : value;
-                   });
+                   [tolerance](double value) { return std::abs(value) < tolerance ? 0.0 : value; });
 }

--- a/src/cpp/benders/benders_core/WorkerMaster.cpp
+++ b/src/cpp/benders/benders_core/WorkerMaster.cpp
@@ -24,11 +24,12 @@ WorkerMaster::WorkerMaster(const VariableMap& variable_map,
                            ProblemsFormat format,
                            IBendersProblemProvider* benders_problem_provider,
                            double master_solution_tolerance,
-                           double cut_coefficient_tolerance):
-    Worker(variable_map, std::move(logger), cut_coefficient_tolerance),
+                           const std::map<int, double>& subproblem_cut_coefficient_tolerance):
+    Worker(variable_map, std::move(logger)),
     subproblems_count{subproblems_count},
     _mps_has_alpha{mps_has_alpha},
-    _master_solution_tolerance{master_solution_tolerance}
+    _master_solution_tolerance{master_solution_tolerance},
+    _subproblem_tolerance{std::move(subproblem_cut_coefficient_tolerance)}
 {
     _is_master = true;
 
@@ -311,11 +312,9 @@ void WorkerMaster::addSubproblemCut(int i,
     std::vector<int> subproblem_ids = {i};
     define_matval_mclind_for_index(subproblem_ids, subgradient, matval, mclind);
 
-    // Round numerically small rhs to zero to get clean cuts and avoid numerical artifacts
-    // Cuts coefficients (obtained from subgradient) have already been rounded in
-    // SubproblemWorker::get_subgradient as it is best to round it as soon as possible (because
-    // subgradient information is also used as is to compute cut values : cf. compute_cut_val())
-    roundIfWithinTolerance(rowrhs, 0, rowrhs.size());
+    // Round numerically small rhs ant coefficients to zero to get clean cuts and avoid numerical artifacts
+    roundIfWithinTolerance(rowrhs, 0, rowrhs.size(), subproblem_ids);
+    roundIfWithinTolerance(matval, 0, matval.size(), subproblem_ids);
 
     solver_addrows(*_solver, rowtype, rowrhs, {}, mstart, mclind, matval);
 }
@@ -346,7 +345,9 @@ void WorkerMaster::addGroupSubproblemCut(std::vector<int> subproblem_ids,
 
     define_matval_mclind_for_index(subproblem_ids, s, matval, mclind);
 
-    roundIfWithinTolerance(rowrhs, 0, rowrhs.size());
+    // Round rhs and coefficients of the cut to clean it
+    roundIfWithinTolerance(rowrhs, 0, rowrhs.size(), subproblem_ids);
+    roundIfWithinTolerance(matval, 0, matval.size(), subproblem_ids);
 
     solver_addrows(*_solver, rowtype, rowrhs, {}, mstart, mclind, matval);
 }
@@ -515,4 +516,25 @@ void WorkerMaster::ActivateIntegrityConstraints() const
 {
     std::vector<char> col_types(_id_int_vars.size(), 'I');
     _solver->chg_col_type(_id_int_vars, col_types);
+}
+
+void WorkerMaster::roundIfWithinTolerance(std::vector<double>& values,
+                                          int first,
+                                          int last,
+                                          const std::vector<int>& subproblem_ids) const
+{
+    double cut_coefficient_tolerance = 0.0;
+    for (int sb_id : subproblem_ids) {
+        cut_coefficient_tolerance += _subproblem_tolerance.find(sb_id)->second;
+    }
+
+    const double tolerance = cut_coefficient_tolerance;
+
+    std::transform(values.begin() + first,
+                   values.begin() + last,
+                   values.begin() + first,
+                   [tolerance](double value)
+                   {
+                       return std::abs(value) < tolerance ? 0.0 : value;
+                   });
 }

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
@@ -23,8 +23,7 @@ public:
                      const SolverLogManager& solver_log_manager,
                      Logger logger,
                      ProblemsFormat format,
-                     IBendersProblemProvider* benders_problem_provider,
-                     double cut_coefficient_tolerance);
+                     IBendersProblemProvider* benders_problem_provider);
     virtual ~SubproblemWorker() = default;
     std::vector<double> get_solution() const;
 

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
@@ -18,7 +18,7 @@
 class Worker
 {
 public:
-    Worker(VariableMap variable_map, Logger logger, double cut_coefficient_tolerance);
+    Worker(VariableMap variable_map, Logger logger);
     void init(const std::string& solver_name,
               int log_level,
               const SolverLogManager& solver_log_manager,
@@ -73,8 +73,4 @@ public:
 private:
     SolverIO solver_io_;
     void writeProb(const std::filesystem::path& out) const;
-    double cut_coefficient_tolerance_;
-
-protected:
-    void roundIfWithinTolerance(std::vector<double>& values, int first, int last) const;
 };

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/WorkerMaster.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/WorkerMaster.h
@@ -65,7 +65,7 @@ private:
     int subproblems_count;
     bool _mps_has_alpha = false;
     double _master_solution_tolerance;
-    std::map<int, double> _subproblem_tolerance;  
+    std::map<int, double> _subproblem_tolerance;
     void define_matval_mclind(const Point& s,
                               std::vector<double>& matval,
                               std::vector<int>& mclind) const;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/WorkerMaster.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/WorkerMaster.h
@@ -24,7 +24,7 @@ public:
                  ProblemsFormat format,
                  IBendersProblemProvider* benders_problem_provider,
                  double master_solution_tolerance,
-                 double cut_coefficient_tolerance);
+                 const std::map<int, double>& subproblem_cut_coefficient_tolerance);
     ~WorkerMaster() override = default;
     std::vector<int> _id_master_only_vars;
 
@@ -65,6 +65,7 @@ private:
     int subproblems_count;
     bool _mps_has_alpha = false;
     double _master_solution_tolerance;
+    std::map<int, double> _subproblem_tolerance;  
     void define_matval_mclind(const Point& s,
                               std::vector<double>& matval,
                               std::vector<int>& mclind) const;
@@ -90,6 +91,10 @@ private:
 
 protected:
     void _set_master_only_var_ids();
+    void roundIfWithinTolerance(std::vector<double>& values,
+                                int first,
+                                int last,
+                                const std::vector<int>& subproblem_ids) const;
 
 public:
     // Used only for testing purposes

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -144,6 +144,10 @@ void BendersMpi::BuildMasterProblem()
     {
         std::shared_ptr<IBendersProblemProvider>
           benders_problem_provider = std::make_shared<BendersProblemFromFile>(get_master_path());
+        std::map<int, double> subproblem_cut_coefficient_tolerance{};
+        for (int i=0; i<_data.nsubproblem; i++){
+            subproblem_cut_coefficient_tolerance[i] = Options().CUT_COEFFICIENT_TOLERANCE;
+        }
         reset_master<WorkerMaster>(master_variable_map_,
                                    get_solver_name(),
                                    get_log_level(),
@@ -154,7 +158,7 @@ void BendersMpi::BuildMasterProblem()
                                    Options().PROBLEMS_FORMAT,
                                    benders_problem_provider.get(),
                                    Options().MASTER_SOLUTION_TOLERANCE,
-                                   Options().CUT_COEFFICIENT_TOLERANCE);
+                                   subproblem_cut_coefficient_tolerance);
     }
 }
 

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -145,7 +145,8 @@ void BendersMpi::BuildMasterProblem()
         std::shared_ptr<IBendersProblemProvider>
           benders_problem_provider = std::make_shared<BendersProblemFromFile>(get_master_path());
         std::map<int, double> subproblem_cut_coefficient_tolerance{};
-        for (int i=0; i<_data.nsubproblem; i++){
+        for (int i = 0; i < _data.nsubproblem; i++)
+        {
             subproblem_cut_coefficient_tolerance[i] = Options().CUT_COEFFICIENT_TOLERANCE;
         }
         reset_master<WorkerMaster>(master_variable_map_,

--- a/src/cpp/benders/benders_sequential/BendersSequential.cpp
+++ b/src/cpp/benders/benders_sequential/BendersSequential.cpp
@@ -30,6 +30,10 @@ void BendersSequential::InitializeProblems()
     MatchProblemToId();
     std::shared_ptr<IBendersProblemProvider>
       benders_problem_provider = std::make_shared<BendersProblemFromFile>(get_master_path());
+    std::map<int, double> subproblem_cut_coefficient_tolerance{};
+    for (int i=0; i<_data.nsubproblem; i++){
+        subproblem_cut_coefficient_tolerance[i] = Options().CUT_COEFFICIENT_TOLERANCE;
+    }
     reset_master<WorkerMaster>(master_variable_map_,
                                get_solver_name(),
                                get_log_level(),
@@ -40,7 +44,7 @@ void BendersSequential::InitializeProblems()
                                Options().PROBLEMS_FORMAT,
                                benders_problem_provider.get(),
                                Options().MASTER_SOLUTION_TOLERANCE,
-                               Options().CUT_COEFFICIENT_TOLERANCE);
+                               subproblem_cut_coefficient_tolerance);
     for (const auto& problem: coupling_map_)
     {
         const auto subProblemFilePath = GetSubproblemPath(problem.first);

--- a/src/cpp/benders/benders_sequential/BendersSequential.cpp
+++ b/src/cpp/benders/benders_sequential/BendersSequential.cpp
@@ -31,7 +31,8 @@ void BendersSequential::InitializeProblems()
     std::shared_ptr<IBendersProblemProvider>
       benders_problem_provider = std::make_shared<BendersProblemFromFile>(get_master_path());
     std::map<int, double> subproblem_cut_coefficient_tolerance{};
-    for (int i=0; i<_data.nsubproblem; i++){
+    for (int i = 0; i < _data.nsubproblem; i++)
+    {
         subproblem_cut_coefficient_tolerance[i] = Options().CUT_COEFFICIENT_TOLERANCE;
     }
     reset_master<WorkerMaster>(master_variable_map_,

--- a/tests/cpp/benders/SubproblemWorkerTest.cpp
+++ b/tests/cpp/benders/SubproblemWorkerTest.cpp
@@ -68,7 +68,7 @@ public:
 protected:
     Point subgradient;
 
-    std::shared_ptr<SubproblemWorker> init_subproblem_worker(double cut_coefficient_tolerance) const
+    std::shared_ptr<SubproblemWorker> init_subproblem_worker() const
     {
         auto test_solver = std::make_shared<NOOPSolverForSubproblemWorker>();
         EmptyLogManager solver_log_manager;
@@ -81,8 +81,7 @@ protected:
           solver_log_manager,
           std::make_shared<xpansion::logger::Master>(),
           ProblemsFormat::MPS_FILE,
-          problem_provider.get(),
-          cut_coefficient_tolerance);
+          problem_provider.get());
         subproblem->_solver = test_solver;
         subproblem->_id_to_name = {{2, "var1"}, {3, "var2"}, {4, "var3"}};
         return subproblem;
@@ -97,8 +96,7 @@ TEST_F(SubproblemWorkerTest, RoundSubgradientIfWithinTolerance)
     std::vector<double> lbs;
     std::vector<double> ubs;
 
-    double cut_coefficient_tolerance = 0.1;
-    auto subproblem = init_subproblem_worker(cut_coefficient_tolerance);
+    auto subproblem = init_subproblem_worker();
     std::dynamic_pointer_cast<NOOPSolverForSubproblemWorker>(subproblem->_solver)
       ->setSolverBehavior(reduced_cots, col_types, lbs, ubs);
     subproblem->get_subgradient(subgradient);

--- a/tests/cpp/benders/WorkerMasterTest.cpp
+++ b/tests/cpp/benders/WorkerMasterTest.cpp
@@ -77,6 +77,8 @@ protected:
         auto test_solver = std::make_shared<NOOPSolverForWorkerMaster>();
         EmptyLogManager solver_log_manager;
         auto problem_provider = std::make_shared<NOOPBendersProblemProvider>();
+        std::map<int, double> subproblem_cut_coefficient_tolerance{};
+        subproblem_cut_coefficient_tolerance[0] = cut_coefficient_tolerance;
         auto master = std::make_shared<WorkerMaster>(VariableMap{},
                                                      "COIN",
                                                      0,
@@ -87,7 +89,7 @@ protected:
                                                      ProblemsFormat::MPS_FILE,
                                                      problem_provider.get(),
                                                      master_solution_tolerance,
-                                                     cut_coefficient_tolerance);
+                                                     subproblem_cut_coefficient_tolerance);
         master->_solver = test_solver;
         master->_id_to_name = {{0, "var1"}, {1, "var2"}, {2, "var3"}};
         master->set_id_alpha(3);


### PR DESCRIPTION
Cut coefficient tolerance will be used to round coefficients and rhs of cuts. The tolerance will depend on the weight of the subproblem. 