### PR TITLE
refactor(benders): move OuterLoopBenders to outer_loop module

### DIFF
--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/ICommunicationStrategy.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/ICommunicationStrategy.h
@@ -49,6 +49,10 @@ public:
     /// Synchronization barrier across all processes (no-op for sequential)
     virtual void Barrier() const = 0;
 
+    /// Broadcast a bool value from the master (rank 0) to all processes.
+    /// For sequential execution this is a no-op (value is already available).
+    virtual void Broadcast(bool& value) const = 0;
+
     /// Whether subproblems should be parallelized locally using TBB.
     /// Returns true for sequential (local parallelism), false for MPI
     /// (distribution handles parallelism across ranks).

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SequentialCommunicationStrategy.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SequentialCommunicationStrategy.h
@@ -27,6 +27,11 @@ public:
         // No-op for single process
     }
 
+    void Broadcast(bool& /*value*/) const override
+    {
+        // No-op for single process: value is already set on the only process
+    }
+
     [[nodiscard]] bool ShouldParallelize() const override
     {
         return true;

--- a/src/cpp/benders/benders_mpi/CMakeLists.txt
+++ b/src/cpp/benders/benders_mpi/CMakeLists.txt
@@ -21,11 +21,9 @@ add_library(benders_mpi_core)
 
 target_sources(benders_mpi_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/BendersMPI.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/OuterLoopBenders.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/common_mpi.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_mpi/BendersMPI.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_mpi/MpiCommunicationStrategy.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_mpi/OuterLoopBenders.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_mpi/common_mpi.h
 
 )

--- a/src/cpp/benders/benders_mpi/include/antares-xpansion/benders/benders_mpi/MpiCommunicationStrategy.h
+++ b/src/cpp/benders/benders_mpi/include/antares-xpansion/benders/benders_mpi/MpiCommunicationStrategy.h
@@ -34,6 +34,11 @@ public:
         world_.barrier();
     }
 
+    void Broadcast(bool& value) const override
+    {
+        mpi::broadcast(world_, value, 0);
+    }
+
     [[nodiscard]] bool ShouldParallelize() const override
     {
         return false;

--- a/src/cpp/benders/factories/BendersApp.cpp
+++ b/src/cpp/benders/factories/BendersApp.cpp
@@ -9,7 +9,8 @@
 #include "antares-xpansion/benders/benders_core/CouplingMapGenerator.h"
 #include "antares-xpansion/benders/benders_core/MasterUpdate.h"
 #include "antares-xpansion/benders/benders_core/StartUp.h"
-#include "antares-xpansion/benders/benders_mpi/OuterLoopBenders.h"
+#include "antares-xpansion/benders/benders_mpi/MpiCommunicationStrategy.h"
+#include "antares-xpansion/benders/outer_loop/OuterLoopBenders.h"
 #include "antares-xpansion/benders/factories/LoggerFactories.h"
 #include "antares-xpansion/benders/factories/WriterFactories.h"
 #include "antares-xpansion/core/ProblemFormatStream.h"
@@ -184,11 +185,12 @@ int BendersApp::RunExternalLoop()
         std::shared_ptr<Outerloop::ICutsManager>
           cuts_manager = std::make_shared<Outerloop::CutsManagerRunTime>();
 
-        Outerloop::OuterLoopBenders ext_loop(outer_loop_inputs.Criteria(),
-                                             master_updater,
-                                             cuts_manager,
-                                             benders_,
-                                             *pworld_);
+        Outerloop::OuterLoopBenders ext_loop(
+          outer_loop_inputs.Criteria(),
+          master_updater,
+          cuts_manager,
+          benders_,
+          std::make_shared<MpiCommunicationStrategy>(*pworld_));
         StartMessage();
         ext_loop.Run();
         EndMessage(ext_loop.Runtime());

--- a/src/cpp/benders/outer_loop/CMakeLists.txt
+++ b/src/cpp/benders/outer_loop/CMakeLists.txt
@@ -21,9 +21,11 @@ endif ()
 add_library(outer_loop_lib)
 target_sources(outer_loop_lib PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/OuterLoop.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/OuterLoopBenders.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/OuterLoopBiLevel.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/outer_loop/IMasterUpdate.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/outer_loop/OuterLoop.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/outer_loop/OuterLoopBenders.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/outer_loop/OuterLoopBiLevel.h
 
 )

--- a/src/cpp/benders/outer_loop/OuterLoopBenders.cpp
+++ b/src/cpp/benders/outer_loop/OuterLoopBenders.cpp
@@ -1,4 +1,4 @@
-#include "antares-xpansion/benders/benders_mpi/OuterLoopBenders.h"
+#include "antares-xpansion/benders/outer_loop/OuterLoopBenders.h"
 
 namespace Outerloop
 {
@@ -8,11 +8,11 @@ OuterLoopBenders::OuterLoopBenders(
   std::shared_ptr<IMasterUpdate> master_updater,
   std::shared_ptr<ICutsManager> cuts_manager,
   pBendersBase benders,
-  mpi::communicator& world):
+  std::shared_ptr<ICommunicationStrategy> communication_strategy):
     master_updater_(std::move(master_updater)),
     cuts_manager_(std::move(cuts_manager)),
     benders_(std::move(benders)),
-    world_(world),
+    communication_strategy_(std::move(communication_strategy)),
     outer_loop_biLevel_(outer_loop_data)
 {
     loggers_.AddLogger(benders_->_logger);
@@ -68,20 +68,20 @@ double OuterLoopBenders::OuterLoopLambdaMax() const
 bool OuterLoopBenders::UpdateMaster()
 {
     bool stop_update_master = false;
-    if (world_.rank() == 0)
+    if (communication_strategy_->IsMaster())
     {
         stop_update_master = master_updater_->Update(outer_loop_biLevel_.LambdaMin(),
                                                      outer_loop_biLevel_.LambdaMax());
     }
 
-    mpi::broadcast(world_, stop_update_master, 0);
+    communication_strategy_->Broadcast(stop_update_master);
     return stop_update_master;
 }
 
 void OuterLoopBenders::OuterLoopCheckFeasibility()
 {
     std::vector<double> obj_coeff;
-    if (world_.rank() == 0)
+    if (communication_strategy_->IsMaster())
     {
         obj_coeff = benders_->MasterObjectiveFunctionCoeffs();
 
@@ -90,7 +90,7 @@ void OuterLoopBenders::OuterLoopCheckFeasibility()
     }
 
     benders_->launch();
-    if (world_.rank() == 0)
+    if (communication_strategy_->IsMaster())
     {
         benders_->SetMasterObjectiveFunction(obj_coeff.data(), 0, obj_coeff.size() - 1);
         benders_->UpdateOverallCosts();
@@ -118,8 +118,8 @@ void OuterLoopBenders::InitExternalValues(bool is_bilevel_check_all, double lamb
 
 void OuterLoopBenders::OuterLoopBilevelChecks()
 {
-    if (world_.rank() == 0 && benders_->Options().EXTERNAL_LOOP_OPTIONS.DO_OUTER_LOOP
-        && !is_bilevel_check_all_)
+    if (communication_strategy_->IsMaster()
+        && benders_->Options().EXTERNAL_LOOP_OPTIONS.DO_OUTER_LOOP && !is_bilevel_check_all_)
     {
         const WorkerMasterData& workerMasterData = benders_->BestIterationWorkerMaster();
         const auto& invest_cost = workerMasterData._invest_cost;

--- a/src/cpp/benders/outer_loop/include/antares-xpansion/benders/outer_loop/OuterLoopBenders.h
+++ b/src/cpp/benders/outer_loop/include/antares-xpansion/benders/outer_loop/OuterLoopBenders.h
@@ -2,10 +2,10 @@
 #include "antares-xpansion/benders/benders_core/BendersBase.h"
 #include "antares-xpansion/benders/benders_core/CriterionComputation.h"
 #include "antares-xpansion/benders/benders_core/CutsManagement.h"
+#include "antares-xpansion/benders/benders_core/ICommunicationStrategy.h"
 #include "antares-xpansion/benders/outer_loop/IMasterUpdate.h"
 #include "antares-xpansion/benders/outer_loop/OuterLoop.h"
 #include "antares-xpansion/benders/outer_loop/OuterLoopBiLevel.h"
-#include "common_mpi.h"
 
 namespace Outerloop
 {
@@ -23,7 +23,7 @@ public:
       std::shared_ptr<IMasterUpdate> master_updater,
       std::shared_ptr<ICutsManager> cuts_manager,
       pBendersBase benders,
-      mpi::communicator& world);
+      std::shared_ptr<ICommunicationStrategy> communication_strategy);
 
     void Run() override;
 
@@ -43,7 +43,7 @@ private:
     std::shared_ptr<ICutsManager> cuts_manager_;
     pBendersBase benders_;
     BendersLoggerBase loggers_;
-    mpi::communicator& world_;
+    std::shared_ptr<ICommunicationStrategy> communication_strategy_;
     bool is_bilevel_check_all_ = false;
     void InitExternalValues(bool is_bilevel_check_all, double lambda);
     OuterLoopBiLevel outer_loop_biLevel_;

--- a/tests/cpp/outer_loop/outer_loop_test.cpp
+++ b/tests/cpp/outer_loop/outer_loop_test.cpp
@@ -6,7 +6,8 @@
 #include "antares-xpansion/benders/benders_core/CriterionInputDataReader.h"
 #include "antares-xpansion/benders/benders_core/MasterUpdate.h"
 #include "antares-xpansion/benders/benders_core/VariablesGroup.h"
-#include "antares-xpansion/benders/benders_mpi/OuterLoopBenders.h"
+#include "antares-xpansion/benders/benders_mpi/MpiCommunicationStrategy.h"
+#include "antares-xpansion/benders/outer_loop/OuterLoopBenders.h"
 #include "antares-xpansion/benders/factories/LoggerFactories.h"
 #include "antares-xpansion/benders/factories/WriterFactories.h"
 #include "antares-xpansion/benders/outer_loop/OuterLoopBiLevel.h"
@@ -157,7 +158,7 @@ TEST_P(MasterUpdateBaseTest, ConstraintIsAddedBendersMPI)
                                          master_updater,
                                          cut_manager,
                                          benders,
-                                         *pworld);
+                                         std::make_shared<MpiCommunicationStrategy>(*pworld));
     out_loop.OuterLoopCheckFeasibility();
 
     auto num_constraints_master_before = benders->MasterGetnrows();


### PR DESCRIPTION
## Summary

- Moves `OuterLoopBenders` from `benders_mpi/` to `outer_loop/` where its base class `OuterLoop` resides, fixing a module boundary violation
- Replaces direct `mpi::communicator&` dependency with `std::shared_ptr<ICommunicationStrategy>` injection — uses `IsMaster()` and `Broadcast(bool&)` 
- Adds `Broadcast(bool&)` pure virtual to `ICommunicationStrategy` with no-op in `SequentialCommunicationStrategy` and `mpi::broadcast` in `MpiCommunicationStrategy`
- `outer_loop_lib` no longer carries a Boost.MPI/MPI dependency; `benders_mpi_core` now only contains `MpiCommunicationStrategy` + `common_mpi`
- Factory (`BendersApp.cpp`) updated to use new include path and pass `make_shared<MpiCommunicationStrategy>(*world_)`

## Test plan

- [ ] Build: `cmake --build . --target benders_core benders_mpi_core outer_loop_lib factories`
- [ ] Unit tests: `ctest -L unit --output-on-failure`
- [ ] Verify no stale refs: `grep -rn "benders_mpi/OuterLoopBenders" src/` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)