### PR TITLE
ANT-4339 - ci: run ctest in parallel to detect concurrency issues

### DIFF
--- a/.github/workflows/build_oracle8.yml
+++ b/.github/workflows/build_oracle8.yml
@@ -156,7 +156,7 @@ jobs:
         run: |
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin/:$PATH
           cd _build
-          ctest -C Release --output-on-failure -L "unit|benders|lpnamer|medium"
+          ctest -C Release --output-on-failure -L "unit|benders|lpnamer|medium" -j$(nproc)
 
       - name: Cache vcpkg binary dir
         if: always()

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -142,7 +142,7 @@ jobs:
         run: |
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
           cd _build
-          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer"
+          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer" -j$(nproc)
 
       - name: Cache vcpkg binary dir
         if: always()

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -137,7 +137,10 @@ jobs:
         uses: ./.github/workflows/cucumber-tests
         with:
           mpi_path: ${{ github.workspace }}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin
-
+      - name: Check CPU info
+        run: |
+          nproc
+          lscpu | grep "CPU(s)"
       - name: Test
         run: |
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           set PATH=%PATH%;C:\Program Files\Microsoft MPI\Bin
           cd _build
-          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer"
+          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer" -j%NUMBER_OF_PROCESSORS%
 
       ##############
       - name: install

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin:$PATH
           cd $GITHUB_WORKSPACE/_build
-          ctest -C Release --output-on-failure
+          ctest -C Release --output-on-failure -j$(nproc)
 
       - name: Compile coverage reports
         run: |

--- a/.github/workflows/ubuntu-system-deps-build.yml
+++ b/.github/workflows/ubuntu-system-deps-build.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           export PATH=${GITHUB_WORKSPACE}/_build/vcpkg_installed/x64-linux-release/tools/openmpi/bin/:$PATH
           cd _build
-          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer"
+          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer" -j$(nproc)
 
       - id: create-single-file
         name: Single file .tar.gz creation

--- a/.github/workflows/windows-vcpkg-deps-build.yml
+++ b/.github/workflows/windows-vcpkg-deps-build.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           set PATH=%PATH%;C:\Program Files\Microsoft MPI\Bin\
           cd _build
-          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer"
+          ctest -C Release --output-on-failure -L "medium|unit|benders|lpnamer" -j%NUMBER_OF_PROCESSORS%
 
       - name: Installer .zip creation
         run: |

--- a/docker/centos7-build
+++ b/docker/centos7-build
@@ -134,7 +134,7 @@ RUN \
       behave --tags "not @flaky and not @noci"  cucumber/features --no-capture --no-capture-stderr --format pretty && \
       popd && \
       cd _build && \
-      ctest -C Release --output-on-failure -L "unit|benders|lpnamer|medium"
+      ctest -C Release --output-on-failure -L "unit|benders|lpnamer|medium" -j$(nproc)
 
 # Install
 RUN cd _build && \


### PR DESCRIPTION
**Run CTest in parallel across all CI workflows**

Currently, CTest runs sequentially in all CI pipelines (Ubuntu, Oracle 8, Windows, CentOS 7 Docker, Sonarcloud, and the system/vcpkg deps builds). 

This makes it harder to catch concurrency-related bugs that only surface when tests run in parallel.
This change adds the -j flag to every ctest invocation:

- -j$(nproc) on Linux (Ubuntu, Oracle 8, CentOS 7 Docker, Sonarcloud, system deps build)
- -j%NUMBER_OF_PROCESSORS% on Windows (main build and vcpkg deps build)