### PR TITLE
Memory optimization for Benders algorithm 

### DIFF
--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -25,6 +25,8 @@ BendersBase::BendersBase(BendersBaseOptions options,
     _csv_file_path(std::filesystem::path(_options.OUTPUTROOT) / (_options.CSV_NAME + ".csv")),
     communication_strategy_(std::move(communication_strategy))
 {
+
+    std::cout<<"entered in benders base constructor "<<std::endl ; 
 }
 
 bool BendersBase::shouldParallelize() const
@@ -127,7 +129,7 @@ void BendersBase::PrintCurrentIterationCsv()
  *
  *  \param name : problem name
  *
- *  \param subproblem_index : problem id
+ *  \param subproblem_index : problem idto run sph simulation i need a clus
  */
 void print_cut_csv(std::ostream& stream,
                    const PlainData::SubProblemData& subproblem_data,

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -482,9 +482,9 @@ void BendersBase::GetSubproblemCut(SubProblemDataMap& subproblem_data_map)
     {
         GetSubproblemCutCache(subproblem_data_map);
     }
-    else if (Options().MEMORY_OPTIMIZATION) 
+    else if (Options().MEMORY_OPTIMIZATION)
     {
-        GetMemOptimCuts(subproblem_data_map) ; 
+        GetMemOptimCuts(subproblem_data_map);
     }
     else
     {
@@ -492,10 +492,9 @@ void BendersBase::GetSubproblemCut(SubProblemDataMap& subproblem_data_map)
     }
 }
 
-
-void BendersBase::set_rank(int rank)  
+void BendersBase::set_rank(int rank)
 {
-    rank_ = rank ; 
+    rank_ = rank;
 }
 
 void BendersBase::GetSubproblemCutFast(SubProblemDataMap& subproblem_data_map)
@@ -629,24 +628,25 @@ void BendersBase::GetSubproblemCutCache(SubProblemDataMap& subproblem_data_map)
       shouldParallelize());
 }
 
-
 void BendersBase::GetMemOptimCuts(SubProblemDataMap& subproblem_data_map)
 {
-    auto subs_on_proc = subs_per_procs_mem_optim_[rank_] ; 
-        
-    for (auto& sub : subs_on_proc) 
+    auto subs_on_proc = subs_per_procs_mem_optim_[rank_];
+
+    for (auto& sub: subs_on_proc)
     {
-        auto variable_map  = coupling_map_[sub] ;
-        double slave_weights = SubproblemWeight(memoptim_subprob_builder_->get_sub_number(),sub ) ;  
-        auto subproblem_worker = memoptim_subprob_builder_->create_sub_solver_abstract(sub,variable_map,_options.CUT_COEFFICIENT_TOLERANCE,slave_weights) ;
+        auto variable_map = coupling_map_[sub];
+        double slave_weights = SubproblemWeight(memoptim_subprob_builder_->get_sub_number(), sub);
+        auto subproblem_worker = memoptim_subprob_builder_->create_sub_solver_abstract(
+          sub,
+          variable_map,
+          _options.CUT_COEFFICIENT_TOLERANCE,
+          slave_weights);
         PlainData::SubProblemData subproblem_data;
         SolveSubproblem(subproblem_data, sub, subproblem_worker);
 
         subproblem_data_map[sub] = subproblem_data;
-
     }
-            
-}  
+}
 
 void BendersBase::SolveSubproblem(PlainData::SubProblemData& subproblem_data,
                                   const std::string& name,

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -482,10 +482,20 @@ void BendersBase::GetSubproblemCut(SubProblemDataMap& subproblem_data_map)
     {
         GetSubproblemCutCache(subproblem_data_map);
     }
+    else if (Options().MEMORY_OPTIMIZATION) 
+    {
+        GetMemOptimCuts(subproblem_data_map) ; 
+    }
     else
     {
         GetSubproblemCutFast(subproblem_data_map);
     }
+}
+
+
+void BendersBase::set_rank(int rank)  
+{
+    rank_ = rank ; 
 }
 
 void BendersBase::GetSubproblemCutFast(SubProblemDataMap& subproblem_data_map)
@@ -618,6 +628,25 @@ void BendersBase::GetSubproblemCutCache(SubProblemDataMap& subproblem_data_map)
       },
       shouldParallelize());
 }
+
+
+void BendersBase::GetMemOptimCuts(SubProblemDataMap& subproblem_data_map)
+{
+    auto subs_on_proc = subs_per_procs_mem_optim_[rank_] ; 
+        
+    for (auto& sub : subs_on_proc) 
+    {
+        auto variable_map  = coupling_map_[sub] ;
+        double slave_weights = SubproblemWeight(memoptim_subprob_builder_->get_sub_number(),sub ) ;  
+        auto subproblem_worker = memoptim_subprob_builder_->create_sub_solver_abstract(sub,variable_map,_options.CUT_COEFFICIENT_TOLERANCE,slave_weights) ;
+        PlainData::SubProblemData subproblem_data;
+        SolveSubproblem(subproblem_data, sub, subproblem_worker);
+
+        subproblem_data_map[sub] = subproblem_data;
+
+    }
+            
+}  
 
 void BendersBase::SolveSubproblem(PlainData::SubProblemData& subproblem_data,
                                   const std::string& name,

--- a/src/cpp/benders/benders_core/CMakeLists.txt
+++ b/src/cpp/benders/benders_core/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(benders_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/VariablesGroup.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/CouplingMapGenerator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ConstraintsFileReader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/MemOptim_subproblem_builder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/SubproblemConstraintsManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/BendersBase.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/BendersMathLogger.h
@@ -52,6 +53,7 @@ target_sources(benders_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/VariablesGroup.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/Worker.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/WorkerMaster.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/common.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/ConstraintsFileReader.h

--- a/src/cpp/benders/benders_core/CMakeLists.txt
+++ b/src/cpp/benders/benders_core/CMakeLists.txt
@@ -31,6 +31,7 @@ target_sources(benders_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/VariablesGroup.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/CouplingMapGenerator.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/ConstraintsFileReader.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/ConstraintsFileReaderMemOptim.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/MemOptim_subproblem_builder.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/SubproblemConstraintsManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -57,6 +58,7 @@ target_sources(benders_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/WorkerMaster.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/common.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/ConstraintsFileReader.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/ConstraintsFileReaderMemOptim.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/SubproblemConstraintsManager.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/ICommunicationStrategy.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/SequentialCommunicationStrategy.h

--- a/src/cpp/benders/benders_core/ConstraintsFileReader.cpp
+++ b/src/cpp/benders/benders_core/ConstraintsFileReader.cpp
@@ -71,3 +71,5 @@ SolverRepresentedRows ConstraintsFileReader::get_row(const std::string& name)
 
     return result;
 }
+
+

--- a/src/cpp/benders/benders_core/ConstraintsFileReaderMemOptim.cpp
+++ b/src/cpp/benders/benders_core/ConstraintsFileReaderMemOptim.cpp
@@ -1,0 +1,218 @@
+#include "antares-xpansion/benders/benders_core/ConstraintsFileReaderMemOptim.h" 
+
+
+ConstraintsFileReaderMemOptim::ConstraintsFileReaderMemOptim(const std::filesystem::path& inputRoot,
+                                          const std::string& solver_name,
+                                          const SolverLogManager& solver_log_manager,
+                                          Logger& logger,
+                                          int log_level,
+                                          ProblemsFormat format)
+{
+    build_skeleton(solver_name,
+                   solver_log_manager,
+                    log_level,
+                    format) ;
+
+
+    read_coef(); 
+    read_coef_cols();
+    read_coef_rows();
+    read_obj_coef();
+    read_obj_cols();
+    read_rhs();
+    read_rhs_rows();
+    build_skeleton(solver_name,solver_log_manager,log_level,format) ; 
+} 
+
+
+
+void ConstraintsFileReaderMemOptim::read_coef()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto coef_csv_path = inputRoot_ / "constraints" / "coef.csv";
+    std::ifstream coef_csv_stream(coef_csv_path);
+    if (coef_csv_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(coef_csv_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            std::vector<std::string> tokens(tok.begin(), tok.end());
+            std::string key = tokens[0];
+            std::vector<double> values_double;
+            if (tokens.size() > 1)
+            {
+                values_double.resize(tokens.size() - 1);
+                std::transform(tokens.begin() + 1,
+                               tokens.end(),
+                               values_double.begin(),
+                               [](const std::string& s) { return std::stod(s); });
+            }
+            coeffs_[key] = values_double;
+        }
+    }
+}
+
+void ConstraintsFileReaderMemOptim::read_coef_cols()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto coef_cols_path = inputRoot_ / "constraints" / "coef_cols.csv";
+    std::ifstream coef_cols_stream(coef_cols_path);
+    if (coef_cols_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(coef_cols_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            coef_cols_.assign(tok.begin(), tok.end());
+        }
+    }
+}
+
+void ConstraintsFileReaderMemOptim::read_coef_rows()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto coef_rows_path = inputRoot_ / "constraints" / "coef_rows.csv";
+    std::ifstream coef_rows_stream(coef_rows_path);
+    if (coef_rows_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(coef_rows_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            coef_rows_.assign(tok.begin(), tok.end());
+        }
+    }
+}
+
+void ConstraintsFileReaderMemOptim::read_obj_coef()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto obj_coef_path = inputRoot_ / "constraints" / "obj_coef.csv";
+    std::ifstream obj_coef_stream(obj_coef_path);
+    if (obj_coef_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(obj_coef_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            std::vector<std::string> tokens(tok.begin(), tok.end());
+            std::string key = tokens[0];
+            std::vector<double> values_double;
+            if (tokens.size() > 1)
+            {
+                values_double.resize(tokens.size() - 1);
+                std::transform(tokens.begin() + 1,
+                               tokens.end(),
+                               values_double.begin(),
+                               [](const std::string& s) { return std::stod(s); });
+            }
+            obj_coefs_[key] = values_double;
+        }
+    }
+}
+
+void ConstraintsFileReaderMemOptim::read_obj_cols()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto obj_cols_path = inputRoot_ / "constraints" / "obj_cols.csv";
+    std::ifstream obj_cols_stream(obj_cols_path);
+    if (obj_cols_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(obj_cols_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            obj_cols_.assign(tok.begin(), tok.end());
+        }
+    }
+}
+
+void ConstraintsFileReaderMemOptim::read_rhs()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto rhs_path = inputRoot_ / "constraints" / "rhs.csv";
+    std::ifstream rhs_stream(rhs_path);
+    if (rhs_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(rhs_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            std::vector<std::string> tokens(tok.begin(), tok.end());
+            std::string key = tokens[0];
+            std::vector<double> values_double;
+            if (tokens.size() > 1)
+            {
+                values_double.resize(tokens.size() - 1);
+                std::transform(tokens.begin() + 1,
+                               tokens.end(),
+                               values_double.begin(),
+                               [](const std::string& s) { return std::stod(s); });
+            }
+            rhs_[key] = values_double;
+        }
+    }
+}
+
+void ConstraintsFileReaderMemOptim::read_rhs_rows()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto rhs_rows_path = inputRoot_ / "constraints" / "rhs_rows.csv";
+    std::ifstream rhs_rows_stream(rhs_rows_path);
+    if (rhs_rows_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(rhs_rows_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            rhs_rows_.assign(tok.begin(), tok.end());
+        }
+    }
+}
+
+void ConstraintsFileReaderMemOptim::read_constraints_for_mem_optim() 
+{
+ 
+} 
+
+
+void ConstraintsFileReaderMemOptim::build_skeleton(std::string solver_name,
+                                                   const SolverLogManager& solver_log_manager,
+                                                   int log_level,
+                                                   ProblemsFormat format)
+{
+    SolverFactory solver_factory(logger_);
+    solver_skeleton = solver_factory.create_solver(solver_name,
+                                           SOLVER_TYPE::CONTINUOUS,
+                                           solver_log_manager);
+
+    solver_skeleton->set_threads(1);
+    solver_skeleton->set_output_log_level(log_level);
+    std::filesystem::path skeleton_sub = inputRoot_ / "sub" / "sub.mps";
+
+    benders_problem_provider_ = std::make_shared<BendersProblemFromFile>(skeleton_sub);
+    solver_IO_.configure(solver_name, format);
+
+    benders_problem_provider_->provide_problem(solver_IO_, solver_skeleton);
+
+    int number_of_rows = solver_skeleton->get_nrows();
+}
+
+
+
+

--- a/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
+++ b/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
@@ -26,8 +26,8 @@ MemOptimSubProblemBuilder::MemOptimSubProblemBuilder(const std::filesystem::path
     read_obj_cols();
     read_rhs();
     read_rhs_rows();
-    micro_iters_ = false ; 
-    warm_start_ = false ; 
+    micro_iters_ = false;
+    warm_start_ = false;
 }
 
 void MemOptimSubProblemBuilder::read_coef()
@@ -253,7 +253,7 @@ std::shared_ptr<SubproblemWorker> MemOptimSubProblemBuilder::create_sub_solver_a
     auto& coeffs_obj = obj_coefs_[sub_name];
     auto& rhs_values = rhs_[sub_name];
     int n_coefs = coeffs_sub.size();
-    std::shared_ptr<SolverAbstract> sub_solver(solver_->clone()) ; 
+    std::shared_ptr<SolverAbstract> sub_solver(solver_->clone());
 
     auto start = std::chrono::high_resolution_clock::now();
     sub_solver->chg_coefs(n_coefs,

--- a/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
+++ b/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
@@ -1,8 +1,6 @@
 #include "antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h"
+
 #include <antares-xpansion/benders/benders_core/SolverIO.h>
-#include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
-
-
 #include <chrono>
 #include <fstream>
 #include <iostream>
@@ -10,11 +8,17 @@
 #include <boost/mpi.hpp>
 #include <boost/tokenizer.hpp>
 
-MemOptimSubProblemBuilder::MemOptimSubProblemBuilder(const std::filesystem::path& inputRoot,Logger& logger,std::string solver_name, int log_level,ProblemsFormat format) 
-    : inputRoot_(inputRoot)
+#include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
+
+MemOptimSubProblemBuilder::MemOptimSubProblemBuilder(const std::filesystem::path& inputRoot,
+                                                     Logger& logger,
+                                                     std::string solver_name,
+                                                     int log_level,
+                                                     ProblemsFormat format):
+    inputRoot_(inputRoot)
 {
-    logger_ = logger ; 
-    build_sub_skeleton(solver_name,   solver_log_manager_,  log_level, format) ; 
+    logger_ = logger;
+    build_sub_skeleton(solver_name, solver_log_manager_, log_level, format);
     read_coef();
     read_coef_cols();
     read_coef_rows();
@@ -26,7 +30,7 @@ MemOptimSubProblemBuilder::MemOptimSubProblemBuilder(const std::filesystem::path
 
 void MemOptimSubProblemBuilder::read_coef()
 {
-    boost::char_separator<char> sep(",") ; 
+    boost::char_separator<char> sep(",");
     using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
     auto coef_csv_path = inputRoot_ / "sub" / "coef.csv";
@@ -37,27 +41,26 @@ void MemOptimSubProblemBuilder::read_coef()
         std::string line;
         while (std::getline(coef_csv_stream, line))
         {
-            Tokenizer tok(line,sep);
+            Tokenizer tok(line, sep);
             std::vector<std::string> tokens(tok.begin(), tok.end());
             std::string key = tokens[0];
             std::vector<double> values_double;
             if (tokens.size() > 1)
             {
                 values_double.resize(tokens.size() - 1);
-                std::transform(tokens.begin() + 1, tokens.end(), 
+                std::transform(tokens.begin() + 1,
+                               tokens.end(),
                                values_double.begin(),
                                [](const std::string& s) { return std::stod(s); });
             }
             coeffs_[key] = values_double;
         }
-
     }
-
 }
 
 void MemOptimSubProblemBuilder::read_coef_cols()
 {
-    boost::char_separator<char> sep(",") ; 
+    boost::char_separator<char> sep(",");
     using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
     auto coef_cols_path = inputRoot_ / "sub" / "coef_cols.csv";
@@ -68,19 +71,19 @@ void MemOptimSubProblemBuilder::read_coef_cols()
 
         while (std::getline(coef_cols_stream, line))
         {
-            Tokenizer tok(line,sep) ; 
+            Tokenizer tok(line, sep);
             coef_cols_.assign(tok.begin(), tok.end());
         }
-        for (auto& col_name : coef_cols_) 
+        for (auto& col_name: coef_cols_)
         {
-            constraints_col_indices_.push_back(solver_->get_col_index(col_name)) ; 
+            constraints_col_indices_.push_back(solver_->get_col_index(col_name));
         }
     }
 }
 
 void MemOptimSubProblemBuilder::read_coef_rows()
 {
-    boost::char_separator<char> sep(",") ; 
+    boost::char_separator<char> sep(",");
     using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
     auto coef_rows_path = inputRoot_ / "sub" / "coef_rows.csv";
@@ -94,9 +97,9 @@ void MemOptimSubProblemBuilder::read_coef_rows()
             coef_rows_.assign(tok.begin(), tok.end());
         }
 
-        for (auto& row_name: coef_rows_) 
+        for (auto& row_name: coef_rows_)
         {
-            constraints_row_indices_.push_back(solver_->get_row_index(row_name)) ; 
+            constraints_row_indices_.push_back(solver_->get_row_index(row_name));
         }
     }
 }
@@ -121,13 +124,15 @@ void MemOptimSubProblemBuilder::read_obj_coef()
             if (tokens.size() > 1)
             {
                 values_double.resize(tokens.size() - 1);
-                std::transform(tokens.begin() + 1, tokens.end(), 
+                std::transform(tokens.begin() + 1,
+                               tokens.end(),
                                values_double.begin(),
                                [](const std::string& s) { return std::stod(s); });
             }
             if (j < 2)
-
-            ++j;
+            {
+                ++j;
+            }
             obj_coefs_[key] = values_double;
         }
     }
@@ -149,9 +154,9 @@ void MemOptimSubProblemBuilder::read_obj_cols()
             Tokenizer tok(line, sep);
             obj_cols_.assign(tok.begin(), tok.end());
         }
-        for (auto& obj_col : obj_cols_) 
+        for (auto& obj_col: obj_cols_)
         {
-            obj_col_indices_.push_back(solver_->get_col_index(obj_col)) ; 
+            obj_col_indices_.push_back(solver_->get_col_index(obj_col));
         }
     }
 }
@@ -177,15 +182,14 @@ void MemOptimSubProblemBuilder::read_rhs()
             if (tokens.size() > 1)
             {
                 values_double.resize(tokens.size() - 1);
-                std::transform(tokens.begin() + 1, tokens.end(), 
+                std::transform(tokens.begin() + 1,
+                               tokens.end(),
                                values_double.begin(),
                                [](const std::string& s) { return std::stod(s); });
             }
             rhs_[key] = values_double;
         }
-
     }
-
 }
 
 void MemOptimSubProblemBuilder::read_rhs_rows()
@@ -203,64 +207,66 @@ void MemOptimSubProblemBuilder::read_rhs_rows()
             Tokenizer tok(line, sep);
             rhs_rows_.assign(tok.begin(), tok.end());
         }
-        for (auto& rhs_row : rhs_rows_) 
+        for (auto& rhs_row: rhs_rows_)
         {
-            rhs_row_indices_.push_back(solver_->get_row_index(rhs_row)) ; 
-    
+            rhs_row_indices_.push_back(solver_->get_row_index(rhs_row));
         }
     }
 }
 
-
-void  MemOptimSubProblemBuilder::build_sub_skeleton(std::string solver_name, const SolverLogManager& solver_log_manager, int log_level,ProblemsFormat format) 
+void MemOptimSubProblemBuilder::build_sub_skeleton(std::string solver_name,
+                                                   const SolverLogManager& solver_log_manager,
+                                                   int log_level,
+                                                   ProblemsFormat format)
 {
     SolverFactory solver_factory(logger_);
     solver_ = solver_factory.create_solver(solver_name,
                                            SOLVER_TYPE::CONTINUOUS,
                                            solver_log_manager);
 
-
-    solver_->set_threads(1) ; 
-    solver_->set_output_log_level(log_level) ; 
-    std::filesystem::path skeleton_sub = inputRoot_ / "sub" / "sub.mps" ; 
+    solver_->set_threads(1);
+    solver_->set_output_log_level(log_level);
+    std::filesystem::path skeleton_sub = inputRoot_ / "sub" / "sub.mps";
 
     benders_problem_provider_ = std::make_shared<BendersProblemFromFile>(skeleton_sub);
-    solver_IO_.configure(solver_name,format) ; 
+    solver_IO_.configure(solver_name, format);
 
     benders_problem_provider_->provide_problem(solver_IO_, solver_);
 
-    int number_of_rows  = solver_->get_nrows() ; 
-
-} 
+    int number_of_rows = solver_->get_nrows();
+}
 
 int MemOptimSubProblemBuilder::get_sub_number()
 {
-    return rhs_.size() ; 
-}  
+    return rhs_.size();
+}
 
-
-std::shared_ptr<SubproblemWorker> MemOptimSubProblemBuilder::create_sub_solver_abstract(std::string sub_name,VariableMap& variable_map,double cut_coefficient_tolerance,double slave_weight)
+std::shared_ptr<SubproblemWorker> MemOptimSubProblemBuilder::create_sub_solver_abstract(
+  std::string sub_name,
+  VariableMap& variable_map,
+  double cut_coefficient_tolerance,
+  double slave_weight)
 {
-    auto& coeffs_sub = coeffs_[sub_name] ;
-    auto& coeffs_obj = obj_coefs_[sub_name] ;
-    auto& rhs_values = rhs_[sub_name] ;   
-    int n_coefs = coeffs_sub.size() ; 
-    auto sub_solver = solver_ ;
-    
+    auto& coeffs_sub = coeffs_[sub_name];
+    auto& coeffs_obj = obj_coefs_[sub_name];
+    auto& rhs_values = rhs_[sub_name];
+    int n_coefs = coeffs_sub.size();
+    auto sub_solver = solver_;
+
     auto start = std::chrono::high_resolution_clock::now();
-    sub_solver->chg_coefs(n_coefs,constraints_row_indices_.data(), constraints_col_indices_.data(),coeffs_sub.data()) ; 
-    sub_solver->chg_obj(obj_col_indices_,coeffs_obj) ;
-    sub_solver->chg_rhs_values(rhs_row_indices_,rhs_values) ;
+    sub_solver->chg_coefs(n_coefs,
+                          constraints_row_indices_.data(),
+                          constraints_col_indices_.data(),
+                          coeffs_sub.data());
+    sub_solver->chg_obj(obj_col_indices_, coeffs_obj);
+    sub_solver->chg_rhs_values(rhs_row_indices_, rhs_values);
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
 
-    auto subproblem_worker = std::make_shared<SubproblemWorker>(
-             variable_map, 
-             sub_solver , 
-             logger_, 
-             slave_weight
-    ) ; 
+    auto subproblem_worker = std::make_shared<SubproblemWorker>(variable_map,
+                                                                sub_solver,
+                                                                logger_,
+                                                                slave_weight);
 
-    return subproblem_worker ; 
-
-} 
+    return subproblem_worker;
+}

--- a/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
+++ b/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
@@ -1,0 +1,266 @@
+#include "antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h"
+#include <antares-xpansion/benders/benders_core/SolverIO.h>
+#include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
+
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+
+#include <boost/mpi.hpp>
+#include <boost/tokenizer.hpp>
+
+MemOptimSubProblemBuilder::MemOptimSubProblemBuilder(const std::filesystem::path& inputRoot,Logger& logger,std::string solver_name, int log_level,ProblemsFormat format) 
+    : inputRoot_(inputRoot)
+{
+    logger_ = logger ; 
+    build_sub_skeleton(solver_name,   solver_log_manager_,  log_level, format) ; 
+    read_coef();
+    read_coef_cols();
+    read_coef_rows();
+    read_obj_coef();
+    read_obj_cols();
+    read_rhs();
+    read_rhs_rows();
+}
+
+void MemOptimSubProblemBuilder::read_coef()
+{
+    boost::char_separator<char> sep(",") ; 
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto coef_csv_path = inputRoot_ / "sub" / "coef.csv";
+    std::ifstream coef_csv_stream(coef_csv_path);
+    if (coef_csv_stream.is_open())
+    {
+        int j = 0;
+        std::string line;
+        while (std::getline(coef_csv_stream, line))
+        {
+            Tokenizer tok(line,sep);
+            std::vector<std::string> tokens(tok.begin(), tok.end());
+            std::string key = tokens[0];
+            std::vector<double> values_double;
+            if (tokens.size() > 1)
+            {
+                values_double.resize(tokens.size() - 1);
+                std::transform(tokens.begin() + 1, tokens.end(), 
+                               values_double.begin(),
+                               [](const std::string& s) { return std::stod(s); });
+            }
+            coeffs_[key] = values_double;
+        }
+
+    }
+
+}
+
+void MemOptimSubProblemBuilder::read_coef_cols()
+{
+    boost::char_separator<char> sep(",") ; 
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto coef_cols_path = inputRoot_ / "sub" / "coef_cols.csv";
+    std::ifstream coef_cols_stream(coef_cols_path);
+    if (coef_cols_stream.is_open())
+    {
+        std::string line;
+
+        while (std::getline(coef_cols_stream, line))
+        {
+            Tokenizer tok(line,sep) ; 
+            coef_cols_.assign(tok.begin(), tok.end());
+        }
+        for (auto& col_name : coef_cols_) 
+        {
+            constraints_col_indices_.push_back(solver_->get_col_index(col_name)) ; 
+        }
+    }
+}
+
+void MemOptimSubProblemBuilder::read_coef_rows()
+{
+    boost::char_separator<char> sep(",") ; 
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto coef_rows_path = inputRoot_ / "sub" / "coef_rows.csv";
+    std::ifstream coef_rows_stream(coef_rows_path);
+    if (coef_rows_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(coef_rows_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            coef_rows_.assign(tok.begin(), tok.end());
+        }
+
+        for (auto& row_name: coef_rows_) 
+        {
+            constraints_row_indices_.push_back(solver_->get_row_index(row_name)) ; 
+        }
+    }
+}
+
+void MemOptimSubProblemBuilder::read_obj_coef()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto obj_coef_path = inputRoot_ / "sub" / "obj_coef.csv";
+    std::ifstream obj_coef_stream(obj_coef_path);
+    if (obj_coef_stream.is_open())
+    {
+        std::string line;
+        int j = 0;
+        while (std::getline(obj_coef_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            std::vector<std::string> tokens(tok.begin(), tok.end());
+            std::string key = tokens[0];
+            std::vector<double> values_double;
+            if (tokens.size() > 1)
+            {
+                values_double.resize(tokens.size() - 1);
+                std::transform(tokens.begin() + 1, tokens.end(), 
+                               values_double.begin(),
+                               [](const std::string& s) { return std::stod(s); });
+            }
+            if (j < 2)
+
+            ++j;
+            obj_coefs_[key] = values_double;
+        }
+    }
+}
+
+void MemOptimSubProblemBuilder::read_obj_cols()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto obj_cols_path = inputRoot_ / "sub" / "obj_cols.csv";
+    std::ifstream obj_cols_stream(obj_cols_path);
+
+    if (obj_cols_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(obj_cols_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            obj_cols_.assign(tok.begin(), tok.end());
+        }
+        for (auto& obj_col : obj_cols_) 
+        {
+            obj_col_indices_.push_back(solver_->get_col_index(obj_col)) ; 
+        }
+    }
+}
+
+void MemOptimSubProblemBuilder::read_rhs()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto rhs_path = inputRoot_ / "sub" / "rhs.csv";
+    std::ifstream rhs_stream(rhs_path);
+    if (rhs_stream.is_open())
+    {
+        std::string line;
+        int j = 0;
+
+        while (std::getline(rhs_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            std::vector<std::string> tokens(tok.begin(), tok.end());
+            std::string key = tokens[0];
+            std::vector<double> values_double;
+            if (tokens.size() > 1)
+            {
+                values_double.resize(tokens.size() - 1);
+                std::transform(tokens.begin() + 1, tokens.end(), 
+                               values_double.begin(),
+                               [](const std::string& s) { return std::stod(s); });
+            }
+            rhs_[key] = values_double;
+        }
+
+    }
+
+}
+
+void MemOptimSubProblemBuilder::read_rhs_rows()
+{
+    boost::char_separator<char> sep(",");
+    using Tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
+    auto rhs_rows_path = inputRoot_ / "sub" / "rhs_rows.csv";
+    std::ifstream rhs_rows_stream(rhs_rows_path);
+    if (rhs_rows_stream.is_open())
+    {
+        std::string line;
+        while (std::getline(rhs_rows_stream, line))
+        {
+            Tokenizer tok(line, sep);
+            rhs_rows_.assign(tok.begin(), tok.end());
+        }
+        for (auto& rhs_row : rhs_rows_) 
+        {
+            rhs_row_indices_.push_back(solver_->get_row_index(rhs_row)) ; 
+    
+        }
+    }
+}
+
+
+void  MemOptimSubProblemBuilder::build_sub_skeleton(std::string solver_name, const SolverLogManager& solver_log_manager, int log_level,ProblemsFormat format) 
+{
+    SolverFactory solver_factory(logger_);
+    solver_ = solver_factory.create_solver(solver_name,
+                                           SOLVER_TYPE::CONTINUOUS,
+                                           solver_log_manager);
+
+
+    solver_->set_threads(1) ; 
+    solver_->set_output_log_level(log_level) ; 
+    std::filesystem::path skeleton_sub = inputRoot_ / "sub" / "sub.mps" ; 
+
+    benders_problem_provider_ = std::make_shared<BendersProblemFromFile>(skeleton_sub);
+    solver_IO_.configure(solver_name,format) ; 
+
+    benders_problem_provider_->provide_problem(solver_IO_, solver_);
+
+    int number_of_rows  = solver_->get_nrows() ; 
+
+} 
+
+int MemOptimSubProblemBuilder::get_sub_number()
+{
+    return rhs_.size() ; 
+}  
+
+
+std::shared_ptr<SubproblemWorker> MemOptimSubProblemBuilder::create_sub_solver_abstract(std::string sub_name,VariableMap& variable_map,double cut_coefficient_tolerance,double slave_weight)
+{
+    auto& coeffs_sub = coeffs_[sub_name] ;
+    auto& coeffs_obj = obj_coefs_[sub_name] ;
+    auto& rhs_values = rhs_[sub_name] ;   
+    int n_coefs = coeffs_sub.size() ; 
+    auto sub_solver = solver_ ;
+    
+    auto start = std::chrono::high_resolution_clock::now();
+    sub_solver->chg_coefs(n_coefs,constraints_row_indices_.data(), constraints_col_indices_.data(),coeffs_sub.data()) ; 
+    sub_solver->chg_obj(obj_col_indices_,coeffs_obj) ;
+    sub_solver->chg_rhs_values(rhs_row_indices_,rhs_values) ;
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    auto subproblem_worker = std::make_shared<SubproblemWorker>(
+             variable_map, 
+             sub_solver , 
+             logger_, 
+             slave_weight
+    ) ; 
+
+    return subproblem_worker ; 
+
+} 

--- a/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
+++ b/src/cpp/benders/benders_core/MemOptim_subproblem_builder.cpp
@@ -26,6 +26,8 @@ MemOptimSubProblemBuilder::MemOptimSubProblemBuilder(const std::filesystem::path
     read_obj_cols();
     read_rhs();
     read_rhs_rows();
+    micro_iters_ = false ; 
+    warm_start_ = false ; 
 }
 
 void MemOptimSubProblemBuilder::read_coef()
@@ -251,7 +253,7 @@ std::shared_ptr<SubproblemWorker> MemOptimSubProblemBuilder::create_sub_solver_a
     auto& coeffs_obj = obj_coefs_[sub_name];
     auto& rhs_values = rhs_[sub_name];
     int n_coefs = coeffs_sub.size();
-    auto sub_solver = solver_;
+    std::shared_ptr<SolverAbstract> sub_solver(solver_->clone()) ; 
 
     auto start = std::chrono::high_resolution_clock::now();
     sub_solver->chg_coefs(n_coefs,

--- a/src/cpp/benders/benders_core/SimulationOptions.cpp
+++ b/src/cpp/benders/benders_core/SimulationOptions.cpp
@@ -200,6 +200,7 @@ BendersBaseOptions SimulationOptions::get_benders_options() const
     result.TRACE = TRACE;
     result.BOUND_ALPHA = BOUND_ALPHA;
     result.CACHE_PROBLEMS = CACHE_PROBLEMS;
+    result.MEMORY_OPTIMIZATION = MEMORY_OPTIMIZATION; 
 
     if (MASTER_FORMULATION == "integer")
     {

--- a/src/cpp/benders/benders_core/SimulationOptions.cpp
+++ b/src/cpp/benders/benders_core/SimulationOptions.cpp
@@ -200,7 +200,7 @@ BendersBaseOptions SimulationOptions::get_benders_options() const
     result.TRACE = TRACE;
     result.BOUND_ALPHA = BOUND_ALPHA;
     result.CACHE_PROBLEMS = CACHE_PROBLEMS;
-    result.MEMORY_OPTIMIZATION = MEMORY_OPTIMIZATION; 
+    result.MEMORY_OPTIMIZATION = MEMORY_OPTIMIZATION;
 
     if (MASTER_FORMULATION == "integer")
     {

--- a/src/cpp/benders/benders_core/SubproblemWorker.cpp
+++ b/src/cpp/benders/benders_core/SubproblemWorker.cpp
@@ -38,6 +38,33 @@ SubproblemWorker::SubproblemWorker(const VariableMap& variable_map,
     _solver->chg_obj(sequence, obj_func_coeffs);
 }
 
+
+SubproblemWorker::SubproblemWorker(VariableMap& variable_map, std::shared_ptr<SolverAbstract> solver,Logger logger,double slave_weight)  : 
+Worker( variable_map,  logger)
+{
+    init_for_mem_optim(solver,variable_map) ; 
+    setup_obj(slave_weight) ; 
+}
+
+
+void SubproblemWorker::setup_obj(double slave_weight) 
+{    
+    int mps_ncols(_solver->get_ncols());
+    DblVector obj_func_coeffs(mps_ncols);
+    IntVector sequence(mps_ncols);
+    for (int i = 0; i < mps_ncols; ++i)
+    {
+        sequence[i] = i;
+    }
+    solver_get_obj_func_coeffs(*_solver, obj_func_coeffs, 0, mps_ncols - 1);
+    for (auto& c: obj_func_coeffs)
+    {
+        c *= slave_weight;
+    }
+    _solver->chg_obj(sequence, obj_func_coeffs);    
+} 
+
+
 /*!
  *  \brief Fix a set of variables to constant in a problem
  *

--- a/src/cpp/benders/benders_core/SubproblemWorker.cpp
+++ b/src/cpp/benders/benders_core/SubproblemWorker.cpp
@@ -38,17 +38,18 @@ SubproblemWorker::SubproblemWorker(const VariableMap& variable_map,
     _solver->chg_obj(sequence, obj_func_coeffs);
 }
 
-
-SubproblemWorker::SubproblemWorker(VariableMap& variable_map, std::shared_ptr<SolverAbstract> solver,Logger logger,double slave_weight)  : 
-Worker( variable_map,  logger)
+SubproblemWorker::SubproblemWorker(VariableMap& variable_map,
+                                   std::shared_ptr<SolverAbstract> solver,
+                                   Logger logger,
+                                   double slave_weight):
+    Worker(variable_map, logger)
 {
-    init_for_mem_optim(solver,variable_map) ; 
-    setup_obj(slave_weight) ; 
+    init_for_mem_optim(solver, variable_map);
+    setup_obj(slave_weight);
 }
 
-
-void SubproblemWorker::setup_obj(double slave_weight) 
-{    
+void SubproblemWorker::setup_obj(double slave_weight)
+{
     int mps_ncols(_solver->get_ncols());
     DblVector obj_func_coeffs(mps_ncols);
     IntVector sequence(mps_ncols);
@@ -61,9 +62,8 @@ void SubproblemWorker::setup_obj(double slave_weight)
     {
         c *= slave_weight;
     }
-    _solver->chg_obj(sequence, obj_func_coeffs);    
-} 
-
+    _solver->chg_obj(sequence, obj_func_coeffs);
+}
 
 /*!
  *  \brief Fix a set of variables to constant in a problem

--- a/src/cpp/benders/benders_core/Worker.cpp
+++ b/src/cpp/benders/benders_core/Worker.cpp
@@ -125,6 +125,23 @@ void Worker::solve(int& lp_status,
     }
 }
 
+
+void Worker::set_id_to_name(VariableMap& variable_map) 
+{
+    _name_to_id = variable_map ; 
+    for (const auto& kvp : _name_to_id) 
+    {
+        _id_to_name[kvp.second] = kvp.first;
+    }    
+} 
+
+
+void Worker::init_for_mem_optim(std::shared_ptr<SolverAbstract> solver, VariableMap& variable_map) 
+{
+    _solver = solver ; 
+    set_id_to_name(variable_map) ; 
+}
+
 /*!
  *  \brief Get the number of iteration needed to solve a problem
  *

--- a/src/cpp/benders/benders_core/Worker.cpp
+++ b/src/cpp/benders/benders_core/Worker.cpp
@@ -125,21 +125,19 @@ void Worker::solve(int& lp_status,
     }
 }
 
-
-void Worker::set_id_to_name(VariableMap& variable_map) 
+void Worker::set_id_to_name(VariableMap& variable_map)
 {
-    _name_to_id = variable_map ; 
-    for (const auto& kvp : _name_to_id) 
+    _name_to_id = variable_map;
+    for (const auto& kvp: _name_to_id)
     {
         _id_to_name[kvp.second] = kvp.first;
-    }    
-} 
+    }
+}
 
-
-void Worker::init_for_mem_optim(std::shared_ptr<SolverAbstract> solver, VariableMap& variable_map) 
+void Worker::init_for_mem_optim(std::shared_ptr<SolverAbstract> solver, VariableMap& variable_map)
 {
-    _solver = solver ; 
-    set_id_to_name(variable_map) ; 
+    _solver = solver;
+    set_id_to_name(variable_map);
 }
 
 /*!

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -4,7 +4,6 @@
 #include <execution>
 #include <filesystem>
 #include <mutex>
-#include "antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h"
 #include <tbb/tbb.h>
 
 #include "BendersMathLogger.h"
@@ -15,6 +14,7 @@
 #include "SubproblemWorker.h"
 #include "Worker.h"
 #include "WorkerMaster.h"
+#include "antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h"
 #include "antares-xpansion/helpers/Timer.h"
 #include "antares-xpansion/xpansion_interfaces/ILogger.h"
 #include "common.h"
@@ -61,7 +61,7 @@ public:
     int MasterRowIndex(const std::string& row_name) const;
     void MasterChangeRhs(int id_row, double val) const;
     void MasterGetRhs(double& rhs, int id_row) const;
-    void GetMemOptimCuts(SubProblemDataMap& subproblem_data_map) ; 
+    void GetMemOptimCuts(SubProblemDataMap& subproblem_data_map);
 
     const VariableMap& MasterVariables() const
     {
@@ -158,8 +158,8 @@ protected:
     VariableMap master_variable_map_;
     CouplingMap coupling_map_;
     VariableMap _problem_to_id;
-    std::vector<std::vector<std::string>> subs_per_procs_mem_optim_ ; 
-    std::shared_ptr<MemOptimSubProblemBuilder> memoptim_subprob_builder_ ;
+    std::vector<std::vector<std::string>> subs_per_procs_mem_optim_;
+    std::shared_ptr<MemOptimSubProblemBuilder> memoptim_subprob_builder_;
     BendersRelevantIterationsData relevantIterationData_ = {WorkerMasterData(), WorkerMasterData()};
     bool init_data_ = true;
     bool init_problems_ = true;
@@ -199,7 +199,7 @@ protected:
     virtual void ActivateIntegrityConstraints() const;
     virtual void SetDataPreRelaxation();
     virtual void ResetDataPostRelaxation();
-    void set_rank(int rank) ;   
+    void set_rank(int rank);
     [[nodiscard]] std::filesystem::path GetSubproblemPath(const std::string& subproblem_name) const;
     [[nodiscard]] double SubproblemWeight(int subproblem_count, const std::string& name) const;
     [[nodiscard]] std::filesystem::path get_master_path() const;
@@ -376,8 +376,8 @@ private:
     Output::SolutionData outer_loop_solution_data_;
     std::unordered_map<std::string, std::pair<std::vector<int>, std::vector<int>>> basiss_;
     std::shared_ptr<ICommunicationStrategy> communication_strategy_;
- 
-    int rank_ ; 
+
+    int rank_;
 };
 
 using pBendersBase = std::shared_ptr<BendersBase>;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -4,6 +4,7 @@
 #include <execution>
 #include <filesystem>
 #include <mutex>
+#include "antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h"
 #include <tbb/tbb.h>
 
 #include "BendersMathLogger.h"
@@ -60,6 +61,7 @@ public:
     int MasterRowIndex(const std::string& row_name) const;
     void MasterChangeRhs(int id_row, double val) const;
     void MasterGetRhs(double& rhs, int id_row) const;
+    void GetMemOptimCuts(SubProblemDataMap& subproblem_data_map) ; 
 
     const VariableMap& MasterVariables() const
     {
@@ -156,7 +158,8 @@ protected:
     VariableMap master_variable_map_;
     CouplingMap coupling_map_;
     VariableMap _problem_to_id;
-
+    std::vector<std::vector<std::string>> subs_per_procs_mem_optim_ ; 
+    std::shared_ptr<MemOptimSubProblemBuilder> memoptim_subprob_builder_ ;
     BendersRelevantIterationsData relevantIterationData_ = {WorkerMasterData(), WorkerMasterData()};
     bool init_data_ = true;
     bool init_problems_ = true;
@@ -196,6 +199,7 @@ protected:
     virtual void ActivateIntegrityConstraints() const;
     virtual void SetDataPreRelaxation();
     virtual void ResetDataPostRelaxation();
+    void set_rank(int rank) ;   
     [[nodiscard]] std::filesystem::path GetSubproblemPath(const std::string& subproblem_name) const;
     [[nodiscard]] double SubproblemWeight(int subproblem_count, const std::string& name) const;
     [[nodiscard]] std::filesystem::path get_master_path() const;
@@ -372,6 +376,8 @@ private:
     Output::SolutionData outer_loop_solution_data_;
     std::unordered_map<std::string, std::pair<std::vector<int>, std::vector<int>>> basiss_;
     std::shared_ptr<ICommunicationStrategy> communication_strategy_;
+ 
+    int rank_ ; 
 };
 
 using pBendersBase = std::shared_ptr<BendersBase>;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/ConstraintsFileReader.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/ConstraintsFileReader.h
@@ -31,9 +31,8 @@ public:
                           ProblemsFormat format);
 
     SolverRepresentedRows get_row(const std::string& name);
-
-private:
     int get_row_index(const std::string& name);
+private:
 
     Logger logger_;
     std::shared_ptr<SolverAbstract> solver_;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/ConstraintsFileReaderMemOptim.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/ConstraintsFileReaderMemOptim.h
@@ -1,0 +1,70 @@
+#pragma once 
+#include <memory>
+#include <string>
+#include <vector>
+#include <filesystem>
+
+
+#include "IBendersProblemProvider.h"
+#include "antares-xpansion/benders/benders_core/BendersProblemFromFile.h"
+
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/tokenizer.hpp>
+
+
+
+
+/*
+This class will handle reading the constraints file in case of memory optimization 
+The main differnce compared to the classical case is that when we are in memory optimization mode
+we don't have a seperate mps per constraints : we have a skeleton mps file and some csv files that allows to read 
+set the solver abstract into the right sub problem 
+*/
+class ConstraintsFileReaderMemOptim
+{
+    public : 
+        ConstraintsFileReaderMemOptim(const std::filesystem::path &inputRoot,
+                              const std::string& solver_name,
+                              const SolverLogManager& solver_log_manager,
+                              Logger& logger,
+                              int log_level,
+                              ProblemsFormat format
+                               ) ; 
+
+    
+    private : 
+        //as the input for memory optimization changes, with these method we read the necessary files 
+        //to construct the correspondant constraint solver abstract   
+        void read_coef(); 
+        void read_coef_cols();
+        void read_coef_rows();
+        void read_obj_coef();
+        void read_obj_cols();
+        void read_rhs();
+        void read_rhs_rows();
+        void read_constraints_for_mem_optim() ;
+        void build_skeleton(std::string solver_name,
+                            const SolverLogManager& solver_log_manager,
+                            int log_level,
+                            ProblemsFormat format) ;  
+
+        std::map<std::string, std::vector<double>> coeffs_;
+        std::vector<std::string> coef_cols_;
+        std::vector<std::string> coef_rows_;
+        std::map<std::string, std::vector<double>> obj_coefs_;
+        std::vector<std::string> obj_cols_;
+        std::vector<std::string> rhs_rows_;
+        std::map<std::string, std::vector<double>> rhs_;
+        std::vector<int> constraints_col_indices_;
+        std::vector<int> constraints_row_indices_;
+        std::vector<int> obj_col_indices_;
+        std::vector<int> rhs_row_indices_;
+
+
+        Logger logger_;
+        std::filesystem::path inputRoot_ ; 
+        std::shared_ptr<SolverAbstract> solver_skeleton;
+        std::shared_ptr<BendersProblemFromFile> benders_problem_provider_;
+        SolverIO solver_IO_;
+} ; 

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include <boost/tokenizer.hpp>
+#include "antares-xpansion/benders/benders_core/ConstraintsFileReader.h"
 
 #include "IBendersProblemProvider.h"
 #include "antares-xpansion/benders/benders_core/BendersProblemFromFile.h"
@@ -43,7 +44,9 @@ private:
     void read_rhs_rows();
 
     std::filesystem::path inputRoot_;
+
     std::map<std::string, std::vector<double>> coeffs_;
+    std::map<std::string,std::vector<SolverRepresentedRows>> micro_iters_added_rows ; 
     std::vector<std::string> coef_cols_;
     std::vector<std::string> coef_rows_;
     std::map<std::string, std::vector<double>> obj_coefs_;
@@ -58,4 +61,6 @@ private:
     std::vector<int> obj_col_indices_;
     SolverLogManager solver_log_manager_;
     SolverIO solver_IO_;
+    bool micro_iters_ ; 
+    bool warm_start_ ; 
 };

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
@@ -1,0 +1,51 @@
+#pragma once 
+
+#include "antares-xpansion/multisolver_interface/Solver.h"
+#include "antares-xpansion/xpansion_interfaces/ILogger.h"
+#include <filesystem> 
+#include <boost/tokenizer.hpp>
+#include <antares-xpansion/benders/benders_core/SolverIO.h>
+#include <utility>
+
+#include "IBendersProblemProvider.h"
+#include "antares-xpansion/benders/benders_core/BendersProblemFromFile.h"
+#include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
+#include "antares-xpansion/benders/benders_core/Worker.h"
+
+class MemOptimSubProblemBuilder
+{
+   public:
+    MemOptimSubProblemBuilder(const std::filesystem::path& inputRoot,Logger& logger,std::string solver_name, int log_level,ProblemsFormat format) ;
+    void build_sub_skeleton(std::string solver_name, const SolverLogManager& solver_log_manager, int log_level,ProblemsFormat format); 
+    std::shared_ptr<SubproblemWorker> create_sub_solver_abstract(std::string sub_name,VariableMap& variable_map,double cut_coefficient_tolerance,double slave_weight); 
+    int get_sub_number() ; 
+
+  private:
+
+    Logger logger_ ; 
+
+    void read_coef();
+    void read_coef_cols();
+    void read_coef_rows();
+    void read_obj_coef();
+    void read_obj_cols();
+    void read_rhs();
+    void read_rhs_rows();
+
+    std::filesystem::path inputRoot_;
+    std::map<std::string, std::vector<double>> coeffs_;
+    std::vector<std::string> coef_cols_;
+    std::vector<std::string> coef_rows_;
+    std::map<std::string, std::vector<double>> obj_coefs_;
+    std::vector<std::string> obj_cols_;
+    std::vector<std::string> rhs_rows_;
+    std::vector<int> rhs_row_indices_ ; 
+    std::map<std::string, std::vector<double>> rhs_;
+    std::shared_ptr<SolverAbstract> solver_ ; 
+    std::shared_ptr<BendersProblemFromFile> benders_problem_provider_;
+    std::vector<int> constraints_col_indices_ ; 
+    std::vector<int> constraints_row_indices_ ; 
+    std::vector<int> obj_col_indices_ ; 
+    SolverLogManager solver_log_manager_; 
+    SolverIO solver_IO_; 
+};  

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
@@ -5,10 +5,10 @@
 #include <utility>
 
 #include <boost/tokenizer.hpp>
-#include "antares-xpansion/benders/benders_core/ConstraintsFileReader.h"
 
 #include "IBendersProblemProvider.h"
 #include "antares-xpansion/benders/benders_core/BendersProblemFromFile.h"
+#include "antares-xpansion/benders/benders_core/ConstraintsFileReader.h"
 #include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
 #include "antares-xpansion/benders/benders_core/Worker.h"
 #include "antares-xpansion/multisolver_interface/Solver.h"
@@ -46,7 +46,7 @@ private:
     std::filesystem::path inputRoot_;
 
     std::map<std::string, std::vector<double>> coeffs_;
-    std::map<std::string,std::vector<SolverRepresentedRows>> micro_iters_added_rows ; 
+    std::map<std::string, std::vector<SolverRepresentedRows>> micro_iters_added_rows;
     std::vector<std::string> coef_cols_;
     std::vector<std::string> coef_rows_;
     std::map<std::string, std::vector<double>> obj_coefs_;
@@ -61,6 +61,6 @@ private:
     std::vector<int> obj_col_indices_;
     SolverLogManager solver_log_manager_;
     SolverIO solver_IO_;
-    bool micro_iters_ ; 
-    bool warm_start_ ; 
+    bool micro_iters_;
+    bool warm_start_;
 };

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/MemOptim_subproblem_builder.h
@@ -1,28 +1,38 @@
-#pragma once 
+#pragma once
 
-#include "antares-xpansion/multisolver_interface/Solver.h"
-#include "antares-xpansion/xpansion_interfaces/ILogger.h"
-#include <filesystem> 
-#include <boost/tokenizer.hpp>
 #include <antares-xpansion/benders/benders_core/SolverIO.h>
+#include <filesystem>
 #include <utility>
+
+#include <boost/tokenizer.hpp>
 
 #include "IBendersProblemProvider.h"
 #include "antares-xpansion/benders/benders_core/BendersProblemFromFile.h"
 #include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
 #include "antares-xpansion/benders/benders_core/Worker.h"
+#include "antares-xpansion/multisolver_interface/Solver.h"
+#include "antares-xpansion/xpansion_interfaces/ILogger.h"
 
 class MemOptimSubProblemBuilder
 {
-   public:
-    MemOptimSubProblemBuilder(const std::filesystem::path& inputRoot,Logger& logger,std::string solver_name, int log_level,ProblemsFormat format) ;
-    void build_sub_skeleton(std::string solver_name, const SolverLogManager& solver_log_manager, int log_level,ProblemsFormat format); 
-    std::shared_ptr<SubproblemWorker> create_sub_solver_abstract(std::string sub_name,VariableMap& variable_map,double cut_coefficient_tolerance,double slave_weight); 
-    int get_sub_number() ; 
+public:
+    MemOptimSubProblemBuilder(const std::filesystem::path& inputRoot,
+                              Logger& logger,
+                              std::string solver_name,
+                              int log_level,
+                              ProblemsFormat format);
+    void build_sub_skeleton(std::string solver_name,
+                            const SolverLogManager& solver_log_manager,
+                            int log_level,
+                            ProblemsFormat format);
+    std::shared_ptr<SubproblemWorker> create_sub_solver_abstract(std::string sub_name,
+                                                                 VariableMap& variable_map,
+                                                                 double cut_coefficient_tolerance,
+                                                                 double slave_weight);
+    int get_sub_number();
 
-  private:
-
-    Logger logger_ ; 
+private:
+    Logger logger_;
 
     void read_coef();
     void read_coef_cols();
@@ -39,13 +49,13 @@ class MemOptimSubProblemBuilder
     std::map<std::string, std::vector<double>> obj_coefs_;
     std::vector<std::string> obj_cols_;
     std::vector<std::string> rhs_rows_;
-    std::vector<int> rhs_row_indices_ ; 
+    std::vector<int> rhs_row_indices_;
     std::map<std::string, std::vector<double>> rhs_;
-    std::shared_ptr<SolverAbstract> solver_ ; 
+    std::shared_ptr<SolverAbstract> solver_;
     std::shared_ptr<BendersProblemFromFile> benders_problem_provider_;
-    std::vector<int> constraints_col_indices_ ; 
-    std::vector<int> constraints_row_indices_ ; 
-    std::vector<int> obj_col_indices_ ; 
-    SolverLogManager solver_log_manager_; 
-    SolverIO solver_IO_; 
-};  
+    std::vector<int> constraints_col_indices_;
+    std::vector<int> constraints_row_indices_;
+    std::vector<int> obj_col_indices_;
+    SolverLogManager solver_log_manager_;
+    SolverIO solver_IO_;
+};

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
@@ -13,6 +13,9 @@ BENDERS_OPTIONS_MACRO(RELATIVE_GAP, double, 1e-6, asDouble())
 // Relative required level of precision with master relaxation
 BENDERS_OPTIONS_MACRO(RELAXED_GAP, double, 1e-5, asDouble())
 
+//variable to hande the memory optimization case 
+BENDERS_OPTIONS_MACRO(MEMORY_OPTIMIZATION, bool, false, asBool())
+
 // In-out separation parameter
 BENDERS_OPTIONS_MACRO(SEPARATION_PARAM, double, 0.5, asDouble())
 

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
@@ -13,7 +13,7 @@ BENDERS_OPTIONS_MACRO(RELATIVE_GAP, double, 1e-6, asDouble())
 // Relative required level of precision with master relaxation
 BENDERS_OPTIONS_MACRO(RELAXED_GAP, double, 1e-5, asDouble())
 
-//variable to hande the memory optimization case 
+// variable to hande the memory optimization case
 BENDERS_OPTIONS_MACRO(MEMORY_OPTIMIZATION, bool, false, asBool())
 
 // In-out separation parameter

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
@@ -24,8 +24,11 @@ public:
                      Logger logger,
                      ProblemsFormat format,
                      IBendersProblemProvider* benders_problem_provider);
-    SubproblemWorker(VariableMap& variable_map, std::shared_ptr<SolverAbstract> solver,Logger logger,double slave_weight) ; 
-    void setup_obj(double slave_weight) ; 
+    SubproblemWorker(VariableMap& variable_map,
+                     std::shared_ptr<SolverAbstract> solver,
+                     Logger logger,
+                     double slave_weight);
+    void setup_obj(double slave_weight);
     virtual ~SubproblemWorker() = default;
     std::vector<double> get_solution() const;
     int get_variable_index(const std::string& variable_name);

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
@@ -24,6 +24,8 @@ public:
                      Logger logger,
                      ProblemsFormat format,
                      IBendersProblemProvider* benders_problem_provider);
+    SubproblemWorker(VariableMap& variable_map, std::shared_ptr<SolverAbstract> solver,Logger logger,double slave_weight) ; 
+    void setup_obj(double slave_weight) ; 
     virtual ~SubproblemWorker() = default;
     std::vector<double> get_solution() const;
     int get_variable_index(const std::string& variable_name);

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
@@ -27,8 +27,8 @@ public:
     virtual ~Worker() = default;
 
     void get_value(double& lb) const;
-    void init_for_mem_optim(std::shared_ptr<SolverAbstract> solver, VariableMap& variable_map) ;
-    void set_id_to_name(VariableMap& variable_map) ;
+    void init_for_mem_optim(std::shared_ptr<SolverAbstract> solver, VariableMap& variable_map);
+    void set_id_to_name(VariableMap& variable_map);
     void get_splex_num_of_ite_last(int& result) const;
 
     void free();

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
@@ -27,7 +27,8 @@ public:
     virtual ~Worker() = default;
 
     void get_value(double& lb) const;
-
+    void init_for_mem_optim(std::shared_ptr<SolverAbstract> solver, VariableMap& variable_map) ;
+    void set_id_to_name(VariableMap& variable_map) ;
     void get_splex_num_of_ite_last(int& result) const;
 
     void free();

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -222,7 +222,7 @@ struct BendersBaseOptions: public SolverBaseOptions
 
     bool RESUME = false;
     bool MICRO_ITERATIONS = false;
-    bool MEMORY_OPTIMIZATION = false ; 
+    bool MEMORY_OPTIMIZATION = false;
     int NB_CUTS_PER_ITER = 0;
     bool TRACE = false;
     bool BOUND_ALPHA = false;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -222,6 +222,7 @@ struct BendersBaseOptions: public SolverBaseOptions
 
     bool RESUME = false;
     bool MICRO_ITERATIONS = false;
+    bool MEMORY_OPTIMIZATION = false ; 
     int NB_CUTS_PER_ITER = 0;
     bool TRACE = false;
     bool BOUND_ALPHA = false;

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -21,8 +21,8 @@ BendersMpi::BendersMpi(const BendersBaseOptions& options,
                 std::make_shared<MpiCommunicationStrategy>(world)),
     _world(world)
 {
-    int rank = _world.rank() ; 
-    set_rank(rank) ; 
+    int rank = _world.rank();
+    set_rank(rank);
 }
 
 /*!
@@ -36,24 +36,27 @@ void BendersMpi::InitializeProblems()
 {
     MatchProblemToId();
     SubProblemNamesInCut subs_per_proc;
-    if (_options.MEMORY_OPTIMIZATION) 
+    if (_options.MEMORY_OPTIMIZATION)
     {
-        memoptim_subprob_builder_ = std::make_shared<MemOptimSubProblemBuilder>(_options.INPUTROOT,_logger,_options.SOLVER_NAME,_options.LOG_LEVEL , _options.PROBLEMS_FORMAT) ; 
+        memoptim_subprob_builder_ = std::make_shared<MemOptimSubProblemBuilder>(
+          _options.INPUTROOT,
+          _logger,
+          _options.SOLVER_NAME,
+          _options.LOG_LEVEL,
+          _options.PROBLEMS_FORMAT);
         int current_problem_id = 0;
-        subs_per_procs_mem_optim_.resize(_world.size()) ; 
-        for (auto it= coupling_map_.begin(); it!= coupling_map_.end(); it++ )
+        subs_per_procs_mem_optim_.resize(_world.size());
+        for (auto it = coupling_map_.begin(); it != coupling_map_.end(); it++)
         {
             auto process_to_feed = current_problem_id % _world.size();
-            subs_per_procs_mem_optim_[process_to_feed].push_back(it->first) ; 
+            subs_per_procs_mem_optim_[process_to_feed].push_back(it->first);
             subs_per_proc.push_back(std::make_pair(it->first, process_to_feed));
 
-            
-            current_problem_id++ ;
+            current_problem_id++;
         }
-        
     }
 
-    else 
+    else
     {
         if (_options.CACHE_PROBLEMS)
         {
@@ -92,10 +95,8 @@ void BendersMpi::InitializeProblems()
                 current_problem_id++;
             }
         }
-
     }
 
-    
     std::vector<SubProblemNamesInCut> gathered_subs_per_proc;
     mpi::gather(_world, subs_per_proc, gathered_subs_per_proc, rank_0);
     if (_world.rank() == rank_0)

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -36,7 +36,7 @@ void BendersMpi::InitializeProblems()
 {
     MatchProblemToId();
     SubProblemNamesInCut subs_per_proc;
-    if (_options.MEMORY_OPTIMIZATION )
+    if (_options.MEMORY_OPTIMIZATION)
     {
         memoptim_subprob_builder_ = std::make_shared<MemOptimSubProblemBuilder>(
           _options.INPUTROOT,

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -21,6 +21,8 @@ BendersMpi::BendersMpi(const BendersBaseOptions& options,
                 std::make_shared<MpiCommunicationStrategy>(world)),
     _world(world)
 {
+    int rank = _world.rank() ; 
+    set_rank(rank) ; 
 }
 
 /*!
@@ -34,43 +36,66 @@ void BendersMpi::InitializeProblems()
 {
     MatchProblemToId();
     SubProblemNamesInCut subs_per_proc;
-    if (_options.CACHE_PROBLEMS)
+    if (_options.MEMORY_OPTIMIZATION) 
     {
+        memoptim_subprob_builder_ = std::make_shared<MemOptimSubProblemBuilder>(_options.INPUTROOT,_logger,_options.SOLVER_NAME,_options.LOG_LEVEL , _options.PROBLEMS_FORMAT) ; 
         int current_problem_id = 0;
-        for (auto it = coupling_map_.begin(); it != coupling_map_.end();)
+        subs_per_procs_mem_optim_.resize(_world.size()) ; 
+        for (auto it= coupling_map_.begin(); it!= coupling_map_.end(); it++ )
         {
             auto process_to_feed = current_problem_id % _world.size();
-            if (process_to_feed != _world.rank())
-            {
-                it = coupling_map_.erase(it);
-            }
-            else
-            {
-                subs_per_proc.emplace_back(it->first, process_to_feed);
-                ++it;
-            }
-            current_problem_id++;
+            subs_per_procs_mem_optim_[process_to_feed].push_back(it->first) ; 
+            subs_per_proc.push_back(std::make_pair(it->first, process_to_feed));
+
+            
+            current_problem_id++ ;
         }
-    }
-    else
-    {
-        int current_problem_id = 0;
-        // Dispatch subproblems to process
-        for (const auto& problem: coupling_map_)
-        {
-            // In case there are more subproblems than process
-            if (auto process_to_feed = current_problem_id % _world.size();
-                process_to_feed == _world.rank())
-            { // Assign  [problemNumber % processCount] to processID
-                const auto subProblemFilePath = GetSubproblemPath(problem.first);
-                subs_per_proc.push_back(std::make_pair(problem.first, process_to_feed));
-                AddSubproblem(problem);
-                AddSubproblemName(problem.first);
-            }
-            current_problem_id++;
-        }
+        
     }
 
+    else 
+    {
+        if (_options.CACHE_PROBLEMS)
+        {
+            int current_problem_id = 0;
+            for (auto it = coupling_map_.begin(); it != coupling_map_.end();)
+            {
+                auto process_to_feed = current_problem_id % _world.size();
+                if (process_to_feed != _world.rank())
+                {
+                    it = coupling_map_.erase(it);
+                }
+
+                else
+                {
+                    subs_per_proc.emplace_back(it->first, process_to_feed);
+                    ++it;
+                }
+                current_problem_id++;
+            }
+        }
+        else
+        {
+            int current_problem_id = 0;
+            // Dispatch subproblems to process
+            for (const auto& problem: coupling_map_)
+            {
+                // In case there are more subproblems than process
+                if (auto process_to_feed = current_problem_id % _world.size();
+                    process_to_feed == _world.rank())
+                { // Assign  [problemNumber % processCount] to processID
+                    const auto subProblemFilePath = GetSubproblemPath(problem.first);
+                    subs_per_proc.push_back(std::make_pair(problem.first, process_to_feed));
+                    AddSubproblem(problem);
+                    AddSubproblemName(problem.first);
+                }
+                current_problem_id++;
+            }
+        }
+
+    }
+
+    
     std::vector<SubProblemNamesInCut> gathered_subs_per_proc;
     mpi::gather(_world, subs_per_proc, gathered_subs_per_proc, rank_0);
     if (_world.rank() == rank_0)

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -36,7 +36,7 @@ void BendersMpi::InitializeProblems()
 {
     MatchProblemToId();
     SubProblemNamesInCut subs_per_proc;
-    if (_options.MEMORY_OPTIMIZATION)
+    if (_options.MEMORY_OPTIMIZATION )
     {
         memoptim_subprob_builder_ = std::make_shared<MemOptimSubProblemBuilder>(
           _options.INPUTROOT,

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -58,6 +58,7 @@ void BendersMpi::InitializeProblems()
 
     else
     {
+        std::cout<<"not memory optim case "<<std::endl ; 
         if (_options.CACHE_PROBLEMS)
         {
             int current_problem_id = 0;

--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -26,9 +26,39 @@ Benders_MICRO_ITERS::Benders_MICRO_ITERS(const SimulationOptions& options,
                                                        constraints_coupling_map_,
                                                        options_);
 
+
+
+    // if (options.MEMORY_OPTIMIZATION)
+    // {
+    //     std::cout<<"from benders micro iters memory optimization "<<std::endl ; 
+
+    //     std::cout<<"printing sub names "<<std::endl ;
+    //     for (auto& [sub_name,_] : subproblem_constraint_map_) 
+    //     {
+    //         std::cout<<"sub name "<<sub_name<<std::endl ; 
+    //     }
+
+    //     std::cout<<"printing constraint names "<<std::endl ; 
+    //     for (auto& [constraint,_] : constraints_coupling_map_)  
+    //     {
+    //         std::cout<<"constraint "<<constraint<<std::endl ; 
+    //     }
+
+    //     std::cout<<"printing sub constrain map "<<std::endl ; 
+    //     for (auto& [sub, constraint] : subproblem_constraint_map_) 
+    //     {
+    //         std::cout<<"sub "<<sub<<" constraint "<<constraint<<std::endl ; 
+    //     }
+
+
+    // }
+
+                        
+
     input_root_ = options_.INPUTROOT;
     warm_start_ = true;
     _world = world;
+    // _world->abort(EXIT_FAILURE);
 
     for (auto& [sub_name, _]: coupling_map_)
     {
@@ -181,6 +211,7 @@ void Benders_MICRO_ITERS::read_micro_iteration_config_file()
     else
     {
         std::cerr << "unable to open : " << mirco_iterations_options_path.string() << std::endl;
+        std::cout<<"after the unable "<<std::endl ; 
         exit(EXIT_FAILURE);
     }
 }
@@ -206,6 +237,7 @@ void Benders_MICRO_ITERS::read_variable_names_to_follow()
     else
     {
         std::cerr << "unable to open : " << variable_names_path.string() << std::endl;
+        std::cout<<"after unable to open" <<std::endl ; 
         exit(EXIT_FAILURE);
     }
 }
@@ -217,7 +249,16 @@ void Benders_MICRO_ITERS::OnBendersStart(const SubproblemsMapPtr& subproblem_map
 {
     _logger = logger;
 
-    BuildSubproblemConstraintsManagerMap(subproblem_map, options, solver_log_manager);
+    std::cout<<"on benders start "<<std::endl ;
+    
+    if (!options.MEMORY_OPTIMIZATION)
+    {
+        std::cout<<"case no memory optimization "<<std::endl ; 
+        BuildSubproblemConstraintsManagerMap(subproblem_map, options, solver_log_manager);
+    }
+    else 
+        BuildResourcesForMemOptim(options,solver_log_manager) ; 
+
 
     onBendersStartPlugin_(sub_pb_ids_,
                           _world->rank(),
@@ -360,7 +401,7 @@ void Benders_MICRO_ITERS::SetSubProblemIDs(const char** subs_ids, int n_subs)
     {
         sub_ids_ptrs_[i] = sub_ids_storage_[i].c_str();
     }
-
+ 
     sub_pb_ids_ = SubProblemIds{sub_ids_ptrs_.data(), n_subs};
 }
 
@@ -386,3 +427,14 @@ void Benders_MICRO_ITERS::BuildSubproblemConstraintsManagerMap(
           sub_worker);
     }
 }
+
+void Benders_MICRO_ITERS::BuildResourcesForMemOptim( const BendersBaseOptions& options,
+                                                     const SolverLogManager& solver_log_manager)
+{
+
+
+    std::cout<<"building constraints file reader from BuildResourcesForMemOptim"<<std::endl ; 
+    constraints_file_reader_mem_optim_ptr_ =   std::make_shared<ConstraintsFileReaderMemOptim>(std::filesystem::path(options.INPUTROOT), options.SOLVER_NAME,
+                                                                            solver_log_manager, _logger, options.LOG_LEVEL, options.PROBLEMS_FORMAT ) ; 
+}
+

--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -9,6 +9,8 @@
 #include <fstream>
 #include <sstream>
 #include <string_view>
+#include <thread>
+#include <chrono>
 
 #include <boost/tokenizer.hpp>
 
@@ -237,7 +239,6 @@ void Benders_MICRO_ITERS::read_variable_names_to_follow()
     else
     {
         std::cerr << "unable to open : " << variable_names_path.string() << std::endl;
-        std::cout<<"after unable to open" <<std::endl ; 
         exit(EXIT_FAILURE);
     }
 }
@@ -249,11 +250,9 @@ void Benders_MICRO_ITERS::OnBendersStart(const SubproblemsMapPtr& subproblem_map
 {
     _logger = logger;
 
-    std::cout<<"on benders start "<<std::endl ;
     
     if (!options.MEMORY_OPTIMIZATION)
     {
-        std::cout<<"case no memory optimization "<<std::endl ; 
         BuildSubproblemConstraintsManagerMap(subproblem_map, options, solver_log_manager);
     }
     else 
@@ -307,6 +306,13 @@ void Benders_MICRO_ITERS::OnBendersMasterResolutionEnd(std::map<std::string, dou
                                   options_.INPUTROOT);
 }
 
+
+void Benders_MICRO_ITERS::build_variables_to_follow_indices_vector_2() 
+{
+    for (auto& [sub_name, constraint_reader_name] : )
+}   
+
+
 void Benders_MICRO_ITERS::build_variables_to_follow_indices_vector(std::string sub_name)
 {
     // TODO: Get variables index in sub only once at benders start (need to iterate over all subs,
@@ -334,6 +340,7 @@ void Benders_MICRO_ITERS::OnBendersMasterResolutionStart()
 
 void Benders_MICRO_ITERS::OnBendersMicroIterationStart()
 {
+
     if (OnBendersMicroIterationStart_)
     {
         OnBendersMicroIterationStart_();
@@ -346,6 +353,7 @@ void Benders_MICRO_ITERS::OnBendersMicroIterationEnd(std::string sub_name,
                                                      int num_master_iter,
                                                      int num_micro_iter)
 {
+
     std::string constraints_manager_name = subproblem_constraint_map_[sub_name];
     auto sub_constraints_manager = constraints_map_[constraints_manager_name];
 
@@ -354,7 +362,9 @@ void Benders_MICRO_ITERS::OnBendersMicroIterationEnd(std::string sub_name,
     std::vector<int> variables_indices = variables_to_follow_indices_per_sub_[sub_name];
 
     std::vector<std::string> constraints_to_add_vec;
-    OnBendersMicroIterationEnd_(sub_name,
+    auto pos = sub_name.rfind('/');
+    auto new_sub_name = sub_name.substr(pos + 1) ; 
+    OnBendersMicroIterationEnd_(new_sub_name,
                                 added_rows,
                                 solving_time,
                                 sub_solution,
@@ -433,7 +443,6 @@ void Benders_MICRO_ITERS::BuildResourcesForMemOptim( const BendersBaseOptions& o
 {
 
 
-    std::cout<<"building constraints file reader from BuildResourcesForMemOptim"<<std::endl ; 
     constraints_file_reader_mem_optim_ptr_ =   std::make_shared<ConstraintsFileReaderMemOptim>(std::filesystem::path(options.INPUTROOT), options.SOLVER_NAME,
                                                                             solver_log_manager, _logger, options.LOG_LEVEL, options.PROBLEMS_FORMAT ) ; 
 }

--- a/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/Benders_MICRO_ITERS.h
+++ b/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/Benders_MICRO_ITERS.h
@@ -187,6 +187,7 @@ private:
 
     void read_variables_to_follow_ids();
     void read_variable_names_to_follow();
+    void build_variables_to_follow_indices_vector_2() ; 
     void build_variables_to_follow_indices_vector(std::string sub_name);
     const std::map<std::string, std::vector<int>>& get_variables_to_follow_indeices_vector();
 

--- a/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/Benders_MICRO_ITERS.h
+++ b/src/cpp/benders/plugins/include/antares-xpansion/benders/plugins/Benders_MICRO_ITERS.h
@@ -27,6 +27,9 @@ Benders_MICRO_ITERS class.
 #include "antares-xpansion/benders/plugins/BendersPlugin.h"
 #include "antares-xpansion/xpansion_interfaces/ILogger.h"
 
+#include "antares-xpansion/benders/benders_core/ConstraintsFileReaderMemOptim.h" 
+
+
 /*
     This structure will be used to set the subproblems ids on the Julia side
     @members :
@@ -167,6 +170,9 @@ private:
                                               const BendersBaseOptions& options,
                                               const SolverLogManager& solver_log_manager);
 
+    void BuildResourcesForMemOptim( const BendersBaseOptions& options,
+                                    const SolverLogManager& solver_log_manager);
+
     /*
         This function is used to check if a constraint key rendered by the julia cde
         has been added or not to the subproblem worker.
@@ -190,6 +196,7 @@ private:
 #else
     void* handle_;
 #endif
+
 
     on_Benders_start_Func onBendersStartPlugin_;
     on_Benders_end_Func OnBendersEndPlugin_;
@@ -217,6 +224,8 @@ private:
     CouplingMap constraints_coupling_map_;
     SubProblemConstraintMap subproblem_constraint_map_;
     SubproblemConstraintsManagerPtrMap constraints_map_;
+    std::shared_ptr<ConstraintsFileReaderMemOptim> constraints_file_reader_mem_optim_ptr_ ; 
     Logger _logger;
     bool warm_start_;
+ 
 };

--- a/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
+++ b/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
@@ -278,6 +278,18 @@ public:
         solver_abstract_->chg_coef(id_row, id_col, val);
     }
 
+
+    void chg_rhs_values(std::vector<int>& id_cols, std::vector<double>&  vals) 
+    {
+        solver_abstract_->chg_rhs_values(id_cols,vals) ;    
+    }
+  
+
+    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) 
+    {
+        solver_abstract_->chg_coefs(num_coefs,id_rows,id_cols,vals) ; 
+    }
+    
     void chg_row_name(int id_row, const std::string& name) override
     {
         solver_abstract_->chg_row_name(id_row, name);

--- a/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
+++ b/src/cpp/lpnamer/model/include/antares-xpansion/lpnamer/model/Problem.h
@@ -278,18 +278,16 @@ public:
         solver_abstract_->chg_coef(id_row, id_col, val);
     }
 
-
-    void chg_rhs_values(std::vector<int>& id_cols, std::vector<double>&  vals) 
+    void chg_rhs_values(std::vector<int>& id_cols, std::vector<double>& vals)
     {
-        solver_abstract_->chg_rhs_values(id_cols,vals) ;    
+        solver_abstract_->chg_rhs_values(id_cols, vals);
     }
-  
 
-    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) 
+    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals)
     {
-        solver_abstract_->chg_coefs(num_coefs,id_rows,id_cols,vals) ; 
+        solver_abstract_->chg_coefs(num_coefs, id_rows, id_cols, vals);
     }
-    
+
     void chg_row_name(int id_row, const std::string& name) override
     {
         solver_abstract_->chg_row_name(id_row, name);

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -713,6 +713,12 @@ void SolverCbc::chg_rhs(int id_row, double val)
     }
 }
 
+
+void SolverCbc::chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals)
+{
+
+}
+
 void SolverCbc::chg_coef(int id_row, int id_col, double val)
 {
     // Very tricky method by method "modifyCoefficient" of OsiClp does not work
@@ -953,3 +959,9 @@ void SolverCbc::get_presolve_map(int*, int*) const
 {
     throw NotImplementedFeatureSolverException("get_presolve_map is not supported for CBC solver");
 }
+
+
+void SolverCbc::chg_rhs_values(std::vector<int>&, std::vector<double>& ) 
+{
+    
+} 

--- a/src/cpp/multisolver_interface/SolverCbc.cpp
+++ b/src/cpp/multisolver_interface/SolverCbc.cpp
@@ -713,10 +713,8 @@ void SolverCbc::chg_rhs(int id_row, double val)
     }
 }
 
-
 void SolverCbc::chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals)
 {
-
 }
 
 void SolverCbc::chg_coef(int id_row, int id_col, double val)
@@ -960,8 +958,6 @@ void SolverCbc::get_presolve_map(int*, int*) const
     throw NotImplementedFeatureSolverException("get_presolve_map is not supported for CBC solver");
 }
 
-
-void SolverCbc::chg_rhs_values(std::vector<int>&, std::vector<double>& ) 
+void SolverCbc::chg_rhs_values(std::vector<int>&, std::vector<double>&)
 {
-    
-} 
+}

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -584,18 +584,13 @@ void SolverClp::chg_coef(int id_row, int id_col, double val)
     matrix->modifyCoefficient(id_row, id_col, val);
 }
 
-void SolverClp::chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) 
+void SolverClp::chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals)
 {
-
 }
 
-
-void SolverClp::chg_rhs_values(std::vector<int>& rhs_indices, std::vector<double>& rhs_values ) 
+void SolverClp::chg_rhs_values(std::vector<int>& rhs_indices, std::vector<double>& rhs_values)
 {
-
-} 
-
-
+}
 
 void SolverClp::chg_row_name(int id_row, const std::string& name)
 {

--- a/src/cpp/multisolver_interface/SolverClp.cpp
+++ b/src/cpp/multisolver_interface/SolverClp.cpp
@@ -584,6 +584,19 @@ void SolverClp::chg_coef(int id_row, int id_col, double val)
     matrix->modifyCoefficient(id_row, id_col, val);
 }
 
+void SolverClp::chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) 
+{
+
+}
+
+
+void SolverClp::chg_rhs_values(std::vector<int>& rhs_indices, std::vector<double>& rhs_values ) 
+{
+
+} 
+
+
+
 void SolverClp::chg_row_name(int id_row, const std::string& name)
 {
     std::string copy_name = name;

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -296,10 +296,7 @@ void SolverXpress::set_obj_to_zero()
     auto ncols = get_ncols();
     std::vector<double> zeros_val(ncols, 0.0);
     set_obj(zeros_val.data(), 0, ncols);
-
 }
-
-
 
 void SolverXpress::set_obj(const double* obj, int first, int last)
 {
@@ -574,24 +571,18 @@ void SolverXpress::chg_col_type(const std::vector<int>& mindex, const std::vecto
     zero_status_check(status, "change column types", LOGLOCATION);
 }
 
-void SolverXpress::chg_rhs_values(std::vector<int>& id_rows, std::vector<double>& vals )   
+void SolverXpress::chg_rhs_values(std::vector<int>& id_rows, std::vector<double>& vals)
 {
-    int status = XPRSchgrhs(_xprs,
-                            id_rows.size(),
-                            id_rows.data(),
-                            vals.data());
-                            
+    int status = XPRSchgrhs(_xprs, id_rows.size(), id_rows.data(), vals.data());
+
     zero_status_check(status, "change rhs", LOGLOCATION);
 }
 
-
-
-void SolverXpress::chg_coefs(int num_coefs ,int* id_rows, int* id_cols, double* vals) 
+void SolverXpress::chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals)
 {
-    int status = XPRSchgmcoef(_xprs,num_coefs,id_rows,id_cols,vals); 
+    int status = XPRSchgmcoef(_xprs, num_coefs, id_rows, id_cols, vals);
     zero_status_check(status, "change matrix coefficient", LOGLOCATION);
-
-} 
+}
 
 void SolverXpress::chg_rhs(int id_row, double val)
 {

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <utility>
 
+
 #include "antares-xpansion/xpansion_interfaces/StringManip.h"
 
 using namespace LoadXpress;
@@ -101,6 +102,7 @@ SolverXpress::SolverXpress(const SolverXpress& toCopy):
 
 SolverXpress::~SolverXpress()
 {
+
     number_of_problems_counter() -= 1;
     SolverXpress::free();
 

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -8,7 +8,6 @@
 #include <set>
 #include <utility>
 
-
 #include "antares-xpansion/xpansion_interfaces/StringManip.h"
 
 using namespace LoadXpress;
@@ -102,7 +101,6 @@ SolverXpress::SolverXpress(const SolverXpress& toCopy):
 
 SolverXpress::~SolverXpress()
 {
-
     number_of_problems_counter() -= 1;
     SolverXpress::free();
 

--- a/src/cpp/multisolver_interface/SolverXpress.cpp
+++ b/src/cpp/multisolver_interface/SolverXpress.cpp
@@ -296,7 +296,10 @@ void SolverXpress::set_obj_to_zero()
     auto ncols = get_ncols();
     std::vector<double> zeros_val(ncols, 0.0);
     set_obj(zeros_val.data(), 0, ncols);
+
 }
+
+
 
 void SolverXpress::set_obj(const double* obj, int first, int last)
 {
@@ -570,6 +573,25 @@ void SolverXpress::chg_col_type(const std::vector<int>& mindex, const std::vecto
                                 qctype.data());
     zero_status_check(status, "change column types", LOGLOCATION);
 }
+
+void SolverXpress::chg_rhs_values(std::vector<int>& id_rows, std::vector<double>& vals )   
+{
+    int status = XPRSchgrhs(_xprs,
+                            id_rows.size(),
+                            id_rows.data(),
+                            vals.data());
+                            
+    zero_status_check(status, "change rhs", LOGLOCATION);
+}
+
+
+
+void SolverXpress::chg_coefs(int num_coefs ,int* id_rows, int* id_cols, double* vals) 
+{
+    int status = XPRSchgmcoef(_xprs,num_coefs,id_rows,id_cols,vals); 
+    zero_status_check(status, "change matrix coefficient", LOGLOCATION);
+
+} 
 
 void SolverXpress::chg_rhs(int id_row, double val)
 {

--- a/src/cpp/multisolver_interface/environment.cc
+++ b/src/cpp/multisolver_interface/environment.cc
@@ -146,6 +146,7 @@ std::function<int(XPRSprob prob, int nrows, const int rowind[], const double rhs
   XPRSchgrhs = nullptr;
 
 std::function<int(XPRSprob prob, int row, int col, double coef)> XPRSchgcoef = nullptr;
+std::function<int(XPRSprob prob, int ncoefs, const int mrow[], const int mcol[], const double dval[])> XPRSchgmcoef = nullptr;
 std::function<int(XPRSprob prob, int rowstat[], int colstat[])> XPRSgetbasis = nullptr;
 std::function<int(XPRSprob prob, int attrib, double* p_value)> XPRSgetdblattrib = nullptr;
 std::function<int(XPRSprob prob, double x[], double slack[], double duals[], double djs[])>
@@ -219,6 +220,7 @@ bool XpressLoader::LoadXpressFunctions(Solver::DynamicLibrary* xpress_dynamic_li
     xpress_dynamic_library->GetFunction(&XPRSchgrhs, "XPRSchgrhs");
     xpress_dynamic_library->GetFunction(&XPRSchgcoef, "XPRSchgcoef");
     xpress_dynamic_library->GetFunction(&XPRSgetbasis, "XPRSgetbasis");
+    xpress_dynamic_library->GetFunction(&XPRSchgmcoef, "XPRSchgmcoef");
     xpress_dynamic_library->GetFunction(&XPRSgetlpsol, "XPRSgetlpsol");
     xpress_dynamic_library->GetFunction(&XPRSgetdblattrib, "XPRSgetdblattrib");
     xpress_dynamic_library->GetFunction(&XPRSgetmipsol, "XPRSgetmipsol");

--- a/src/cpp/multisolver_interface/environment.cc
+++ b/src/cpp/multisolver_interface/environment.cc
@@ -146,7 +146,9 @@ std::function<int(XPRSprob prob, int nrows, const int rowind[], const double rhs
   XPRSchgrhs = nullptr;
 
 std::function<int(XPRSprob prob, int row, int col, double coef)> XPRSchgcoef = nullptr;
-std::function<int(XPRSprob prob, int ncoefs, const int mrow[], const int mcol[], const double dval[])> XPRSchgmcoef = nullptr;
+std::function<
+  int(XPRSprob prob, int ncoefs, const int mrow[], const int mcol[], const double dval[])>
+  XPRSchgmcoef = nullptr;
 std::function<int(XPRSprob prob, int rowstat[], int colstat[])> XPRSgetbasis = nullptr;
 std::function<int(XPRSprob prob, int attrib, double* p_value)> XPRSgetdblattrib = nullptr;
 std::function<int(XPRSprob prob, double x[], double slack[], double duals[], double djs[])>

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -734,6 +734,7 @@ public:
      */
     virtual void chg_coef(int id_row, int id_col, double val) = 0;
 
+
     /**
      * @brief Change multiple coefficients in the matrix
      *

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -734,7 +734,6 @@ public:
      */
     virtual void chg_coef(int id_row, int id_col, double val) = 0;
 
-
     /**
      * @brief Change multiple coefficients in the matrix
      *

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -718,6 +718,15 @@ public:
     virtual void chg_rhs(int id_row, double val) = 0;
 
     /**
+     * @brief Change rhs of a row
+     *
+     * @param id_row : list of indices of the row
+     * @param vals    : list of new rhs values
+     */
+    virtual void chg_rhs_values(std::vector<int>& id_cols, std::vector<double>&  vals) = 0 ; 
+
+
+    /**
      * @brief Change a coefficient in the matrix
      *
      * @param id_row : index of the row
@@ -725,6 +734,17 @@ public:
      * @param val    : new value to set in the matrix
      */
     virtual void chg_coef(int id_row, int id_col, double val) = 0;
+
+
+    /**
+     * @brief Change multiple coefficients in the matrix
+     *
+     * @param num_coefs : number of coefficients to change
+     * @param id_rows   : array of row indices
+     * @param id_cols   : array of column indices
+     * @param vals      : array of new values to set in the matrix
+     */
+    virtual void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) = 0;
 
     /**
      * @brief Change the name of a constraint

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverAbstract.h
@@ -723,8 +723,7 @@ public:
      * @param id_row : list of indices of the row
      * @param vals    : list of new rhs values
      */
-    virtual void chg_rhs_values(std::vector<int>& id_cols, std::vector<double>&  vals) = 0 ; 
-
+    virtual void chg_rhs_values(std::vector<int>& id_cols, std::vector<double>& vals) = 0;
 
     /**
      * @brief Change a coefficient in the matrix
@@ -734,7 +733,6 @@ public:
      * @param val    : new value to set in the matrix
      */
     virtual void chg_coef(int id_row, int id_col, double val) = 0;
-
 
     /**
      * @brief Change multiple coefficients in the matrix

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverXpress.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverXpress.h
@@ -166,7 +166,7 @@ public:
                     const std::vector<double>& bnd) override;
     void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) override;
     void chg_rhs(int id_row, double val) override;
-    void chg_rhs_values(std::vector<int>&, std::vector<double>& )override ; 
+    void chg_rhs_values(std::vector<int>&, std::vector<double>&) override;
     void chg_coef(int id_row, int id_col, double val) override;
     void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) override;
     void chg_row_name(int id_row, const std::string& name) override;

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverXpress.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/SolverXpress.h
@@ -166,7 +166,9 @@ public:
                     const std::vector<double>& bnd) override;
     void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) override;
     void chg_rhs(int id_row, double val) override;
+    void chg_rhs_values(std::vector<int>&, std::vector<double>& )override ; 
     void chg_coef(int id_row, int id_col, double val) override;
+    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) override;
     void chg_row_name(int id_row, const std::string& name) override;
     void chg_col_name(int id_col, const std::string& name) override;
 

--- a/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/environment.h
+++ b/src/cpp/multisolver_interface/include/antares-xpansion/multisolver_interface/environment.h
@@ -478,6 +478,7 @@ extern std::function<int(XPRSprob prob, int nbounds, const int colind[], const c
 extern std::function<int(XPRSprob prob, int ncols, const int colind[], const char coltype[])> XPRSchgcoltype;
 extern std::function<int(XPRSprob prob, int nrows, const int rowind[], const double rhs[])> XPRSchgrhs;
 extern std::function<int(XPRSprob prob, int row, int col, double coef)> XPRSchgcoef;
+extern std::function<int(XPRSprob prob, int ncoefs, const int mrow[], const int mcol[], const double dval[])> XPRSchgmcoef;
 extern std::function<int(XPRSprob prob, int rowstat[], int colstat[])> XPRSgetbasis;
 extern std::function<int(XPRSprob prob, int attrib, double* p_value)> XPRSgetdblattrib;
 extern std::function<int(XPRSprob prob, double x[], double slack[], double duals[], double djs[])> XPRSgetlpsol;

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -155,7 +155,7 @@ public:
                     const std::vector<double>& bnd) override;
     void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) override;
     void chg_rhs(int id_row, double val) override;
-    void chg_rhs_values(std::vector<int>&, std::vector<double>& ) override; 
+    void chg_rhs_values(std::vector<int>&, std::vector<double>&) override;
     void chg_coef(int id_row, int id_col, double val) override;
     void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) override;
     void chg_row_name(int id_row, const std::string& name) override;

--- a/src/cpp/multisolver_interface/private/SolverCbc.h
+++ b/src/cpp/multisolver_interface/private/SolverCbc.h
@@ -155,7 +155,9 @@ public:
                     const std::vector<double>& bnd) override;
     void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) override;
     void chg_rhs(int id_row, double val) override;
+    void chg_rhs_values(std::vector<int>&, std::vector<double>& ) override; 
     void chg_coef(int id_row, int id_col, double val) override;
+    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) override;
     void chg_row_name(int id_row, const std::string& name) override;
     void chg_col_name(int id_col, const std::string& name) override;
 

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -156,8 +156,8 @@ public:
     void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) override;
     void chg_rhs(int id_row, double val) override;
     void chg_coef(int id_row, int id_col, double val) override;
-    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) ;
-    void chg_rhs_values(std::vector<int>&, std::vector<double>& ) ; 
+    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals);
+    void chg_rhs_values(std::vector<int>&, std::vector<double>&);
     void chg_row_name(int id_row, const std::string& name) override;
     void chg_col_name(int id_col, const std::string& name) override;
 

--- a/src/cpp/multisolver_interface/private/SolverClp.h
+++ b/src/cpp/multisolver_interface/private/SolverClp.h
@@ -156,6 +156,8 @@ public:
     void chg_col_type(const std::vector<int>& mindex, const std::vector<char>& qctype) override;
     void chg_rhs(int id_row, double val) override;
     void chg_coef(int id_row, int id_col, double val) override;
+    void chg_coefs(int num_coefs, int* id_rows, int* id_cols, double* vals) ;
+    void chg_rhs_values(std::vector<int>&, std::vector<double>& ) ; 
     void chg_row_name(int id_row, const std::string& name) override;
     void chg_col_name(int id_col, const std::string& name) override;
 


### PR DESCRIPTION
An antares-xpansion study can be very heavy in terms of RAM usage. Indeed, before this PR, we need to initialize the Benders object with all the MPS files and create the solver abstract object corresponding to each subproblem to solve.
However, subproblems tend to have the same structure with certain differences in the objective function and the constraints.
This PR introduces a new way of reading the MPS files: instead of having an MPS file per subproblem, we will have a single MPS file (that we call the skeleton) and we will have CSV files that contain what we should change in the skeleton to build the corresponding subproblem.
This way the subproblem worker will be created only at the moment we need to solve it by doing the right changes in the skeleton.
This approach can significantly reduce RAM usage and make it possible to solve studies with a significant number of subproblems.