### PR TITLE
Fix 4 build warnings

### DIFF
--- a/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersFactory.h
+++ b/src/cpp/benders/factories/include/antares-xpansion/benders/factories/BendersFactory.h
@@ -63,10 +63,10 @@ private:
     void ConfigureSolverLog(BendersBase* benders);
 
     const SimulationOptions& options_;
-    Dependencies dependencies_;
     boost::mpi::communicator* world_ = nullptr;
-    std::shared_ptr<BendersPluginFactory> benders_plugin_factory_;
     int rank = 0;
+    Dependencies dependencies_;
+    std::shared_ptr<BendersPluginFactory> benders_plugin_factory_;
     BENDERSMETHOD method_;
     std::string context_ = bendersmethod_to_string(BENDERSMETHOD::BENDERS);
     static constexpr const char* const LOLD_FILE = "LOLD.txt";

--- a/tests/cpp/logger/logger_test.cpp
+++ b/tests/cpp/logger/logger_test.cpp
@@ -1075,7 +1075,6 @@ TEST(MathLoggerBendersByBatchTest, DataInFileLong)
 
 TEST(MathLoggerBendersByBatchTest, DataInStdOutShort)
 {
-    HEADERSTYPE headers_type = HEADERSTYPE::SHORT;
     std::streamsize width = 25;
 
     CurrentIterationData data;
@@ -1195,7 +1194,6 @@ TEST(MathLoggerBendersBaseTest, DataInFileLong)
 
 TEST(MathLoggerBendersBaseTest, DataInStdOutShort)
 {
-    HEADERSTYPE headers_type = HEADERSTYPE::SHORT;
     std::streamsize width = 25;
 
     CurrentIterationData data;

--- a/tests/cpp/lp_namer/StudyUpdateTest.cc
+++ b/tests/cpp/lp_namer/StudyUpdateTest.cc
@@ -417,7 +417,8 @@ TEST_F(UpdateCapacitiesTest, update_one_link_no_candidate) {
 TEST_F(UpdateCapacitiesTest, update_one_link_one_candidate) {
   ActiveLink active_link(0, "dummy_link", "area1", "area2", 100, logger);
   CandidateData candidate{true, "dummy_link", 0, "area1",          "area2",
-                          "",   "",           1, "dummy_candidate"};
+                          "",   "",           1, "dummy_candidate",
+                          0, 0, 0, 0, "", ""};
   LinkProfile profile(logger);
   active_link.addCandidate(candidate, {profile});
   std::map<std::string, double> solution{
@@ -436,7 +437,8 @@ TEST_F(UpdateCapacitiesTest, update_one_link_one_candidate) {
 TEST_F(UpdateCapacitiesTest, update_version_720) {
   ActiveLink active_link(0, "dummy_link", "area1", "area2", 100, logger);
   CandidateData candidate{true, "dummy_link", 0, "area1",          "area2",
-                          "",   "",           1, "dummy_candidate"};
+                          "",   "",           1, "dummy_candidate",
+                          0, 0, 0, 0, "", ""};
   LinkProfile profile(logger);
   active_link.addCandidate(candidate, {profile});
   std::map<std::string, double> solution{
@@ -458,7 +460,8 @@ TEST_F(UpdateCapacitiesTest, update_version_720) {
 TEST_F(UpdateCapacitiesTest, update_link_parameters_version_720) {
   ActiveLink active_link(0, "dummy_link", "area1", "area2", 100, logger);
   CandidateData candidate{true, "dummy_link", 0, "area1",          "area2",
-                          "",   "",           1, "dummy_candidate"};
+                          "",   "",           1, "dummy_candidate",
+                          0, 0, 0, 0, "", ""};
   LinkProfile profile(logger);
   active_link.addCandidate(candidate, {profile});
   std::map<std::string, double> solution{
@@ -493,7 +496,8 @@ TEST_F(UpdateCapacitiesTest, update_link_parameters_version_720) {
 TEST_F(UpdateCapacitiesTest, update_version_800) {
   ActiveLink active_link(0, "dummy_link", "area1", "area2", 100, logger);
   CandidateData candidate{true, "dummy_link", 0, "area1",          "area2",
-                          "",   "",           1, "dummy_candidate"};
+                          "",   "",           1, "dummy_candidate",
+                          0, 0, 0, 0, "", ""};
   LinkProfile profile(logger);
   active_link.addCandidate(candidate, {profile});
   std::map<std::string, double> solution{
@@ -515,7 +519,8 @@ TEST_F(UpdateCapacitiesTest, update_version_800) {
 TEST_F(UpdateCapacitiesTest, update_link_parameters_version_800) {
   ActiveLink active_link(0, "dummy_link", "area1", "area2", 100, logger);
   CandidateData candidate{true, "dummy_link", 0, "area1",          "area2",
-                          "",   "",           1, "dummy_candidate"};
+                          "",   "",           1, "dummy_candidate",
+                          0, 0, 0, 0, "", ""};
   LinkProfile profile(logger);
   active_link.addCandidate(candidate, {profile});
   std::map<std::string, double> solution{
@@ -636,7 +641,8 @@ TEST_F(UpdateCapacitiesTest,
 TEST_F(UpdateCapacitiesTest, update_link_parameters_version_820) {
   ActiveLink active_link(0, "dummy_link", "area1", "area2", 100, logger);
   CandidateData candidate{true, "dummy_link", 0, "area1",          "area2",
-                          "",   "",           1, "dummy_candidate"};
+                          "",   "",           1, "dummy_candidate",
+                          0, 0, 0, 0, "", ""};
   LinkProfile profile(logger);
   active_link.addCandidate(candidate, {profile});
   std::map<std::string, double> solution{

--- a/tests/cpp/solvers_interface/test_exceptions.cpp
+++ b/tests/cpp/solvers_interface/test_exceptions.cpp
@@ -198,7 +198,7 @@ TEST_CASE("InvalidSetOptimatilityGap", "[exceptions][set_optimality_gap]")
 
 TEST_CASE("InvalidSolverNameException", "[exceptions][invalid_solver_name]")
 {
-    for (const std::string& solver_name: {"SIRIUS", "GUROBI"})
+    for (const std::string solver_name: {"SIRIUS", "GUROBI"})
     {
         SolverFactory factory;
         try


### PR DESCRIPTION
 1. Range-loop type warning (test_exceptions.cpp): Changed `const std::string& solver_name` to `std::string solver_name` 
 2. Member initialization order warning (BendersFactory.h): Reordered member declarations to match the constructor's init-list order: `options_`, `world_`, `rank`, `dependencies_`.
 3. Missing field initializers (StudyUpdateTest.cc): Added the missing `direct_link_profile` and `indirect_link_profile` fields (plus the remaining struct fields) to all 6 `CandidateData` initializers.
 4. Unused variable warnings (logger_test.cpp): Removed the unused `HEADERSTYPE headers_type` variable from both `DataInStdOutShort` test cases.