### PR TITLE
chore(doc) Remove polyfill.io JS dependency - compromised library

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,6 @@ extra_css:
 
 extra_javascript:
   - https://code.jquery.com/jquery-3.6.0.min.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
 


### PR DESCRIPTION
mkdocs uses polyfill.io to enhance compatibility with old browsers. However the polyfill.io website has been compromised in 2024.

See https://www.cert.ssi.gouv.fr/actualite/CERTFR-2024-ACT-030/