### PR TITLE
feat(benders): add dlopen error log for plugin loading

### DIFF
--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -134,6 +134,7 @@ Benders_MICRO_ITERS::Benders_MICRO_ITERS(const SimulationOptions& options,
     {
         std::cerr << "failed to open the plugin given on path " << cpp_lib_absolute_path
                   << std::endl;
+        std::cerr<<"error "<<dlerror()<<std::endl ; 
         _world->abort(EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
## Summary
- Log the `dlerror()` message when `dlopen` fails to load a plugin in `Benders_MICRO_ITERS`, making it easier to diagnose shared library loading issues.

## Test plan
- [ ] Build and verify the error message is printed when a plugin path is invalid or the library has missing dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)