### PR TITLE
Fix operational discounting off-by-one and clarify trajectory investment documentation

### DIFF
--- a/docs/reference/trajectory-investment/index.md
+++ b/docs/reference/trajectory-investment/index.md
@@ -4,13 +4,13 @@
 Recall the annual investment problem in Xpansion :
 
 $$
-\min_{x \in \mathcal{X}} \quad C^T x + \text{ANTARES}(x)
+\min_{x \in \mathcal{X}} \quad \sum_i C_i \, x_i + \text{ANTARES}(x)
 $$
 
-over a set of investment variables specified by the user, where :
+over a set of investment variables specified by the user, where, denoting by $i$ a candidate :
 
-- $x$ is the vector of the capacities installed for each candidate
-- $C$ contains the fixed cost annuities of those candidates
+- $x_i$ is the capacity installed for candidate $i$, and $x = (x_i)_i$ is the vector of those capacities
+- $C_i$ is the fixed cost annuity of candidate $i$, given by its ```annual-cost-per-mw``` entry in the study's [```candidates.ini```](../inputs/candidates.md) file
 - $\text{ANTARES}(x)$ is the operating cost of the system for a given investment level.
 
 ## Switching to a pluriannual vision
@@ -21,11 +21,11 @@ We want to switch to a pluriannual vision and optimise the investments over seve
 
 **Figure 1** - Trajectory tree made up of annual Xpansion studies
 
-The optimisation problem we now want to solve is, denoting by $n \in \mathcal{T}$ a node in the tree:
+The optimisation problem we now want to solve is, denoting by $n \in \mathcal{T}$ a node in the tree, by $i$ a candidate and by $x_n = (x_{i,n})_i$ the vector of the capacities installed at node $n$:
 
 $$
 \begin{aligned}
-    \min_{x, dx^+, dx^-} \quad & \sum_{n \in \mathcal{T}} wIC_n^T dx_n^+ + wDC_n^T dx_n^- + wOC_n^Tx_{n} + w_{n} \times ANTARES_n(x_n)\\\\
+    \min_{x, dx^+, dx^-} \quad & \sum_{n \in \mathcal{T}} \left[ \sum_i \left( wIC_{i,n} \, dx^+_{i,n} + wDC_{i,n} \, dx^-_{i,n} + wOC_{i,n} \, x_{i,n} \right) + w_n \times ANTARES_n(x_n) \right]\\\\
     \text{s.t.} \quad & \forall i,n \quad  x_{i,n} = x_{i, \text{parent}(n)} + dx^+_{i,n}
     - dx^-_{i,n} \\\\
     & \forall i,n \quad dx^+_{i,n} \geq 0, \quad dx^-_{i,n} \geq 0 \\\\
@@ -33,12 +33,14 @@ $$
 \end{aligned}
 $$
 
-- $wIC_n$ contains the already weighted (for probability of the node) and discounted one-time payment investment costs per MW.
-- $wDC_n$ contains the already weighted (for probability of the node) and discounted one-time payment retirement costs per MW.
-- $wOC_n$ contains the already weighted (for represented duration of the node & probability) and discounted operation and maintenance fixed costs.
-- $w(n) = P(n) \times \sum_{y = y_n}^{y = y_n + d_n - 1} \frac{1}{(1+r)^{y - y_0}}$.
-- $P(n)$ is the probability of realisation of node $n$ : $P(n) = P_{\text{parent}(n)}(n) \times P(\text{parent}(n))$.
-- $P(root) = 1$.
+with $r$ the discount rate, $y_0$ the first investment year, $y_n$ the investment date of node $n$ and $d_n$ its represented duration ($d_n$ = next investment date $- y_n$, or end of horizon $- y_n$ for a leaf) :
+
+- $p_n$ is the transition probability from $\text{parent}(n)$ to $n$.
+- $P(n)$ is the probability of realisation of node $n$ : $P(n) = p_n \times P(\text{parent}(n))$, with $P(\text{root}) = 1$.
+- $w_n = P(n) \times \sum_{y = y_n}^{y = y_n + d_n - 1} \frac{1}{(1+r)^{y - y_0}}$.
+- $wIC_{i,n} = P(n) \times \frac{1}{(1+r)^{y_n - y_0}} \times IC_i$, the weighted and discounted one-time payment investment cost per MW.
+- $wDC_{i,n} = P(n) \times \frac{1}{(1+r)^{y_n - y_0}} \times DC_i$, same for the retirement cost per MW.
+- $wOC_{i,n} = w_n \times OC_i$, the weighted and discounted operation and maintenance fixed cost per MW, paid every year of the period.
 
 !!! note "On the $dx^{+/-}$ variables"
 
@@ -47,3 +49,34 @@ $$
     We can impose the decisions to be the same in all children of a given node (see [trajectory constraints](./merge-master.md#trajectory-constraints)) if we want the investment decision of a given period to be independent of what scenario will materialize in the next period when the new capacities enter into service.
 
     In the example from **Figure 1**, this would mean that the capacity we install in the period [2040, 2050] is independent of wether ```2050_A``` or ```2050_B``` will be realised.
+
+
+## Link with the user input file
+
+Every parameter of the problem comes from the [user input file](./user-input.md), except the bounds $X_{i,n}^{max}$ :
+
+| Parameter | Comes from |
+|---|---|
+| $\mathcal{T}$, $\text{parent}(n)$ | the ```tree``` section |
+| $p_n$ | the ```probability``` entry of the ```tree``` section |
+| $r$ | ```global: discount_rate``` |
+| $y_0$ | ```global: first_investment_year``` |
+| $y_n$ | the ```investment_date``` of the node |
+| $d_n$ | the difference between the ```investment_date``` of the children of $n$ and $y_n$, or ```global: end_of_horizon``` $- \, y_n$ for a leaf |
+| $IC_i$, $DC_i$, $OC_i$ | the ```investment```, ```retirement``` and ```operation_maintenance``` [costs](./user-input.md#candidates-costs) of the type associated to the candidate by the node's ```candidate_to_type``` entry |
+| $ANTARES_n$ | the annual study of the node, given in ```global: studies``` |
+| $x_{i, \text{parent}(\text{root})}$ | ```initial_capacities```, the capacity installed before the first investment date, or before the node where the candidate [first appears](./user-input.md#a-note-on-candidates) |
+| $X_{i,n}^{max}$ | the ```candidates.ini``` of the node's annual study, not the trajectory input file |
+
+The ```constraints``` section adds constraints on the $dx^{+/-}_{i,n}$ variables, ```global: formulation``` sets whether the investment variables are integer or relaxed, and ```global: scaling``` divides every coefficient of the objective without changing the optimal solution.
+
+## Link between the annual and the pluriannual problems
+
+The annual problem is the pluriannual problem with a single node $n$ of duration $d_n$ : being the root, $P(n) = 1$ and $y_n = y_0$, and with no initial capacity nor retirement, $dx^+_{i,n} = x_{i,n}$ and $dx^-_{i,n} = 0$. The objective is then :
+
+$$
+\sum_i \left( IC_i + w_n \, OC_i \right) x_{i,n} + w_n \times ANTARES_n(x_n),
+\qquad w_n = \sum_{k = 0}^{d_n - 1} \frac{1}{(1+r)^{k}}
+$$
+
+Dividing by $w_n$ gives back $\sum_i C_i x_i + \text{ANTARES}(x)$ with $C_i = \frac{IC_i}{w_n} + OC_i$ : the annuity amortises the investment cost over the $d_n$ years of the node.

--- a/docs/reference/trajectory-investment/index.md
+++ b/docs/reference/trajectory-investment/index.md
@@ -37,7 +37,7 @@ with $r$ the discount rate, $y_0$ the first investment year, $y_n$ the investmen
 
 - $p_n$ is the transition probability from $\text{parent}(n)$ to $n$.
 - $P(n)$ is the probability of realisation of node $n$ : $P(n) = p_n \times P(\text{parent}(n))$, with $P(\text{root}) = 1$.
-- $w_n = P(n) \times \sum_{y = y_n}^{y = y_n + d_n - 1} \frac{1}{(1+r)^{y - y_0}}$.
+- $w_n = P(n) \times \sum_{y = y_n + 1}^{y = y_n + d_n} \frac{1}{(1+r)^{y - y_0}}$.
 - $wIC_{i,n} = P(n) \times \frac{1}{(1+r)^{y_n - y_0}} \times IC_i$, the weighted and discounted one-time payment investment cost per MW.
 - $wDC_{i,n} = P(n) \times \frac{1}{(1+r)^{y_n - y_0}} \times DC_i$, same for the retirement cost per MW.
 - $wOC_{i,n} = w_n \times OC_i$, the weighted and discounted operation and maintenance fixed cost per MW, paid every year of the period.
@@ -76,7 +76,12 @@ The annual problem is the pluriannual problem with a single node $n$ of duration
 
 $$
 \sum_i \left( IC_i + w_n \, OC_i \right) x_{i,n} + w_n \times ANTARES_n(x_n),
-\qquad w_n = \sum_{k = 0}^{d_n - 1} \frac{1}{(1+r)^{k}}
 $$
 
-Dividing by $w_n$ gives back $\sum_i C_i x_i + \text{ANTARES}(x)$ with $C_i = \frac{IC_i}{w_n} + OC_i$ : the annuity amortises the investment cost over the $d_n$ years of the node.
+with : 
+
+$$
+w_n = \sum_{k = 1}^{d_n} \frac{1}{(1+r)^{k}} = \frac{1 - \frac{1}{(1+r)^{d_n}}}{r}
+$$
+
+Dividing by $w_n$ gives back $\sum_i C_i x_i + \text{ANTARES}(x)$ with $C_i = \frac{IC_i}{w_n} + OC_i = \frac{r}{1 - \frac{1}{(1+r)^{d_n}}}IC_i + OC_i$ : the annuity amortises the investment cost over the $d_n$ years of the node.

--- a/docs/reference/trajectory-investment/merge-master.md
+++ b/docs/reference/trajectory-investment/merge-master.md
@@ -349,9 +349,9 @@ following manner:
 
 - ```coeffs``` is a dict of investment variable reference to their coefficient in the present constraint. Each reference
   is built as : ```<node_name>::<candidate_name>::<variable_type>```, where variable type is either :
-    - ```x``` when referencing the $x_{n,i}$ variable.
-    - ```dx_plus``` when referencing the $dx_{n,i}^+$ variable.
-    - ```dx_minus``` when referencing the $dx_{n,i}^⁻$ variable.
+    - ```x``` when referencing the $x_{i,n}$ variable.
+    - ```dx_plus``` when referencing the $dx_{i,n}^+$ variable.
+    - ```dx_minus``` when referencing the $dx_{i,n}^-$ variable.
 - ```rhs``` contains the right-hand side of the constraint expression.
 - ```operator``` defines the type of constraint we want to set and expects one of three values :
     - ```<``` for constraints of type : $expression \leq rhs$

--- a/docs/reference/trajectory-investment/user-input.md
+++ b/docs/reference/trajectory-investment/user-input.md
@@ -96,6 +96,14 @@ initial_capacities:
   semibase: 250
 ```
 
+## Candidates costs
+
+Each candidate is associated to a type of the ```candidates_types``` section, which holds its three unitary costs. They are given **undiscounted** and **in euros per MW** : the probability of the node and the discounting are applied by the translator (see [the objective's coefficients](./index.md#switching-to-a-pluriannual-vision)).
+
+- ```investment``` : cost of building 1 MW, paid once when the capacity enters into service.
+- ```operation_maintenance``` : fixed operation and maintenance cost of 1 MW, **per year**, paid every year of the period during which the capacity is available.
+- ```retirement``` : cost of decommissioning 1 MW, paid once when the capacity is removed.
+
 ## Input file parser & translator
 
 - Parses the user input file and verifies that the data given in the file matches with the studies (To be implemented :
@@ -129,7 +137,7 @@ A candidate can either :
 
 ## Trajectory constraints translation
 
-The trajectory constraints translator implements 3 types of constraints for now.  
+The trajectory constraints translator implements the following types of constraints.  
 We implement the ```all``` keyword for ease of readability. ```all``` will be expanded to a list containing all of the
 nodes or all of the candidates depending on the context.
 
@@ -147,14 +155,14 @@ Example :
 
 This entry will result in 4 (4 = |```nodes```| $\times$ |```candidates```|) constraints in the merged problem :
 
-- $dx_{2030, semibase}^+ \leq 1000$,
-- $dx_{2040, semibase}^+ \leq 1000$,
-- $dx_{2050\_A, semibase}^+ \leq 1000$,
-- $dx_{2050\_B, semibase}^+ \leq 1000$
+- $dx_{semibase, 2030}^+ \leq 1000$,
+- $dx_{semibase, 2040}^+ \leq 1000$,
+- $dx_{semibase, 2050\_A}^+ \leq 1000$,
+- $dx_{semibase, 2050\_B}^+ \leq 1000$
 
 More generally, this type of input constraint entry translates to :
 $$
-\forall n \in \text{nodes}, \quad \forall c \in \text{candidates}, \quad dx_{n, c}^+ \leq \text{value}
+\forall n \in \text{nodes}, \quad \forall i \in \text{candidates}, \quad dx_{i, n}^+ \leq \text{value}
 $$
 
 ### ```type: max_cumulative_investment_per_node```
@@ -170,12 +178,12 @@ Example :
 
 This entry will result in 2 (2 = |```nodes```|) constraints in the merged problem :
 
-- $dx_{2030, semibase}^+ + dx_{2030, peak}^+ \leq 2000$,
-- $dx_{2040, semibase}^+ + dx_{2040, peak}^+ \leq 2000$
+- $dx_{semibase, 2030}^+ + dx_{peak, 2030}^+ \leq 2000$,
+- $dx_{semibase, 2040}^+ + dx_{peak, 2040}^+ \leq 2000$
 
 More generally, this type of input constraint entry translates to :
 $$
-\forall n \in \text{nodes}, \quad \sum_{c \in \text{candidates}} dx_{n, c}^+ \leq \text{value}
+\forall n \in \text{nodes}, \quad \sum_{i \in \text{candidates}} dx_{i, n}^+ \leq \text{value}
 $$
 
 ### ```type: max_retirement_per_node_per_candidate```
@@ -192,17 +200,17 @@ Example :
 
 This entry will result in 8 (8 = |```nodes```| $\times$ |```candidates```|) constraints in the merged problem :
 
-- $dx_{2030, semibase}^- \leq 0, \quad dx_{2030, peak}^- \leq 0$,
-- $dx_{2040, semibase}^- \leq 0, \quad dx_{2040, peak}^- \leq 0$,
-- $dx_{2050\_A, semibase}^- \leq 0, \quad dx_{2050\_A, peak}^- \leq 0$,
-- $dx_{2050\_B, semibase}^- \leq 0, \quad dx_{2050\_B, peak}^- \leq 0$
+- $dx_{semibase, 2030}^- \leq 0, \quad dx_{peak, 2030}^- \leq 0$,
+- $dx_{semibase, 2040}^- \leq 0, \quad dx_{peak, 2040}^- \leq 0$,
+- $dx_{semibase, 2050\_A}^- \leq 0, \quad dx_{peak, 2050\_A}^- \leq 0$,
+- $dx_{semibase, 2050\_B}^- \leq 0, \quad dx_{peak, 2050\_B}^- \leq 0$
 
 More generally, this type of input constraint entry translates to :
 $$
-\forall n \in \text{nodes}, \quad \forall c \in \text{candidates}, \quad dx_{n, c}^- \leq \text{value}
+\forall n \in \text{nodes}, \quad \forall i \in \text{candidates}, \quad dx_{i, n}^- \leq \text{value}
 $$
 
-**Note :** as we always have $\forall n \in T, \quad \forall c \in C, \quad dx^{+/-}_{n,c} \geq 0$, regardless of the
+**Note :** as we always have $\forall n \in T, \quad \forall i \in C, \quad dx^{+/-}_{i,n} \geq 0$, regardless of the
 trajectory constraints added by the user, this last example ends up forbidding any kind of retirement, thus its label.
 
 ### ```type: max_cumulative_retirement_per_node```  
@@ -218,55 +226,55 @@ Example :
 
 This entry would result in 2 (2 = |```nodes```|) constraints in the merged problem :
 
-- $dx_{2030, semibase}^- + dx_{2030, peak}^- \leq 2000$,
-- $dx_{2040, semibase}^- + dx_{2040, peak}^- \leq 2000$
+- $dx_{semibase, 2030}^- + dx_{peak, 2030}^- \leq 2000$,
+- $dx_{semibase, 2040}^- + dx_{peak, 2040}^- \leq 2000$
 
 More generally, this type of input constraint entry translates to :
 $$
-\forall n \in \text{nodes}, \quad \sum_{c \in \text{candidates}} dx_{n, c}^- \leq \text{value}
+\forall n \in \text{nodes}, \quad \sum_{i \in \text{candidates}} dx_{i, n}^- \leq \text{value}
 $$
 
-### ```type: min_investment_per_candidate_per_node```  
+### ```type: min_investment_per_node_per_candidate```  
 Example :
 
 ```yaml
   - name: min_invest_1_5GW
     nodes: [ "2030", "2040", "2050_A" ]
     candidates: [ semibase ]
-    type: min_investment_per_candidate_per_node
+    type: min_investment_per_node_per_candidate
     value: 1500
 ```
 
 This entry would result in 3 (3 = |```nodes```|) constraints in the merged problem :
 
-- $dx_{2030, semibase}^+ \geq 1500$,
-- $dx_{2040, semibase}^+ \geq 1500$,
-- $dx_{2040\_A, semibase}^+ \geq 1500$,
+- $dx_{semibase, 2030}^+ \geq 1500$,
+- $dx_{semibase, 2040}^+ \geq 1500$,
+- $dx_{semibase, 2050\_A}^+ \geq 1500$,
 
 More generally, this type of input constraint entry translates to :
 $$
-\forall n \in \text{nodes}, \quad \forall{c \in \text{candidates}} \quad dx_{n, c}^+ \geq \text{value}
+\forall n \in \text{nodes}, \quad \forall i \in \text{candidates}, \quad dx_{i, n}^+ \geq \text{value}
 $$
 
-### ```type: min_retirement_per_candidate_per_node```  
+### ```type: min_retirement_per_node_per_candidate```  
 Example :
 
 ```yaml
   - name: min_decom_1GW
     nodes: [ "2030", "2040" ]
     candidates: [ peak ]
-    type: min_retirement_per_candidate_per_node
+    type: min_retirement_per_node_per_candidate
     value: 1000
 ```
 
 This entry would result in 2 (2 = |```nodes```|) constraints in the merged problem :
 
-- $dx_{2030, peak}^- \geq 1000$,
-- $dx_{2040, peak}^- \geq 1000$
+- $dx_{peak, 2030}^- \geq 1000$,
+- $dx_{peak, 2040}^- \geq 1000$
 
 More generally, this type of input constraint entry translates to :
 $$
-\forall n \in \text{nodes}, \quad \forall{c \in \text{candidates}} \quad dx_{n, c}^- \geq \text{value}
+\forall n \in \text{nodes}, \quad \forall i \in \text{candidates}, \quad dx_{i, n}^- \geq \text{value}
 $$
 
 ## Input data of local study or input data from `input-trajectory.yaml` ?
@@ -274,7 +282,7 @@ $$
 Each yearly study defines some input data from either `candidates.ini` and `settings.ini`. Some of this data are overriden by `input-trajectory.yaml` whereas some are reused:
 
 - **Master formulation**: The parameter of each individual study (integer or relaxed given in `settings.ini`) is overriden by the `formulation` given in the `input-trajectory.yaml` so that the same master formulation is applied at each node of the tree.
-- **Investment costs**:  In each individual study, investment costs are given in `candidates.ini`. However, in the trajectory case we need to explicitly split investment costs, fixed operation/maintenance costs and retirement costs. Therefore **candidate costs given in `input-trajectory.yaml` override the local study ones**. The candidate costs are given in **euros** in the `candidates_types` section, for each candidate type and each case (investment, operation_maintenance and retirement).
+- **Investment costs**:  In each individual study, investment costs are given in `candidates.ini`. However, in the trajectory case we need to explicitly split investment costs, fixed operation/maintenance costs and retirement costs. Therefore **candidate costs given in `input-trajectory.yaml` override the local study ones**. The candidate costs are given in **euros per MW** in the `candidates_types` section, for each candidate type and each case (investment, operation_maintenance and retirement).
 !!! Note
     For each node, the list of candidates present in `candidate_to_type` must exactly match the candidates of the `candidates.ini` file of the corresponding study.
 

--- a/src/python/antares_xpansion/trajectory/user_input_translation.py
+++ b/src/python/antares_xpansion/trajectory/user_input_translation.py
@@ -290,7 +290,7 @@ class NodeData(BaseModel):
 
     def compute_operational_discounting(self, global_data: GlobalData):
         factor = 0.0
-        for year in range(self.investment_date, self.investment_date + self.duration):
+        for year in range(self.investment_date + 1, self.investment_date + self.duration + 1):
             factor += (1 + global_data.discount_rate) ** (
                     global_data.first_investment_date - year
             )

--- a/tests/end_to_end/cucumber/features/trajectory.feature
+++ b/tests/end_to_end/cucumber/features/trajectory.feature
@@ -7,13 +7,13 @@ Feature: Multi-year investment problem
 		Given the study path is "data_test/trajectory/simple_tree"
 		When I run antares-xpansion in trajectory
 		Then the simulation succeeds
-		And the expected overall cost is 3319916676.4628983
-		And the expected investment cost is 1391071819.5959396
+		And the expected overall cost is 3255790462.8835249
+		And the expected investment cost is 1355866205.1483021
 		And the solution is
 			| variable                | value  |
 			| node_2030__semibase     | 1250.0 |
 			| node_2040__peak         | 1000.0 |
 			| node_2040__semibase     | 2250.0 |
 			| node_2050_A__peak       | 1000.0 |
-			| node_2050_A__semibase   | 3031.9947402993416 |
+			| node_2050_A__semibase   | 2908.345483539013 |
 			| node_2050_B__peak       | 2500.0 |

--- a/tests/python/test_trajectory_input_translation.py
+++ b/tests/python/test_trajectory_input_translation.py
@@ -1,0 +1,125 @@
+import json
+
+import pytest
+import yaml
+
+from antares_xpansion.trajectory.user_input_translation import (
+    UserInputTranslator,
+)
+
+
+def _write_candidates_ini(study_path):
+    expansion_dir = study_path / "user" / "expansion"
+    expansion_dir.mkdir(parents=True)
+    (expansion_dir / "candidates.ini").write_text(
+        "[1]\n"
+        "name = cand1\n"
+        "link = area1 - area2\n"
+    )
+
+
+class TestTrajectoryInputTranslationEndToEnd:
+    """
+    Test that the discounted costs written to master_merger_info.json by
+    UserInputTranslator match the expected discounting of the user's raw costs.
+    """
+
+    def test_write_merger_json_discounts_costs_from_user_input(self, tmp_path):
+        discount_rate = 0.05
+        first_investment_year = 2020
+        end_of_horizon = 2025
+
+        # investment_cost, retirement_cost, oam_cost as entered by the user (undiscounted)
+        investment_cost = 1000.0
+        retirement_cost = 200.0
+        oam_cost = 50.0
+
+        # Two studies : root node (investing at the reference date) and a child node
+        # investing two years later, each with a single candidate "cand1".
+        root_study = tmp_path / "root_study"
+        child_study = tmp_path / "child_study"
+        for study_path in (root_study, child_study):
+            study_path.mkdir()
+            _write_candidates_ini(study_path)
+
+        input_data = {
+            "global": {
+                "formulation": "relaxed",
+                "discount_rate": discount_rate,
+                "first_investment_year": first_investment_year,
+                "end_of_horizon": end_of_horizon,
+                "scaling": 1,
+                "studies": {
+                    "root": str(root_study),
+                    "child": str(child_study),
+                },
+            },
+            "tree": {
+                "node": "root",
+                "children": [{"node": "child", "probability": 1.0}],
+            },
+            "constraints": [],
+            "nodes": {
+                "root": {
+                    "investment_date": first_investment_year,
+                    "candidate_to_type": {"cand1": "type1"},
+                },
+                "child": {
+                    "investment_date": first_investment_year + 2,
+                    "candidate_to_type": {"cand1": "type1"},
+                },
+            },
+            "candidates_types": {
+                "type1": {
+                    "investment": investment_cost,
+                    "operation_maintenance": oam_cost,
+                    "retirement": retirement_cost,
+                }
+            },
+            "initial_capacities": {"default": 0},
+        }
+
+        input_file = tmp_path / "input-trajectory.yaml"
+        input_file.write_text(yaml.safe_dump(input_data))
+
+        translator = UserInputTranslator(input_file)
+        translator.parse_trajectory_user_file()
+        translator.run_all_verification()
+
+        output_file = tmp_path / "master_merger_info.json"
+        translator.write_merger_json(output_file)
+
+        output = json.loads(output_file.read_text())
+        tree = output["tree"]
+
+        # Root node invests exactly at the reference date : discounting factors of 1
+        # for investment/retirement, and a sum over its 2-year duration for O&M.
+        root_costs = tree["root"]["candidates_costs"]["cand1"]
+        assert root_costs["investment"] == pytest.approx(investment_cost)
+        assert root_costs["retirement"] == pytest.approx(retirement_cost)
+        expected_root_omc_factor = sum(
+            (1 + discount_rate) ** (first_investment_year - year)
+            for year in range(first_investment_year + 1, first_investment_year + 2 + 1)
+        )
+        assert root_costs["operation_maintenance"] == pytest.approx(
+            expected_root_omc_factor * oam_cost
+        )
+
+        # Child node invests 2 years after the reference date : investment/retirement
+        # are discounted by (1+r)^-2, and O&M is summed over its remaining duration.
+        child_investment_date = first_investment_year + 2
+        child_costs = tree["child"]["candidates_costs"]["cand1"]
+        expected_ic_factor = (1 + discount_rate) ** (
+            first_investment_year - child_investment_date
+        )
+        assert child_costs["investment"] == pytest.approx(expected_ic_factor * investment_cost)
+        assert child_costs["retirement"] == pytest.approx(expected_ic_factor * retirement_cost)
+        expected_child_omc_factor = sum(
+            (1 + discount_rate) ** (first_investment_year - year)
+            for year in range(child_investment_date + 1, end_of_horizon + 1)
+        )
+        assert child_costs["operation_maintenance"] == pytest.approx(
+            expected_child_omc_factor * oam_cost
+        )
+
+        assert tree["child"]["parent"] == "root"


### PR DESCRIPTION
## Fix operational discounting

`compute_operational_discounting` summed years `[investment_date, investment_date + duration)` instead of `[investment_date + 1, investment_date + duration]`. Updates the trajectory e2e test expected values.

## Documentation

- Clarify objective notation in `index.md` ($C_i$, $x_i$, consistent $(i,n)$ indexing), detail $w_n$, $wIC$, $wDC$, $wOC$, add mapping to input file fields and link between annual/pluriannual objectives.
- `user-input.md`: document candidate costs (undiscounted, €/MW), rename `min_investment_per_candidate_per_node` → `min_investment_per_node_per_candidate` (same for retirement), fix indexing in constraint examples.
- `merge-master.md`: fix indexing typo.
