### PR TITLE
integrating best ub tracker in bendersmpi

### DIFF
--- a/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
+++ b/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
@@ -13,6 +13,9 @@ void BendersByBatch::InitializeProblems()
     BuildMasterProblem();
     BroadCastVariablesIndices();
     init_problems_ = false;
+
+    std::filesystem::path trackedVariablesFile = std::filesystem::path(_options.INPUTROOT) / "sub_variables_to_save.csv"; 
+    best_ub_tracker_ = std::make_shared<BestUbTracker>(&_world,trackedVariablesFile, std::filesystem::path(_options.OUTPUTROOT), _logger ) ; 
 }
 
 void BendersByBatch::BuildMasterProblem()
@@ -441,6 +444,7 @@ void BendersByBatch::GetSubproblemCutCache(SubProblemDataMap& subproblem_data_ma
         auto timer = calculate_subproblem_contribution(name, subproblem_data);
         subproblem_data.subproblem_timer += timer.elapsed();
         subproblem_data_map[name] = subproblem_data;
+        best_ub_tracker_->set_variables_values(name, worker, _data.it, _data.best_ub);
         StoreSubproblemBasis(name, worker);
         std::call_once(
           variable_indice_once_flag,
@@ -489,6 +493,7 @@ void BendersByBatch::GetSubproblemCutFast(SubProblemDataMap& subproblem_data_map
             // subproblem_timer already set time, we add the remaining computation time
             subproblem_data.subproblem_timer += subproblem_timer.elapsed();
             subproblem_data_map[name] = subproblem_data;
+            best_ub_tracker_->set_variables_values(name, worker, _data.it, _data.best_ub);
         }
     }
 }
@@ -530,6 +535,7 @@ void BendersByBatch::GetCompactInMemCuts(SubProblemDataMap& subproblem_data_map,
         auto timer = calculate_subproblem_contribution(name, subproblem_data);
         subproblem_data.subproblem_timer += timer.elapsed();
         subproblem_data_map[name] = subproblem_data;
+        best_ub_tracker_->set_variables_values(name, worker, _data.it, _data.best_ub);
         subproblem_worker_factory_->GetBasis(name);
     }
 }

--- a/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
+++ b/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
@@ -14,8 +14,12 @@ void BendersByBatch::InitializeProblems()
     BroadCastVariablesIndices();
     init_problems_ = false;
 
-    std::filesystem::path trackedVariablesFile = std::filesystem::path(_options.INPUTROOT) / "sub_variables_to_save.csv"; 
-    best_ub_tracker_ = std::make_shared<BestUbTracker>(&_world,trackedVariablesFile, std::filesystem::path(_options.OUTPUTROOT), _logger ) ; 
+    std::filesystem::path trackedVariablesFile = std::filesystem::path(_options.INPUTROOT)
+                                                 / "sub_variables_to_save.csv";
+    best_ub_tracker_ = std::make_shared<BestUbTracker>(&_world,
+                                                       trackedVariablesFile,
+                                                       std::filesystem::path(_options.OUTPUTROOT),
+                                                       _logger);
 }
 
 void BendersByBatch::BuildMasterProblem()

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -532,10 +532,12 @@ void BendersBase::GetSubproblemCutFast(SubProblemDataMap& subproblem_data_map)
                                 PlainData::SubProblemData subproblem_data;
                                 const auto& [name, worker] = kvp;
                                 SolveSubproblem(subproblem_data, name, worker, nullptr);
-                                std::lock_guard guard(m);   
+                                std::lock_guard guard(m);
                                 subproblem_data_map[name] = subproblem_data;
-                                best_ub_tracker_->set_variables_values(name,worker,_data.it,_data.best_ub) ;
-
+                                best_ub_tracker_->set_variables_values(name,
+                                                                       worker,
+                                                                       _data.it,
+                                                                       _data.best_ub);
                             }
                             catch (...)
                             {
@@ -606,48 +608,46 @@ void BendersBase::GetSubproblemCutCache(SubProblemDataMap& subproblem_data_map)
     selectPolicy(
       [this, &nameAndVariableMap, &m, &subproblem_data_map, &first_exception](auto& policy)
       {
-          std::for_each(policy,
-                        nameAndVariableMap.begin(),
-                        nameAndVariableMap.end(),
-                        [this, &m, &subproblem_data_map, &first_exception](
-                          const std::pair<std::string, VariableMap>& kvp)
-                        {
-                            // A parallel execution policy calls std::terminate if an
-                            // exception escapes this callable, so any solve failure
-                            // must be caught here and rethrown after the loop instead.
-                            try
-                            {
-                                const auto& [name, variables] = kvp;
-                                std::shared_ptr<SubproblemWorker> worker = makeSubproblemWorker(
-                                  kvp);
-                                PlainData::SubProblemData subproblem_data;
-                                SolveSubproblem(subproblem_data,
-                                                name,
-                                                worker,
-                                                [this, &name, &worker]
-                                                { TryRestoreSubproblemBasis(name, worker); });
-                                std::lock_guard guard(m);
-                                subproblem_data_map[name] = subproblem_data;
-                                StoreSubproblemBasis(name, worker);
+          std::for_each(
+            policy,
+            nameAndVariableMap.begin(),
+            nameAndVariableMap.end(),
+            [this, &m, &subproblem_data_map, &first_exception](
+              const std::pair<std::string, VariableMap>& kvp)
+            {
+                // A parallel execution policy calls std::terminate if an
+                // exception escapes this callable, so any solve failure
+                // must be caught here and rethrown after the loop instead.
+                try
+                {
+                    const auto& [name, variables] = kvp;
+                    std::shared_ptr<SubproblemWorker> worker = makeSubproblemWorker(kvp);
+                    PlainData::SubProblemData subproblem_data;
+                    SolveSubproblem(subproblem_data,
+                                    name,
+                                    worker,
+                                    [this, &name, &worker]
+                                    { TryRestoreSubproblemBasis(name, worker); });
+                    std::lock_guard guard(m);
+                    subproblem_data_map[name] = subproblem_data;
+                    StoreSubproblemBasis(name, worker);
 
-                                best_ub_tracker_->set_variables_values(name,worker,_data.it,_data.best_ub) ;
+                    best_ub_tracker_->set_variables_values(name, worker, _data.it, _data.best_ub);
 
-
-                                std::call_once(
-                                  variable_indice_once_flag,
-                                  [this](const auto& worker_)
-                                  { SetSubproblemVariablesIndices(worker_); },
-                                  *worker);
-                            }
-                            catch (...)
-                            {
-                                std::lock_guard guard(m);
-                                if (!first_exception)
-                                {
-                                    first_exception = std::current_exception();
-                                }
-                            }
-                        });
+                    std::call_once(
+                      variable_indice_once_flag,
+                      [this](const auto& worker_) { SetSubproblemVariablesIndices(worker_); },
+                      *worker);
+                }
+                catch (...)
+                {
+                    std::lock_guard guard(m);
+                    if (!first_exception)
+                    {
+                        first_exception = std::current_exception();
+                    }
+                }
+            });
       },
       shouldParallelize());
     if (first_exception)
@@ -669,7 +669,6 @@ void BendersBase::GetCompactInMemCuts(SubProblemDataMap& subproblem_data_map)
                                                                                      variable_map,
                                                                                      slave_weights);
 
-
         PlainData::SubProblemData subproblem_data;
         SolveSubproblem(subproblem_data,
                         sub,
@@ -680,9 +679,7 @@ void BendersBase::GetCompactInMemCuts(SubProblemDataMap& subproblem_data_map)
 
         subproblem_data_map[sub] = subproblem_data;
 
-        best_ub_tracker_->set_variables_values(sub,subproblem_worker,_data.it,_data.best_ub) ;
-
-
+        best_ub_tracker_->set_variables_values(sub, subproblem_worker, _data.it, _data.best_ub);
     }
 }
 

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -532,9 +532,10 @@ void BendersBase::GetSubproblemCutFast(SubProblemDataMap& subproblem_data_map)
                                 PlainData::SubProblemData subproblem_data;
                                 const auto& [name, worker] = kvp;
                                 SolveSubproblem(subproblem_data, name, worker, nullptr);
-
-                                std::lock_guard guard(m);
+                                std::lock_guard guard(m);   
                                 subproblem_data_map[name] = subproblem_data;
+                                best_ub_tracker_->set_variables_values(name,worker,_data.it,_data.best_ub) ;
+
                             }
                             catch (...)
                             {
@@ -629,6 +630,9 @@ void BendersBase::GetSubproblemCutCache(SubProblemDataMap& subproblem_data_map)
                                 subproblem_data_map[name] = subproblem_data;
                                 StoreSubproblemBasis(name, worker);
 
+                                best_ub_tracker_->set_variables_values(name,worker,_data.it,_data.best_ub) ;
+
+
                                 std::call_once(
                                   variable_indice_once_flag,
                                   [this](const auto& worker_)
@@ -665,6 +669,7 @@ void BendersBase::GetCompactInMemCuts(SubProblemDataMap& subproblem_data_map)
                                                                                      variable_map,
                                                                                      slave_weights);
 
+
         PlainData::SubProblemData subproblem_data;
         SolveSubproblem(subproblem_data,
                         sub,
@@ -674,6 +679,10 @@ void BendersBase::GetCompactInMemCuts(SubProblemDataMap& subproblem_data_map)
         subproblem_worker_factory_->GetBasis(sub);
 
         subproblem_data_map[sub] = subproblem_data;
+
+        best_ub_tracker_->set_variables_values(sub,subproblem_worker,_data.it,_data.best_ub) ;
+
+
     }
 }
 

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -1,0 +1,141 @@
+#include <antares-xpansion/benders/benders_core/BestUbTracker.h>
+
+#include <boost/tokenizer.hpp>
+
+#include "iostream"
+
+BestUbTracker::BestUbTracker(mpi::communicator* world,
+                                     const std::filesystem::path& file_path,
+                                     const std::filesystem::path& output_root,
+                                     Logger logger):
+    file_stream_(file_path),
+    _world(world),
+    _logger(logger)
+{
+    output_file_ = output_root / "sub_best_ub_variables.csv";
+    if (!file_stream_.is_open())
+    {
+        _logger->display_message("sub_variables_to_save.csv  not found ") ; 
+        return;
+
+    }
+
+    std::string line;
+    if (std::getline(file_stream_, line))
+    {
+        boost::escaped_list_separator<char> sep('\\', ',', '\"');
+        using Tokenizer = boost::tokenizer<boost::escaped_list_separator<char>>;
+        Tokenizer tok(line, sep);
+        variables_to_follow_.assign(tok.begin(), tok.end());
+    }
+
+    for (auto& variable: variables_to_follow_)
+    {
+        std::cout << "variable " << variable << std::endl;
+    }
+}
+
+bool BestUbTracker::set_best_ub_solution_(double new_best_ub, int iter)
+{
+    if (new_best_ub < best_ub_)
+    {
+        std::cout << "found new best ub " << std::endl;
+        last_iteration_update_ = iter;
+        return true ; 
+    }
+    return false ; 
+}
+
+void BestUbTracker::set_variables_values(std::string sub_name,
+                                             const std::shared_ptr<SubproblemWorker>& worker,
+                                             int iter, 
+                                             double new_ub)
+{
+
+    if (set_best_ub_solution_(new_ub,iter)) 
+    {
+
+        if ( variables_to_follow_indices_per_sub_.find(sub_name)
+        == variables_to_follow_indices_per_sub_.end())
+        {
+            std::cout << "getting indices for " << sub_name << std::endl;
+            for (auto& variable: variables_to_follow_)
+            {
+                auto index = worker->get_variable_index(variable);
+                if (index < 0)
+                {
+                    std::cerr << "unable to find " << variable << " in sub_problem " << sub_name
+                    << std::endl;
+                }
+                variables_to_follow_indices_per_sub_[sub_name].push_back(index);
+            }
+        }
+        
+        if (last_iteration_update_ == iter)
+        {
+            std::cout << "updating the solution " << std::endl;
+            values_per_sub_[sub_name] = worker->get_solution();
+        }
+    }
+}
+
+void BestUbTracker::dump_values()
+{
+    // Gather values_per_sub_ from all ranks to rank 0
+    std::vector<std::map<std::string, std::vector<double>>> gathered_values;
+
+    mpi::gather(*_world, values_per_sub_, gathered_values, 0);
+
+    // Also gather indices so rank 0 has indices for all subproblems
+    std::vector<std::map<std::string, std::vector<int>>> gathered_indices;
+    mpi::gather(*_world, variables_to_follow_indices_per_sub_, gathered_indices, 0);
+
+    if (_world->rank() != 0)
+    {
+        return;
+    }
+
+    // Merge all gathered maps into values_per_sub_
+    for (const auto& rank_values: gathered_values)
+    {
+        for (const auto& [sub_name, values]: rank_values)
+        {
+            values_per_sub_[sub_name] = values;
+        }
+    }
+
+    for (const auto& rank_indices: gathered_indices)
+    {
+        for (const auto& [sub_name, indices]: rank_indices)
+        {
+            variables_to_follow_indices_per_sub_[sub_name] = indices;
+        }
+    }
+
+    std::ofstream out(output_file_);
+    if (!out.is_open())
+    {
+        std::cerr << "unable to open sub_best_ub_variables.csv for writing" << std::endl;
+        return;
+    }
+
+    // header: first column is sub name, then the followed variables
+    out << "sub_name";
+    for (const auto& var: variables_to_follow_)
+    {
+        out << "," << "\"" << var << "\"";
+    }
+    out << "\n";
+
+    // one row per subproblem
+    for (const auto& [sub_name, values]: values_per_sub_)
+    {
+        out << sub_name;
+        const auto& indices = variables_to_follow_indices_per_sub_[sub_name];
+        for (size_t i = 0; i < indices.size(); ++i)
+        {
+            out << "," << values[indices[i]];
+        }
+        out << "\n";
+    }
+}

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -3,9 +3,9 @@
 #include <boost/tokenizer.hpp>
 
 BestUbTracker::BestUbTracker(mpi::communicator* world,
-                                     const std::filesystem::path& file_path,
-                                     const std::filesystem::path& output_root,
-                                     Logger logger):
+                             const std::filesystem::path& file_path,
+                             const std::filesystem::path& output_root,
+                             Logger logger):
     file_stream_(file_path),
     _world(world),
     _logger(logger)
@@ -13,9 +13,8 @@ BestUbTracker::BestUbTracker(mpi::communicator* world,
     output_file_ = output_root / "sub_best_ub_variables.csv";
     if (!file_stream_.is_open())
     {
-        _logger->display_message("sub_variables_to_save.csv  not found ") ; 
+        _logger->display_message("sub_variables_to_save.csv  not found ");
         return;
-
     }
 
     std::string line;
@@ -26,7 +25,6 @@ BestUbTracker::BestUbTracker(mpi::communicator* world,
         Tokenizer tok(line, sep);
         variables_to_follow_.assign(tok.begin(), tok.end());
     }
-
 }
 
 bool BestUbTracker::set_best_ub_solution_(double new_best_ub, int iter)
@@ -35,20 +33,18 @@ bool BestUbTracker::set_best_ub_solution_(double new_best_ub, int iter)
     {
         best_ub_ = new_best_ub;
         last_iteration_update_ = iter;
-        return true ;
+        return true;
     }
-    return false ; 
+    return false;
 }
 
 void BestUbTracker::set_variables_values(std::string sub_name,
-                                             const std::shared_ptr<SubproblemWorker>& worker,
-                                             int iter, 
-                                             double new_ub)
+                                         const std::shared_ptr<SubproblemWorker>& worker,
+                                         int iter,
+                                         double new_ub)
 {
-
-    if (set_best_ub_solution_(new_ub,iter)) 
+    if (set_best_ub_solution_(new_ub, iter))
     {
-
         if (iter <= 1) [[unlikely]]
         {
             for (auto& variable: variables_to_follow_)
@@ -56,12 +52,13 @@ void BestUbTracker::set_variables_values(std::string sub_name,
                 auto index = worker->get_variable_index(variable);
                 if (index < 0)
                 {
-                    _logger->display_message("unable to find " + variable + " in sub_problem " + sub_name);
+                    _logger->display_message("unable to find " + variable + " in sub_problem "
+                                             + sub_name);
                 }
                 variables_to_follow_indices_per_sub_[sub_name].push_back(index);
             }
         }
-        
+
         if (last_iteration_update_ == iter)
         {
             values_per_sub_[sub_name] = worker->get_solution();

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -124,7 +124,7 @@ void BestUbTracker::dump_values()
         const auto& indices = variables_to_follow_indices_per_sub_[sub_name];
         for (size_t i = 0; i < indices.size(); ++i)
         {
-            out << "," << values[indices[i]];
+            out << "," << values[static_cast<size_t>(indices[i])];
         }
         out << "\n";
     }

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -31,7 +31,7 @@ BestUbTracker::BestUbTracker(mpi::communicator* world,
 
 bool BestUbTracker::set_best_ub_solution_(double new_best_ub, int iter)
 {
-    if (new_best_ub < best_ub_)
+    if (new_best_ub <= best_ub_)
     {
         best_ub_ = new_best_ub;
         last_iteration_update_ = iter;

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -49,8 +49,7 @@ void BestUbTracker::set_variables_values(std::string sub_name,
     if (set_best_ub_solution_(new_ub,iter)) 
     {
 
-        if ( variables_to_follow_indices_per_sub_.find(sub_name)
-        == variables_to_follow_indices_per_sub_.end())
+        if (iter <= 1) [[unlikely]]
         {
             for (auto& variable: variables_to_follow_)
             {

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -2,8 +2,6 @@
 
 #include <boost/tokenizer.hpp>
 
-#include "iostream"
-
 BestUbTracker::BestUbTracker(mpi::communicator* world,
                                      const std::filesystem::path& file_path,
                                      const std::filesystem::path& output_root,
@@ -29,19 +27,15 @@ BestUbTracker::BestUbTracker(mpi::communicator* world,
         variables_to_follow_.assign(tok.begin(), tok.end());
     }
 
-    for (auto& variable: variables_to_follow_)
-    {
-        std::cout << "variable " << variable << std::endl;
-    }
 }
 
 bool BestUbTracker::set_best_ub_solution_(double new_best_ub, int iter)
 {
     if (new_best_ub < best_ub_)
     {
-        std::cout << "found new best ub " << std::endl;
+        best_ub_ = new_best_ub;
         last_iteration_update_ = iter;
-        return true ; 
+        return true ;
     }
     return false ; 
 }
@@ -58,14 +52,12 @@ void BestUbTracker::set_variables_values(std::string sub_name,
         if ( variables_to_follow_indices_per_sub_.find(sub_name)
         == variables_to_follow_indices_per_sub_.end())
         {
-            std::cout << "getting indices for " << sub_name << std::endl;
             for (auto& variable: variables_to_follow_)
             {
                 auto index = worker->get_variable_index(variable);
                 if (index < 0)
                 {
-                    std::cerr << "unable to find " << variable << " in sub_problem " << sub_name
-                    << std::endl;
+                    _logger->display_message("unable to find " + variable + " in sub_problem " + sub_name);
                 }
                 variables_to_follow_indices_per_sub_[sub_name].push_back(index);
             }
@@ -73,7 +65,6 @@ void BestUbTracker::set_variables_values(std::string sub_name,
         
         if (last_iteration_update_ == iter)
         {
-            std::cout << "updating the solution " << std::endl;
             values_per_sub_[sub_name] = worker->get_solution();
         }
     }
@@ -115,7 +106,7 @@ void BestUbTracker::dump_values()
     std::ofstream out(output_file_);
     if (!out.is_open())
     {
-        std::cerr << "unable to open sub_best_ub_variables.csv for writing" << std::endl;
+        _logger->display_message("unable to open sub_best_ub_variables.csv for writing");
         return;
     }
 

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -27,12 +27,11 @@ BestUbTracker::BestUbTracker(mpi::communicator* world,
     }
 }
 
-bool BestUbTracker::set_best_ub_solution_(double new_best_ub, int iter)
+bool BestUbTracker::set_best_ub_solution_(double new_best_ub)
 {
     if (new_best_ub <= best_ub_)
     {
         best_ub_ = new_best_ub;
-        last_iteration_update_ = iter;
         return true;
     }
     return false;
@@ -43,7 +42,7 @@ void BestUbTracker::set_variables_values(std::string sub_name,
                                          int iter,
                                          double new_ub)
 {
-    if (set_best_ub_solution_(new_ub, iter))
+    if (set_best_ub_solution_(new_ub))
     {
         if (iter <= 1) [[unlikely]]
         {
@@ -59,43 +58,38 @@ void BestUbTracker::set_variables_values(std::string sub_name,
             }
         }
 
-        if (last_iteration_update_ == iter)
-        {
-            values_per_sub_[sub_name] = worker->get_solution();
-        }
+        extract_tracked_values_(sub_name, worker);
+    }
+}
+
+void BestUbTracker::extract_tracked_values_(const std::string& sub_name,
+                                            const std::shared_ptr<SubproblemWorker>& worker)
+{
+    const auto& indices = variables_to_follow_indices_per_sub_[sub_name];
+    auto full_solution = worker->get_solution();
+    auto& tracked = values_per_sub_[sub_name];
+    tracked.resize(indices.size());
+    for (size_t i = 0; i < indices.size(); ++i)
+    {
+        tracked[i] = full_solution[static_cast<size_t>(indices[i])];
     }
 }
 
 void BestUbTracker::dump_values()
 {
-    // Gather values_per_sub_ from all ranks to rank 0
     std::vector<std::map<std::string, std::vector<double>>> gathered_values;
-
     mpi::gather(*_world, values_per_sub_, gathered_values, 0);
-
-    // Also gather indices so rank 0 has indices for all subproblems
-    std::vector<std::map<std::string, std::vector<int>>> gathered_indices;
-    mpi::gather(*_world, variables_to_follow_indices_per_sub_, gathered_indices, 0);
 
     if (_world->rank() != 0)
     {
         return;
     }
 
-    // Merge all gathered maps into values_per_sub_
     for (const auto& rank_values: gathered_values)
     {
         for (const auto& [sub_name, values]: rank_values)
         {
             values_per_sub_[sub_name] = values;
-        }
-    }
-
-    for (const auto& rank_indices: gathered_indices)
-    {
-        for (const auto& [sub_name, indices]: rank_indices)
-        {
-            variables_to_follow_indices_per_sub_[sub_name] = indices;
         }
     }
 
@@ -106,7 +100,6 @@ void BestUbTracker::dump_values()
         return;
     }
 
-    // header: first column is sub name, then the followed variables
     out << "sub_name";
     for (const auto& var: variables_to_follow_)
     {
@@ -114,14 +107,12 @@ void BestUbTracker::dump_values()
     }
     out << "\n";
 
-    // one row per subproblem
     for (const auto& [sub_name, values]: values_per_sub_)
     {
         out << sub_name;
-        const auto& indices = variables_to_follow_indices_per_sub_[sub_name];
-        for (size_t i = 0; i < indices.size(); ++i)
+        for (const auto& val: values)
         {
-            out << "," << values[static_cast<size_t>(indices[i])];
+            out << "," << val;
         }
         out << "\n";
     }

--- a/src/cpp/benders/benders_core/BestUbTracker.cpp
+++ b/src/cpp/benders/benders_core/BestUbTracker.cpp
@@ -42,22 +42,25 @@ void BestUbTracker::set_variables_values(std::string sub_name,
                                          int iter,
                                          double new_ub)
 {
+    std::call_once(indices_once_flag_,
+                   [this, &sub_name, &worker]()
+                   {
+                       for (auto& variable: variables_to_follow_)
+                       {
+                           auto index = worker->get_variable_index(variable);
+                           if (index < 0)
+                           {
+                               _logger->display_message("unable to find " + variable
+                                                        + " in sub_problem " + sub_name);
+                           }
+                           variables_to_follow_indices_.push_back(index);
+                       }
+                   });
+
+    // for mutlithreaded parallel subproblem case to avoid data race on best_ub
+    std::lock_guard guard(mutex_);
     if (set_best_ub_solution_(new_ub))
     {
-        if (iter <= 1) [[unlikely]]
-        {
-            for (auto& variable: variables_to_follow_)
-            {
-                auto index = worker->get_variable_index(variable);
-                if (index < 0)
-                {
-                    _logger->display_message("unable to find " + variable + " in sub_problem "
-                                             + sub_name);
-                }
-                variables_to_follow_indices_per_sub_[sub_name].push_back(index);
-            }
-        }
-
         extract_tracked_values_(sub_name, worker);
     }
 }
@@ -65,7 +68,7 @@ void BestUbTracker::set_variables_values(std::string sub_name,
 void BestUbTracker::extract_tracked_values_(const std::string& sub_name,
                                             const std::shared_ptr<SubproblemWorker>& worker)
 {
-    const auto& indices = variables_to_follow_indices_per_sub_[sub_name];
+    const auto& indices = variables_to_follow_indices_;
     auto full_solution = worker->get_solution();
     auto& tracked = values_per_sub_[sub_name];
     tracked.resize(indices.size());

--- a/src/cpp/benders/benders_core/CMakeLists.txt
+++ b/src/cpp/benders/benders_core/CMakeLists.txt
@@ -37,6 +37,7 @@ target_sources(benders_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/SkeletonConstraintSetLoader.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/SubproblemBasisCache.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/SubproblemWorkerFactory.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/BestUbTracker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/SubproblemConstraintsManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/BendersBase.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/BendersMathLogger.h
@@ -69,7 +70,9 @@ target_sources(benders_core PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/SkeletonSolverLoader.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/SubproblemConstraintsManager.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/ICommunicationStrategy.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/BestUbTracker.h
         ${CMAKE_CURRENT_SOURCE_DIR}/include/antares-xpansion/benders/benders_core/SequentialCommunicationStrategy.h
+
 )
 
 add_library(antaresXpansion::benders_core ALIAS benders_core)

--- a/src/cpp/benders/benders_core/SubproblemConstraintsManager.cpp
+++ b/src/cpp/benders/benders_core/SubproblemConstraintsManager.cpp
@@ -37,7 +37,7 @@ SubproblemConstraintsManagerPtr SubproblemConstraintsManager::FromSharedSolver(
     return std::make_shared<SubproblemConstraintsManager>(std::move(solver), subproblem_worker);
 }
 
-std::vector<double> SubproblemConstraintsManager::GetSubSolution()
+const std::vector<double>& SubproblemConstraintsManager::GetSubSolution()
 {
     return subproblem_worker_->get_solution();
 }

--- a/src/cpp/benders/benders_core/SubproblemWorker.cpp
+++ b/src/cpp/benders/benders_core/SubproblemWorker.cpp
@@ -93,19 +93,19 @@ void SubproblemWorker::get_subgradient(Point& subgradient) const
  *
  *  \param lb : reference to a map
  */
-std::vector<double> SubproblemWorker::get_solution() const
+const std::vector<double>& SubproblemWorker::get_solution() const
 {
-    std::vector<double> solution(_solver->get_ncols());
+    solution_cache_.resize(_solver->get_ncols());
 
     if (_solver->get_n_integer_vars() > 0)
     {
-        _solver->get_mip_sol(solution.data());
+        _solver->get_mip_sol(solution_cache_.data());
     }
     else
     {
-        _solver->get_lp_sol(solution.data(), NULL, NULL);
+        _solver->get_lp_sol(solution_cache_.data(), NULL, NULL);
     }
-    return solution;
+    return solution_cache_;
 }
 
 void SubproblemWorker::delete_rows(int start_pos)

--- a/src/cpp/benders/benders_core/SubproblemWorkerFactory.cpp
+++ b/src/cpp/benders/benders_core/SubproblemWorkerFactory.cpp
@@ -113,13 +113,15 @@ std::shared_ptr<SubproblemWorker> SubproblemWorkerFactory::CreateSubSolverAbstra
 
     std::vector<int> indices(skeletonObjCoeffs_.size());
     std::iota(indices.begin(), indices.end(), 0);
-
     solver_->chg_obj(indices, weighted_obj);
-
-    solver_->chg_coefs(coef_set_.RowIndices(),
-                       coef_set_.ColIndices(),
-                       coef_set_.CoefficientsFor(sub_name));
-
+   
+    if (!coef_set_.RowIndices().empty() )
+    {
+        solver_->chg_coefs(coef_set_.RowIndices(),
+                           coef_set_.ColIndices(),
+                           coef_set_.CoefficientsFor(sub_name));
+    }
+        
     const auto& obj_coeffs = obj_set_.CoefficientsFor(sub_name);
     std::vector<double> weighted_obj_coeffs(obj_coeffs.size());
     std::ranges::transform(obj_coeffs,

--- a/src/cpp/benders/benders_core/SubproblemWorkerFactory.cpp
+++ b/src/cpp/benders/benders_core/SubproblemWorkerFactory.cpp
@@ -114,14 +114,14 @@ std::shared_ptr<SubproblemWorker> SubproblemWorkerFactory::CreateSubSolverAbstra
     std::vector<int> indices(skeletonObjCoeffs_.size());
     std::iota(indices.begin(), indices.end(), 0);
     solver_->chg_obj(indices, weighted_obj);
-   
-    if (!coef_set_.RowIndices().empty() )
+
+    if (!coef_set_.RowIndices().empty())
     {
         solver_->chg_coefs(coef_set_.RowIndices(),
                            coef_set_.ColIndices(),
                            coef_set_.CoefficientsFor(sub_name));
     }
-        
+
     const auto& obj_coeffs = obj_set_.CoefficientsFor(sub_name);
     std::vector<double> weighted_obj_coeffs(obj_coeffs.size());
     std::ranges::transform(obj_coeffs,

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -19,6 +19,7 @@
 #include "WorkerMaster.h"
 #include "antares-xpansion/helpers/Timer.h"
 #include "antares-xpansion/xpansion_interfaces/ILogger.h"
+#include "BestUbTracker.h"
 #include "common.h"
 
 /**
@@ -171,6 +172,8 @@ protected:
     bool init_problems_ = true;
     bool free_problems_ = true;
     BendersBaseOptions _options;
+    std::shared_ptr<BestUbTracker> best_ub_tracker_ = nullptr;
+ 
 
     std::vector<std::vector<double>> criteria_vector_for_each_iteration_;
     bool is_bilevel_check_all_ = false;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BendersBase.h
@@ -9,6 +9,7 @@
 
 #include "BendersMathLogger.h"
 #include "BendersStructsDatas.h"
+#include "BestUbTracker.h"
 #include "CriterionComputation.h"
 #include "ICommunicationStrategy.h"
 #include "SubproblemBasisCache.h"
@@ -19,7 +20,6 @@
 #include "WorkerMaster.h"
 #include "antares-xpansion/helpers/Timer.h"
 #include "antares-xpansion/xpansion_interfaces/ILogger.h"
-#include "BestUbTracker.h"
 #include "common.h"
 
 /**
@@ -173,7 +173,6 @@ protected:
     bool free_problems_ = true;
     BendersBaseOptions _options;
     std::shared_ptr<BestUbTracker> best_ub_tracker_ = nullptr;
- 
 
     std::vector<std::vector<double>> criteria_vector_for_each_iteration_;
     bool is_bilevel_check_all_ = false;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi.hpp>
+#include <boost/serialization/deque.hpp>
+#include <boost/serialization/list.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/set.hpp>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/vector.hpp>
+
+#include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
+#include "antares-xpansion/xpansion_interfaces/ILogger.h"
+
+namespace mpi = boost::mpi;
+
+class BestUbTracker
+{
+public:
+
+    BestUbTracker() = default ; 
+    BestUbTracker(mpi::communicator* world,
+                  const std::filesystem::path& file_path,
+                  const std::filesystem::path& output_root,
+                  Logger logger);
+
+    ~BestUbTracker() = default;
+
+    void set_variables_values(std::string sub_name,
+                              const std::shared_ptr<SubproblemWorker>& worker,
+                              int iter, 
+                              double new_ub);
+
+    void dump_values();
+
+private:
+    bool set_best_ub_solution_(double new_best_ub, int iter);
+
+    std::ifstream file_stream_;
+    mpi::communicator* _world;
+    std::filesystem::path output_file_;
+    Logger _logger;
+
+    double best_ub_ = std::numeric_limits<double>::max();
+    int last_iteration_update_ = -1;
+
+    std::vector<std::string> variables_to_follow_;
+    std::map<std::string, std::vector<int>> variables_to_follow_indices_per_sub_;
+    std::map<std::string, std::vector<double>> values_per_sub_;
+};

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
@@ -8,8 +8,8 @@
 #include <string>
 #include <vector>
 
-#include <boost/mpi/communicator.hpp>
 #include <boost/mpi.hpp>
+#include <boost/mpi/communicator.hpp>
 #include <boost/serialization/deque.hpp>
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/map.hpp>
@@ -27,8 +27,7 @@ namespace mpi = boost::mpi;
 class BestUbTracker
 {
 public:
-
-    BestUbTracker() = default ; 
+    BestUbTracker() = default;
     BestUbTracker(mpi::communicator* world,
                   const std::filesystem::path& file_path,
                   const std::filesystem::path& output_root,
@@ -38,7 +37,7 @@ public:
 
     void set_variables_values(std::string sub_name,
                               const std::shared_ptr<SubproblemWorker>& worker,
-                              int iter, 
+                              int iter,
                               double new_ub);
 
     void dump_values();

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
@@ -43,7 +43,9 @@ public:
     void dump_values();
 
 private:
-    bool set_best_ub_solution_(double new_best_ub, int iter);
+    bool set_best_ub_solution_(double new_best_ub);
+    void extract_tracked_values_(const std::string& sub_name,
+                                 const std::shared_ptr<SubproblemWorker>& worker);
 
     std::ifstream file_stream_;
     mpi::communicator* _world;
@@ -51,7 +53,6 @@ private:
     Logger _logger;
 
     double best_ub_ = std::numeric_limits<double>::max();
-    int last_iteration_update_ = -1;
 
     std::vector<std::string> variables_to_follow_;
     std::map<std::string, std::vector<int>> variables_to_follow_indices_per_sub_;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/BestUbTracker.h
@@ -5,6 +5,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -52,9 +53,11 @@ private:
     std::filesystem::path output_file_;
     Logger _logger;
 
+    std::mutex mutex_;
+    std::once_flag indices_once_flag_;
     double best_ub_ = std::numeric_limits<double>::max();
 
     std::vector<std::string> variables_to_follow_;
-    std::map<std::string, std::vector<int>> variables_to_follow_indices_per_sub_;
+    std::vector<int> variables_to_follow_indices_;
     std::map<std::string, std::vector<double>> values_per_sub_;
 };

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemConstraintsManager.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemConstraintsManager.h
@@ -33,7 +33,7 @@ public:
       const std::shared_ptr<SubproblemWorker>& subproblem_worker);
 
     SolverRepresentedRows AddRows(std::string& row_name);
-    std::vector<double> GetSubSolution();
+    const std::vector<double>& GetSubSolution();
     int GetVariableIndexInSub(std::string variable_id);
     void DeleteAddedRows(int base_size);
 

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
@@ -29,9 +29,11 @@ public:
                      std::shared_ptr<SolverAbstract> solver,
                      Logger logger);
 
+    SubproblemWorker() = default ; 
+
     virtual ~SubproblemWorker() = default;
-    std::vector<double> get_solution() const;
-    int get_variable_index(const std::string& variable_name);
+    virtual std::vector<double> get_solution() const;
+    virtual int get_variable_index(const std::string& variable_name);
     void delete_rows(int start_pos);
     int get_problem_row_num();
 

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
@@ -29,7 +29,7 @@ public:
                      std::shared_ptr<SolverAbstract> solver,
                      Logger logger);
 
-    SubproblemWorker() = default ; 
+    SubproblemWorker() = default;
 
     virtual ~SubproblemWorker() = default;
     virtual std::vector<double> get_solution() const;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SubproblemWorker.h
@@ -32,7 +32,7 @@ public:
     SubproblemWorker() = default;
 
     virtual ~SubproblemWorker() = default;
-    virtual std::vector<double> get_solution() const;
+    virtual const std::vector<double>& get_solution() const;
     virtual int get_variable_index(const std::string& variable_name);
     void delete_rows(int start_pos);
     int get_problem_row_num();
@@ -41,4 +41,7 @@ public:
     void fix_to(const Point& x0) const;
 
     void get_subgradient(Point& subgradient) const;
+
+private:
+    mutable std::vector<double> solution_cache_;
 };

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
@@ -21,6 +21,7 @@ class Worker
 {
 public:
     Worker(VariableMap variable_map, Logger logger);
+    Worker() = default ; 
     void init(const std::string& solver_name,
               int log_level,
               const SolverLogManager& solver_log_manager,

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/Worker.h
@@ -21,7 +21,7 @@ class Worker
 {
 public:
     Worker(VariableMap variable_map, Logger logger);
-    Worker() = default ; 
+    Worker() = default;
     void init(const std::string& solver_name,
               int log_level,
               const SolverLogManager& solver_log_manager,

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -84,6 +84,11 @@ void BendersMpi::InitializeProblems()
     BuildMasterProblem();
     BroadCastVariablesIndices();
     init_problems_ = false;
+
+    //creating the bestUBtracker 
+    std::filesystem::path trackedVariablesFile = std::filesystem::path(_options.INPUTROOT) / "sub_variables_to_save.csv"; 
+    best_ub_tracker_ = std::make_shared<BestUbTracker>(&_world,trackedVariablesFile, std::filesystem::path(_options.OUTPUTROOT), _logger ) ; 
+    std::cout<<"set best_ub_tracker_"<<std::endl ; 
 }
 
 std::vector<SubProblemNamesInCut> BendersMpi::get_subs_per_cut(
@@ -495,6 +500,7 @@ void BendersMpi::Run()
     }
     _data.number_of_subproblem_solved = _data.nsubproblem;
 
+    std::cout<<"start running "<<std::endl ; 
     while (!_data.stop)
     {
         benders_plugin_->OnBendersIterationStart();
@@ -508,6 +514,8 @@ void BendersMpi::Run()
         benders_plugin_->OnBendersMasterResolutionStart();
 
         step_1_solve_master();
+
+        std::cout<<"finished solving master "<<std::endl ; 
 
         benders_plugin_->OnBendersMasterResolutionEnd(_data.x_cut, _data.it);
 
@@ -593,6 +601,8 @@ void BendersMpi::launch()
     _world.barrier();
 
     benders_plugin_->OnBendersEnd();
+    std::cout<<"dumping value ..... "<<std::endl ; 
+    best_ub_tracker_->dump_values() ; 
 
     post_run_actions();
 

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -499,7 +499,6 @@ void BendersMpi::Run()
     }
     _data.number_of_subproblem_solved = _data.nsubproblem;
 
-    std::cout<<"start running "<<std::endl ; 
     while (!_data.stop)
     {
         benders_plugin_->OnBendersIterationStart();
@@ -514,7 +513,6 @@ void BendersMpi::Run()
 
         step_1_solve_master();
 
-        std::cout<<"finished solving master "<<std::endl ; 
 
         benders_plugin_->OnBendersMasterResolutionEnd(_data.x_cut, _data.it);
 
@@ -600,7 +598,6 @@ void BendersMpi::launch()
     _world.barrier();
 
     benders_plugin_->OnBendersEnd();
-    std::cout<<"dumping value ..... "<<std::endl ; 
     best_ub_tracker_->dump_values() ; 
 
     post_run_actions();

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -88,7 +88,6 @@ void BendersMpi::InitializeProblems()
     //creating the bestUBtracker 
     std::filesystem::path trackedVariablesFile = std::filesystem::path(_options.INPUTROOT) / "sub_variables_to_save.csv"; 
     best_ub_tracker_ = std::make_shared<BestUbTracker>(&_world,trackedVariablesFile, std::filesystem::path(_options.OUTPUTROOT), _logger ) ; 
-    std::cout<<"set best_ub_tracker_"<<std::endl ; 
 }
 
 std::vector<SubProblemNamesInCut> BendersMpi::get_subs_per_cut(

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -85,9 +85,13 @@ void BendersMpi::InitializeProblems()
     BroadCastVariablesIndices();
     init_problems_ = false;
 
-    //creating the bestUBtracker 
-    std::filesystem::path trackedVariablesFile = std::filesystem::path(_options.INPUTROOT) / "sub_variables_to_save.csv"; 
-    best_ub_tracker_ = std::make_shared<BestUbTracker>(&_world,trackedVariablesFile, std::filesystem::path(_options.OUTPUTROOT), _logger ) ; 
+    // creating the bestUBtracker
+    std::filesystem::path trackedVariablesFile = std::filesystem::path(_options.INPUTROOT)
+                                                 / "sub_variables_to_save.csv";
+    best_ub_tracker_ = std::make_shared<BestUbTracker>(&_world,
+                                                       trackedVariablesFile,
+                                                       std::filesystem::path(_options.OUTPUTROOT),
+                                                       _logger);
 }
 
 std::vector<SubProblemNamesInCut> BendersMpi::get_subs_per_cut(
@@ -513,7 +517,6 @@ void BendersMpi::Run()
 
         step_1_solve_master();
 
-
         benders_plugin_->OnBendersMasterResolutionEnd(_data.x_cut, _data.it);
 
         /*Gather cut from each subproblem in master thread and add them to Master
@@ -598,7 +601,7 @@ void BendersMpi::launch()
     _world.barrier();
 
     benders_plugin_->OnBendersEnd();
-    best_ub_tracker_->dump_values() ; 
+    best_ub_tracker_->dump_values();
 
     post_run_actions();
 

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -320,7 +320,7 @@ void BendersMpi::SolveSubproblem(PlainData::SubProblemData& subproblem_data,
 {
     BendersBase::SolveSubproblem(subproblem_data, name, worker, post_reset_hook);
 
-    std::vector<double> solution = worker->get_solution();
+    const auto& solution = worker->get_solution();
     criterion_computation_.ComputeCriterion(SubproblemWeight(_data.nsubproblem, name),
                                             solution,
                                             subproblem_data.criteria,

--- a/tests/cpp/benders/BestUbTrackerTest.cpp
+++ b/tests/cpp/benders/BestUbTrackerTest.cpp
@@ -5,10 +5,29 @@
 #include <string>
 #include <vector>
 
+#include <boost/mpi.hpp>
+
 #include "LoggerStub.h"
 #include "antares-xpansion/benders/benders_core/BestUbTracker.h"
 #include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
 #include "gtest/gtest.h"
+
+namespace mpi = boost::mpi;
+
+boost::mpi::environment* penv = nullptr;
+boost::mpi::communicator* pworld = nullptr;
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    mpi::environment env(argc, argv);
+    mpi::communicator world;
+    penv = &env;
+    pworld = &world;
+
+    return RUN_ALL_TESTS();
+}
 
 using namespace Xpansion::Test;
 
@@ -76,14 +95,16 @@ protected:
         std::filesystem::create_directories(tmpDir_);
 
         csvFile_ = tmpDir_ / "variable_to_follow.csv";
-        std::ofstream out(csvFile_);
-        out << "variable_1,variable_2,variable_3,variable_4\n";
+        {
+            std::ofstream out(csvFile_);
+            out << "variable_1,variable_2,variable_3,variable_4\n";
+        }
 
         logger_ = std::make_shared<LoggerNOOPStub>();
         worker_1_ = std::make_shared<SubproblemWorkerTest>() ; 
         worker_2_ = std::make_shared<SubproblemWorkerTest>() ;
 
-        best_ub_tracker_ = std::make_shared<BestUbTracker>(nullptr,csvFile_,tmpDir_,logger_) ; 
+        best_ub_tracker_ = std::make_shared<BestUbTracker>(pworld,csvFile_,tmpDir_,logger_) ;
 
     }
 
@@ -102,13 +123,13 @@ protected:
 
 TEST_F(BestUbTrackerTest, ConstructorWithValidFile_DoesNotThrow)
 {
-    EXPECT_NO_THROW(BestUbTracker(nullptr, csvFile_, tmpDir_, logger_));
+    EXPECT_NO_THROW(BestUbTracker(pworld, csvFile_, tmpDir_, logger_));
 }
 
 TEST_F(BestUbTrackerTest, ConstructorWithMissingFile_DoesNotThrow)
 {
     auto missingFile = tmpDir_ / "nonexistent.csv";
-    EXPECT_NO_THROW(BestUbTracker(nullptr, missingFile, tmpDir_, logger_));
+    EXPECT_NO_THROW(BestUbTracker(pworld, missingFile, tmpDir_, logger_));
 }
 
 TEST_F(BestUbTrackerTest, SetAndDumpBehaviour) 
@@ -137,6 +158,7 @@ TEST_F(BestUbTrackerTest, SetAndDumpBehaviour)
     best_ub_tracker_->dump_values();
 
     auto result2 = read_output_csv(tmpDir_ / "sub_best_ub_variables.csv");
+    std::cout<<"resul2 size after the csv read "<<result2.size()<<std::endl ; 
 
     EXPECT_EQ(result2["sub_1"], (std::vector<double>{1., 3., 5., 5.}));
     EXPECT_EQ(result2["sub_2"], (std::vector<double>{3., 3., 5., 5.}));

--- a/tests/cpp/benders/BestUbTrackerTest.cpp
+++ b/tests/cpp/benders/BestUbTrackerTest.cpp
@@ -1,0 +1,158 @@
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "LoggerStub.h"
+#include "antares-xpansion/benders/benders_core/BestUbTracker.h"
+#include "antares-xpansion/benders/benders_core/SubproblemWorker.h"
+#include "gtest/gtest.h"
+
+using namespace Xpansion::Test;
+
+class SubproblemWorkerTest : public SubproblemWorker
+{
+public:
+    using SubproblemWorker::SubproblemWorker;
+
+    void set_solution(std::vector<double> new_sol)
+    {
+        solution_ = new_sol ;
+    }
+
+    std::vector<double> get_solution() const override
+    {
+        return solution_ ;
+    }
+
+    int get_variable_index(const std::string& variable_name) override
+    {
+        return variable_indices_map_.at(variable_name) ;
+    }
+
+private:
+    std::map<std::string, int> variable_indices_map_ = {
+        {"variable_1", 0},
+        {"variable_2", 1},
+        {"variable_3", 2},
+        {"variable_4", 3}
+    };
+    std::vector<double> solution_ ;
+};
+
+std::map<std::string, std::vector<double>> read_output_csv(const std::filesystem::path& file)
+{
+    std::map<std::string, std::vector<double>> result;
+    std::ifstream in(file);
+    std::string line;
+    std::getline(in, line); // skip header
+    while (std::getline(in, line))
+    {
+        std::istringstream ss(line);
+        std::string token;
+        std::string sub_name;
+        std::vector<double> values;
+        bool first = true;
+        while (std::getline(ss, token, ','))
+        {
+            if (first) { sub_name = token; first = false; }
+            else { values.push_back(std::stod(token)); }
+        }
+        result[sub_name] = values;
+    }
+    return result;
+}
+
+class BestUbTrackerTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        tmpDir_ = std::filesystem::temp_directory_path()
+                  / ("best_ub_tracker_test_"
+                     + std::to_string(::testing::UnitTest::GetInstance()->random_seed()));
+        std::filesystem::create_directories(tmpDir_);
+
+        csvFile_ = tmpDir_ / "variable_to_follow.csv";
+        std::ofstream out(csvFile_);
+        out << "variable_1,variable_2,variable_3,variable_4\n";
+
+        logger_ = std::make_shared<LoggerNOOPStub>();
+        worker_1_ = std::make_shared<SubproblemWorkerTest>() ; 
+        worker_2_ = std::make_shared<SubproblemWorkerTest>() ;
+
+        best_ub_tracker_ = std::make_shared<BestUbTracker>(nullptr,csvFile_,tmpDir_,logger_) ; 
+
+    }
+
+    void TearDown() override
+    {
+        std::filesystem::remove_all(tmpDir_);
+    }
+
+    std::filesystem::path tmpDir_;
+    std::filesystem::path csvFile_;
+    Logger logger_;
+    std::shared_ptr<SubproblemWorkerTest> worker_1_ ; 
+    std::shared_ptr<SubproblemWorkerTest> worker_2_ ;
+    std::shared_ptr<BestUbTracker>  best_ub_tracker_ ; 
+};
+
+TEST_F(BestUbTrackerTest, ConstructorWithValidFile_DoesNotThrow)
+{
+    EXPECT_NO_THROW(BestUbTracker(nullptr, csvFile_, tmpDir_, logger_));
+}
+
+TEST_F(BestUbTrackerTest, ConstructorWithMissingFile_DoesNotThrow)
+{
+    auto missingFile = tmpDir_ / "nonexistent.csv";
+    EXPECT_NO_THROW(BestUbTracker(nullptr, missingFile, tmpDir_, logger_));
+}
+
+TEST_F(BestUbTrackerTest, SetAndDumpBehaviour) 
+{
+    //We simulate a firest resolution by setting the solution on the sub_1 and sub_2
+    worker_1_->set_solution({1., 3., 5.,5.}) ; 
+    best_ub_tracker_->set_variables_values("sub_1",worker_1_,1,10);
+    
+    worker_2_->set_solution({3., 3., 5.,5.}) ; 
+    best_ub_tracker_->set_variables_values("sub_2",worker_2_,1,10);
+
+    best_ub_tracker_->dump_values();
+
+    auto result = read_output_csv(tmpDir_ / "sub_best_ub_variables.csv");
+
+    EXPECT_EQ(result["sub_1"], (std::vector<double>{1., 3., 5., 5.}));
+    EXPECT_EQ(result["sub_2"], (std::vector<double>{3., 3., 5., 5.}));
+
+    // Second iteration with a bigger UB — values should not be updated
+    worker_1_->set_solution({9., 8., 7., 6.}) ;
+    best_ub_tracker_->set_variables_values("sub_1", worker_1_, 2, 20);
+
+    worker_2_->set_solution({9., 8., 7., 6.}) ;
+    best_ub_tracker_->set_variables_values("sub_2", worker_2_, 2, 20);
+
+    best_ub_tracker_->dump_values();
+
+    auto result2 = read_output_csv(tmpDir_ / "sub_best_ub_variables.csv");
+
+    EXPECT_EQ(result2["sub_1"], (std::vector<double>{1., 3., 5., 5.}));
+    EXPECT_EQ(result2["sub_2"], (std::vector<double>{3., 3., 5., 5.}));
+
+    // Third iteration with a smaller UB — values should be updated
+    worker_1_->set_solution({2., 4., 6., 8.}) ;
+    best_ub_tracker_->set_variables_values("sub_1", worker_1_, 3, 5);
+
+    worker_2_->set_solution({1., 2., 3., 4.}) ;
+    best_ub_tracker_->set_variables_values("sub_2", worker_2_, 3, 5);
+
+    best_ub_tracker_->dump_values();
+
+    auto result3 = read_output_csv(tmpDir_ / "sub_best_ub_variables.csv");
+
+    EXPECT_EQ(result3["sub_1"], (std::vector<double>{2., 4., 6., 8.}));
+    EXPECT_EQ(result3["sub_2"], (std::vector<double>{1., 2., 3., 4.}));
+}
+

--- a/tests/cpp/benders/BestUbTrackerTest.cpp
+++ b/tests/cpp/benders/BestUbTrackerTest.cpp
@@ -41,7 +41,7 @@ public:
         solution_ = new_sol ;
     }
 
-    std::vector<double> get_solution() const override
+    const std::vector<double>& get_solution() const override
     {
         return solution_ ;
     }

--- a/tests/cpp/benders/CMakeLists.txt
+++ b/tests/cpp/benders/CMakeLists.txt
@@ -56,3 +56,24 @@ target_include_directories(benders_sequential_test
 
 add_test(NAME unit_benders_sequential COMMAND benders_sequential_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 set_property(TEST unit_benders_sequential PROPERTY LABELS unit)
+
+add_executable(benders_utils_test)
+target_sources(benders_utils_test
+        PRIVATE
+        BestUbTrackerTest.cpp
+)
+
+target_link_libraries(benders_utils_test
+        PRIVATE
+        antaresXpansion::benders_core
+        antaresXpansion::logger_lib
+        tests_utils
+        GTest::Main)
+
+target_include_directories(benders_utils_test
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../TestDoubles/
+)
+
+add_test(NAME unit_benders_utils COMMAND benders_utils_test WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+set_property(TEST unit_benders_utils PROPERTY LABELS unit)

--- a/tests/cpp/tests_utils/CMakeLists.txt
+++ b/tests/cpp/tests_utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(tests_utils STATIC 
+add_library(tests_utils STATIC
 						RandomDirGenerator.h RandomDirGenerator.cpp
 						LogPrefixManip.h LogPrefixManip.cpp NOOPSolver.h EmptyLogManager.h
 						 )
@@ -7,4 +7,5 @@ target_include_directories (helpers
 	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}
 )
+target_link_libraries(tests_utils PUBLIC antaresXpansion::benders_core)
 add_library (${PROJECT_NAME}::tests_utils ALIAS tests_utils)


### PR DESCRIPTION
 feat: Track subproblem variable values at best upper bound

  Motivation

  In Benders decomposition, the best upper bound (best UB) iteration produces the best feasible
  solution found. Until now, there was no way to inspect the values of specific subproblem variables
  at that iteration — useful for post-processing, diagnostics, and warm-starting downstream tools.

  What this PR does

  Introduces BestUbTracker, a component integrated into the Benders MPI kernel that monitors a
  user-defined list of subproblem variables and records their values whenever a new best UB is found.

  Usage:
  - Provide a file sub_variables_to_save.csv in the study input root with a comma-separated list of
  variable names to track
  - At the end of the run, sub_best_ub_variables.csv is written in the output root with one row per
  subproblem and one column per tracked variable, reflecting their values at the last best UB
  iteration

  Implementation:
  - BestUbTracker reads the variable list at construction, lazily resolves variable indices per
  subproblem on first encounter, and updates stored solution vectors whenever a new best UB is found
  - At the end of the run, values are gathered across MPI ranks (rank 0 collects and writes the
  output)
  - Integrated into BendersMPI and BendersBase::GetCompactInMemCuts (compact memory / skeleton mode)

