### PR TITLE
adding the dlerror to easily identify abi incompatibility issues

### DIFF
--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -133,6 +133,17 @@ Benders_MICRO_ITERS::Benders_MICRO_ITERS(const SimulationOptions& options,
     {
         std::cerr << "failed to open the plugin given on path " << cpp_lib_absolute_path
                   << std::endl;
+#ifdef _WIN32
+        DWORD err = GetLastError();
+        LPSTR msg = nullptr;
+        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                         FORMAT_MESSAGE_IGNORE_INSERTS,
+                       nullptr, err, 0, reinterpret_cast<LPSTR>(&msg), 0, nullptr);
+        std::cerr << "LoadLibraryW error (" << err << "): " << (msg ? msg : "unknown") << std::endl;
+        LocalFree(msg);
+#else
+        std::cerr << "dlerror: " << dlerror() << std::endl;
+#endif
         _world->abort(EXIT_FAILURE);
     }
 }

--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -136,9 +136,14 @@ Benders_MICRO_ITERS::Benders_MICRO_ITERS(const SimulationOptions& options,
 #ifdef _WIN32
         DWORD err = GetLastError();
         LPSTR msg = nullptr;
-        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
-                         FORMAT_MESSAGE_IGNORE_INSERTS,
-                       nullptr, err, 0, reinterpret_cast<LPSTR>(&msg), 0, nullptr);
+        FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM
+                         | FORMAT_MESSAGE_IGNORE_INSERTS,
+                       nullptr,
+                       err,
+                       0,
+                       reinterpret_cast<LPSTR>(&msg),
+                       0,
+                       nullptr);
         std::cerr << "LoadLibraryW error (" << err << "): " << (msg ? msg : "unknown") << std::endl;
         LocalFree(msg);
 #else


### PR DESCRIPTION
It can happen that the micro iteration plugin has some issue (ABI incompatibility, .so no found etc).
On this PR, we just added dlerror call that will allow to dump the error, helping user in the debug process.