### PR TITLE
Robust Resume mode

### DIFF
--- a/data_test/mini_instance_LP/options_default_restart.json
+++ b/data_test/mini_instance_LP/options_default_restart.json
@@ -13,6 +13,6 @@
      "BOUND_ALPHA": 1,
      "JSON_FILE": "./expansion/out.json",
      "LAST_ITERATION_JSON_FILE": "./expansion/last_iteration.json",
-     "RESUME": true
+     "RESUME": "resume"
 
 }

--- a/data_test/mini_instance_MIP/options_default_restart.json
+++ b/data_test/mini_instance_MIP/options_default_restart.json
@@ -13,5 +13,5 @@
      "BOUND_ALPHA": true,
      "JSON_FILE": "./expansion/out.json",
      "LAST_ITERATION_JSON_FILE": "./expansion/last_iteration.json",
-     "RESUME": true
+     "RESUME": "resume"
 }

--- a/data_test/mini_network/options_default_restart.json
+++ b/data_test/mini_network/options_default_restart.json
@@ -16,5 +16,5 @@
      "SOLVER_NAME": "COIN",
      "JSON_FILE": "./expansion/out.json",
      "LAST_ITERATION_JSON_FILE": "./expansion/last_iteration.json",
-     "RESUME": true
+     "RESUME": "resume"
 }

--- a/data_test/mini_network/options_weights_restart.json
+++ b/data_test/mini_network/options_weights_restart.json
@@ -13,5 +13,5 @@
      "BOUND_ALPHA": true,
      "JSON_FILE": "./expansion/out.json",
      "LAST_ITERATION_JSON_FILE": "./expansion/last_iteration.json",
-     "RESUME": true
+     "RESUME": "resume"
 }

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -68,9 +68,9 @@ void BendersBase::OpenCsvFile()
 {
     if (!_csv_file.is_open())
     {
-        const auto opening_mode = _options.RESUME ? std::ios::app : std::ios::trunc;
+        const auto opening_mode = IsResumeMode() ? std::ios::app : std::ios::trunc;
         _csv_file.open(_csv_file_path, std::ios::out | opening_mode);
-        if (_csv_file && !_options.RESUME)
+        if (_csv_file && !IsResumeMode())
         {
             _csv_file << "Ite;Worker;Problem;Id;UB;LB;bestUB;simplexiter;jump;single_"
                          "subpb_costs_under_approx;"
@@ -1311,7 +1311,7 @@ void BendersBase::ResetSimplexIterationsBounds()
 
 bool BendersBase::IsResumeMode() const
 {
-    return _options.RESUME;
+    return _options.RESUME == 1;
 }
 
 void BendersBase::UpdateMaxNumberIterationResumeMode(int nb_iteration_done)
@@ -1338,7 +1338,7 @@ double BendersBase::execution_time() const
 void BendersBase::ChecksResumeMode()
 {
     benders_timer = Timer();
-    if (IsResumeMode())
+    if (_options.RESUME == 1)
     {
         auto reader = LastIterationReader(LastIterationFile());
         LogData last_iter;

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -1311,7 +1311,7 @@ void BendersBase::ResetSimplexIterationsBounds()
 
 bool BendersBase::IsResumeMode() const
 {
-    return _options.RESUME == 1;
+    return _options.RESUME == ResumeMode::RESUME;
 }
 
 void BendersBase::UpdateMaxNumberIterationResumeMode(int nb_iteration_done)
@@ -1338,7 +1338,7 @@ double BendersBase::execution_time() const
 void BendersBase::ChecksResumeMode()
 {
     benders_timer = Timer();
-    if (_options.RESUME == 1)
+    if (IsResumeMode())
     {
         auto reader = LastIterationReader(LastIterationFile());
         LogData last_iter;

--- a/src/cpp/benders/benders_core/SimulationOptions.cpp
+++ b/src/cpp/benders/benders_core/SimulationOptions.cpp
@@ -28,6 +28,12 @@ inline ProblemsFormat Json::Value::as<ProblemsFormat>() const
     return problemsFormatFromString(asString());
 }
 
+template<>
+inline ResumeMode Json::Value::as<ResumeMode>() const
+{
+    return resumeModeFromString(asString());
+}
+
 /*!
  *  \brief Constructor of Benders Options
  *

--- a/src/cpp/benders/benders_core/StartUp.cpp
+++ b/src/cpp/benders/benders_core/StartUp.cpp
@@ -11,7 +11,7 @@ bool StartUp::StudyAlreadyAchievedCriterion(const SimulationOptions& options,
                                             Output::OutputWriter* writer,
                                             ILogger* logger) const
 {
-    if (options.RESUME != 1)
+    if (options.RESUME != ResumeMode::RESUME)
     {
         return false;
     }

--- a/src/cpp/benders/benders_core/StartUp.cpp
+++ b/src/cpp/benders/benders_core/StartUp.cpp
@@ -11,7 +11,7 @@ bool StartUp::StudyAlreadyAchievedCriterion(const SimulationOptions& options,
                                             Output::OutputWriter* writer,
                                             ILogger* logger) const
 {
-    if (!options.RESUME)
+    if (options.RESUME != 1)
     {
         return false;
     }

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
@@ -72,7 +72,7 @@ BENDERS_OPTIONS_MACRO(TIME_LIMIT, double, 1e12, asDouble())
 // LAST_MASTER_MPS
 BENDERS_OPTIONS_MACRO(LAST_MASTER_MPS, std::string, "master_last_iteration", asString())
 // Resume last benders
-BENDERS_OPTIONS_MACRO(RESUME, bool, false, asBool())
+BENDERS_OPTIONS_MACRO(RESUME, int, 0, asInt())
 
 // Name of the last master basis file
 BENDERS_OPTIONS_MACRO(LAST_MASTER_BASIS, std::string, "master_last_basis", asString())

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
@@ -72,7 +72,7 @@ BENDERS_OPTIONS_MACRO(TIME_LIMIT, double, 1e12, asDouble())
 // LAST_MASTER_MPS
 BENDERS_OPTIONS_MACRO(LAST_MASTER_MPS, std::string, "master_last_iteration", asString())
 // Resume last benders
-BENDERS_OPTIONS_MACRO(RESUME, int, 0, asInt())
+BENDERS_OPTIONS_MACRO(RESUME, ResumeMode, ResumeMode::COLD_START, as<ResumeMode>())
 
 // Name of the last master basis file
 BENDERS_OPTIONS_MACRO(LAST_MASTER_BASIS, std::string, "master_last_basis", asString())

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -220,7 +220,7 @@ struct BendersBaseOptions: public SolverBaseOptions
     double MASTER_SOLUTION_TOLERANCE = 1e-4;
     double CUT_COEFFICIENT_TOLERANCE = 5e-3;
 
-    bool RESUME = false;
+    int RESUME = 0;
     bool MICRO_ITERATIONS = false;
     int NB_CUTS_PER_ITER = 0;
     bool TRACE = false;

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "antares-xpansion/core/ProblemFormat.h"
+#include "antares-xpansion/core/ResumeMode.h"
 
 enum class MasterFormulation
 {
@@ -220,7 +221,7 @@ struct BendersBaseOptions: public SolverBaseOptions
     double MASTER_SOLUTION_TOLERANCE = 1e-4;
     double CUT_COEFFICIENT_TOLERANCE = 5e-3;
 
-    int RESUME = 0;
+    ResumeMode RESUME = ResumeMode::COLD_START;
     bool MICRO_ITERATIONS = false;
     int NB_CUTS_PER_ITER = 0;
     bool TRACE = false;

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -156,7 +156,7 @@ void BendersMpi::InitializeMaster()
                                    get_log_level(),
                                    _data.nsubproblem,
                                    solver_log_manager_,
-                                   IsResumeMode(),
+                                   _options.RESUME != 0,
                                    _logger,
                                    Options().PROBLEMS_FORMAT,
                                    benders_problem_provider.get(),

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -156,7 +156,7 @@ void BendersMpi::InitializeMaster()
                                    get_log_level(),
                                    _data.nsubproblem,
                                    solver_log_manager_,
-                                   _options.RESUME != 0,
+                                   _options.RESUME != ResumeMode::COLD_START,
                                    _logger,
                                    Options().PROBLEMS_FORMAT,
                                    benders_problem_provider.get(),

--- a/src/cpp/benders/benders_sequential/BendersSequential.cpp
+++ b/src/cpp/benders/benders_sequential/BendersSequential.cpp
@@ -40,7 +40,7 @@ void BendersSequential::InitializeProblems()
                                get_log_level(),
                                _data.nsubproblem,
                                solver_log_manager_,
-                               _options.RESUME != 0,
+                               _options.RESUME != ResumeMode::COLD_START,
                                _logger,
                                Options().PROBLEMS_FORMAT,
                                benders_problem_provider.get(),

--- a/src/cpp/benders/benders_sequential/BendersSequential.cpp
+++ b/src/cpp/benders/benders_sequential/BendersSequential.cpp
@@ -40,7 +40,7 @@ void BendersSequential::InitializeProblems()
                                get_log_level(),
                                _data.nsubproblem,
                                solver_log_manager_,
-                               IsResumeMode(),
+                               _options.RESUME != 0,
                                _logger,
                                Options().PROBLEMS_FORMAT,
                                benders_problem_provider.get(),

--- a/src/cpp/benders/factories/BendersApp.cpp
+++ b/src/cpp/benders/factories/BendersApp.cpp
@@ -104,6 +104,13 @@ void BendersApp::InitializeBendersEnvironment(bool outer_loop)
             throw std::runtime_error(
               "Could not initialize benders. Please see above messages for actual error.");
         }
+        if (logger_)
+        {
+            logger_->display_message(
+              "Benders optimization was NOT executed: the previous run status is already "
+              "OPTIMAL in resume mode. If input data has changed since the last run, "
+              "delete the output JSON file or use a non-resume mode to force re-optimization.");
+        }
         return;
     }
     auto&& environment = env.value();

--- a/src/cpp/benders/factories/WriterFactories.cpp
+++ b/src/cpp/benders/factories/WriterFactories.cpp
@@ -12,10 +12,10 @@ std::shared_ptr<Output::OutputWriter> build_void_writer()
 }
 
 std::shared_ptr<Output::OutputWriter> build_json_writer(const std::filesystem::path& json_file_name,
-                                                        const bool restart)
+                                                        const int restart)
 {
     std::shared_ptr<Output::OutputWriter> writer;
-    if (restart)
+    if (restart == 1)
     {
         auto out_json_content = get_json_file_content(json_file_name);
         writer = std::make_shared<Output::JsonWriter>(json_file_name, out_json_content);

--- a/src/cpp/benders/factories/WriterFactories.cpp
+++ b/src/cpp/benders/factories/WriterFactories.cpp
@@ -12,10 +12,10 @@ std::shared_ptr<Output::OutputWriter> build_void_writer()
 }
 
 std::shared_ptr<Output::OutputWriter> build_json_writer(const std::filesystem::path& json_file_name,
-                                                        const int restart)
+                                                        ResumeMode restart)
 {
     std::shared_ptr<Output::OutputWriter> writer;
-    if (restart == 1)
+    if (restart == ResumeMode::RESUME)
     {
         auto out_json_content = get_json_file_content(json_file_name);
         writer = std::make_shared<Output::JsonWriter>(json_file_name, out_json_content);

--- a/src/cpp/benders/factories/include/antares-xpansion/benders/factories/WriterFactories.h
+++ b/src/cpp/benders/factories/include/antares-xpansion/benders/factories/WriterFactories.h
@@ -10,6 +10,6 @@
 std::shared_ptr<Output::OutputWriter> build_void_writer();
 
 std::shared_ptr<Output::OutputWriter> build_json_writer(const std::filesystem::path& json_file_name,
-                                                        bool restart);
+                                                        const int restart);
 
 #endif // ANTARESXPANSION_WRITERFACTORIES_H

--- a/src/cpp/benders/factories/include/antares-xpansion/benders/factories/WriterFactories.h
+++ b/src/cpp/benders/factories/include/antares-xpansion/benders/factories/WriterFactories.h
@@ -5,11 +5,12 @@
 #include <filesystem>
 #include <string>
 
+#include "antares-xpansion/benders/benders_core/common.h"
 #include "antares-xpansion/benders/output/OutputWriter.h"
 
 std::shared_ptr<Output::OutputWriter> build_void_writer();
 
 std::shared_ptr<Output::OutputWriter> build_json_writer(const std::filesystem::path& json_file_name,
-                                                        const int restart);
+                                                        ResumeMode restart);
 
 #endif // ANTARESXPANSION_WRITERFACTORIES_H

--- a/src/cpp/core/include/antares-xpansion/core/ResumeMode.h
+++ b/src/cpp/core/include/antares-xpansion/core/ResumeMode.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <ostream>
+#include <stdexcept>
+#include <string>
+
+enum class ResumeMode
+{
+    COLD_START = 0,
+    RESUME = 1,
+    HOT_START = 2
+};
+
+inline ResumeMode resumeModeFromString(const std::string& str)
+{
+    if (str == "0" || str == "cold_start")
+    {
+        return ResumeMode::COLD_START;
+    }
+    if (str == "1" || str == "resume")
+    {
+        return ResumeMode::RESUME;
+    }
+    if (str == "2" || str == "hot_start")
+    {
+        return ResumeMode::HOT_START;
+    }
+    throw std::runtime_error("Unknown ResumeMode: " + str
+                             + " (expected 0, 1, 2, cold_start, resume, or hot_start)");
+}
+
+inline std::ostream& operator<<(std::ostream& stream, const ResumeMode& mode)
+{
+    switch (mode)
+    {
+    case ResumeMode::COLD_START:
+        stream << "cold_start";
+        break;
+    case ResumeMode::RESUME:
+        stream << "resume";
+        break;
+    case ResumeMode::HOT_START:
+        stream << "hot_start";
+        break;
+    }
+    return stream;
+}

--- a/src/cpp/exe/merge/main.cpp
+++ b/src/cpp/exe/merge/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
 
     std::shared_ptr<Output::OutputWriter> writer = build_json_writer(std::filesystem::path(
                                                                        options.JSON_FILE),
-                                                                     0);
+                                                                     ResumeMode::COLD_START);
     try
     {
         MergeMPS merge_mps(options.get_solver_options(), logger, writer);

--- a/src/cpp/exe/merge/main.cpp
+++ b/src/cpp/exe/merge/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
 
     std::shared_ptr<Output::OutputWriter> writer = build_json_writer(std::filesystem::path(
                                                                        options.JSON_FILE),
-                                                                     false);
+                                                                     0);
     try
     {
         MergeMPS merge_mps(options.get_solver_options(), logger, writer);

--- a/src/cpp/exe/merge_master/main.cpp
+++ b/src/cpp/exe/merge_master/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
 
     std::shared_ptr<Output::OutputWriter> writer = build_json_writer(std::filesystem::path(
                                                                        options.JSON_FILE),
-                                                                     0);
+                                                                     ResumeMode::COLD_START);
     try
     {
         logger->display_message("Given tree path is : " + std::string(argv[2]),

--- a/src/cpp/exe/merge_master/main.cpp
+++ b/src/cpp/exe/merge_master/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
 
     std::shared_ptr<Output::OutputWriter> writer = build_json_writer(std::filesystem::path(
                                                                        options.JSON_FILE),
-                                                                     false);
+                                                                     0);
     try
     {
         logger->display_message("Given tree path is : " + std::string(argv[2]),

--- a/src/python/antares_xpansion/resume_study.py
+++ b/src/python/antares_xpansion/resume_study.py
@@ -104,7 +104,7 @@ class ResumeStudy:
 
         assert master_file_path.exists()
 
-        options[OptimisationKeys.resume_key()] = True
+        options[OptimisationKeys.resume_key()] = "resume"
         with open(options_file_path, "w") as options_json:
             json.dump(options, options_json, indent=4)
 

--- a/tests/cpp/benders/BendersBaseTest.cpp
+++ b/tests/cpp/benders/BendersBaseTest.cpp
@@ -142,7 +142,7 @@ protected:
         BendersBaseOptions options(solver_options);
         options.SEPARATION_PARAM = sep_param;
         options.MASTER_FORMULATION = MasterFormulation::RELAXED;
-        options.RESUME = false;
+        options.RESUME = ResumeMode::COLD_START;
         options.NB_CUTS_PER_ITER = false;
         options.TRACE = false;
         options.BOUND_ALPHA = true;

--- a/tests/cpp/benders/BendersMicroIterationsTest.cpp
+++ b/tests/cpp/benders/BendersMicroIterationsTest.cpp
@@ -197,7 +197,7 @@ protected:
         BendersBaseOptions options(solver_options);
         options.SEPARATION_PARAM = 0.5;
         options.MASTER_FORMULATION = MasterFormulation::RELAXED;
-        options.RESUME = false;
+        options.RESUME = ResumeMode::COLD_START;
         options.NB_CUTS_PER_ITER = false;
         options.TRACE = false;
         options.BOUND_ALPHA = true;

--- a/tests/cpp/benders/benders_sequential_test.cpp
+++ b/tests/cpp/benders/benders_sequential_test.cpp
@@ -243,7 +243,7 @@ protected:
 
         options.MASTER_FORMULATION = master_formulation;
 
-        options.RESUME = false;
+        options.RESUME = ResumeMode::COLD_START;
         options.NB_CUTS_PER_ITER = false;
         options.TRACE = false;
         options.BOUND_ALPHA = true;

--- a/tests/cpp/restart_benders/restart_lib_tests.cpp
+++ b/tests/cpp/restart_benders/restart_lib_tests.cpp
@@ -157,7 +157,7 @@ TEST(Resume, ShouldNotResumeIfCriterionOk)
     options.ABSOLUTE_GAP = 100.f;
     options.RELATIVE_GAP = 200.f;
     options.TIME_LIMIT = 500.f;
-    options.RESUME = true;
+    options.RESUME = ResumeMode::RESUME;
 
     auto writer = std::make_shared<WriterMockStatus>();
     auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
@@ -172,7 +172,7 @@ TEST(Resume, DontResumeIfOptionOff)
     options.ABSOLUTE_GAP = 100.f;
     options.RELATIVE_GAP = 200.f;
     options.TIME_LIMIT = 500.f;
-    options.RESUME = false;
+    options.RESUME = ResumeMode::COLD_START;
 
     auto writer = std::make_shared<WriterMockStatus>();
     auto logger = std::make_shared<Xpansion::Test::LoggerNOOPStub>();
@@ -187,7 +187,7 @@ TEST(Resume, ContinueIfCreterionNotMatch)
     options.ABSOLUTE_GAP = 100.f;
     options.RELATIVE_GAP = 200.f;
     options.TIME_LIMIT = 500.f;
-    options.RESUME = true;
+    options.RESUME = ResumeMode::RESUME;
 
     auto writer = std::make_shared<WriterMockStatus>();
     writer->status = "NotOptimal";

--- a/tests/end_to_end/cucumber/features/benders_resume_modes.feature
+++ b/tests/end_to_end/cucumber/features/benders_resume_modes.feature
@@ -1,0 +1,29 @@
+Feature: Resume modes of Benders
+
+@fast @short @resume
+Scenario: Benders runs for 2 iterations then we resume it from there to convergence
+    Given the study path is "data_test/ieee96_base"
+    When I set MAX_ITERATIONS to 2
+    And I run benders with 1 proc(s)
+    Then the simulation succeeds
+    And the problem_status is "limit reached"
+    And the expected investment cost is 3.2615786040443573
+    When I set MAX_ITERATIONS to -1
+    And I set RESUME to "resume"
+    And I run benders with 1 proc(s)
+    Then the simulation succeeds
+    And the problem_status is "OPTIMAL"
+    And the expected investment cost is 1.6307893020221786
+
+@fast @short @resume 
+Scenario: Benders runs until optimality then we relaunch it with hot start 
+    Given the study path is "data_test/ieee96_base"
+    When I run benders with 1 proc(s) 
+    Then the simulation succeeds
+    And the problem_status is "OPTIMAL" 
+    And the expected investment cost is 1.6307893020221786
+    When I set RESUME to "hot_start"
+    And I run benders with 1 proc(s)
+    Then the simulation succeeds
+    And the number of iterations is 1
+

--- a/tests/end_to_end/cucumber/features/steps/then.py
+++ b/tests/end_to_end/cucumber/features/steps/then.py
@@ -291,6 +291,18 @@ def check_simulator_solver(context, string):
     assert (find_in_simulator_log(context.tmp_study / "output", string_to_find))
 
 
+@then('the problem_status is "{problem_status}"')
+def check_problem_status(context, problem_status):
+    actual = context.outputs["solution"]["problem_status"]
+    assert actual == problem_status, f"Expected problem_status '{problem_status}', got '{actual}'"
+
+
+@then('the number of iterations is {n:d}')
+def check_number_of_iterations(context, n):
+    actual = len(context.outputs["iterations"])
+    assert actual == n, f"Expected {n} iterations, got {actual}"
+
+
 @then('Benders has been launched with solver "{string}"')
 def check_benders_solver(context, string):
     solver_in_benders = context.options_data["SOLVER_NAME"]

--- a/tests/end_to_end/cucumber/features/steps/when.py
+++ b/tests/end_to_end/cucumber/features/steps/when.py
@@ -189,6 +189,32 @@ def step_problem_generation_memory(context, step, memory_mode=None, pb_format=No
     run_xpansion_step(context, step, memory_mode, pb_format, nproc=1)
 
 
+@when('I set MAX_ITERATIONS to {max_iterations:d}')
+def set_max_iterations(context, max_iterations):
+    options_path = Path(context.tmp_study) / "options.json"
+    with open(options_path, "r") as file:
+        options_content = json.load(file)
+    options_content["MAX_ITERATIONS"] = max_iterations
+    with open(options_path, "w") as file:
+        json.dump(options_content, file, indent=4)
+
+
+@when('I set RESUME to "{resume_mode}"')
+def set_resume_mode(context, resume_mode):
+    import shutil
+    study_path = Path(context.tmp_study)
+    options_path = study_path / "options.json"
+    with open(options_path, "r") as file:
+        options_content = json.load(file)
+    options_content["RESUME"] = resume_mode
+    with open(options_path, "w") as file:
+        json.dump(options_content, file, indent=4)
+    # Replace master.mps with master_last_iteration.mps (which contains the accumulated cuts)
+    last_master = study_path / "master_last_iteration.mps"
+    master = study_path / "master.mps"
+    shutil.copy(last_master, master)
+
+
 @when('I run antares-xpansion in trajectory')
 def run_trajectory_mode(context):
     """Run the trajectory investment workflow (full step) and load outputs"""


### PR DESCRIPTION
# feat(benders): robust resume mode — separate RESUME and HOT_START semantics

## Summary

- **Replaces the boolean `RESUME` flag with a three-value `ResumeMode` enum** (`COLD_START`, `RESUME`, `HOT_START`), giving explicit semantics to each re-entry scenario in the Benders algorithm.
- **`RESUME` mode** continues a partially completed simulation from an intermediate iteration — it appends to CSV logs, loads previous JSON output state (best UB, iteration data), and reads the saved master basis/cuts.
- **`HOT_START` mode** starts a fresh simulation (reinitialised output files, iteration count reset to 0) but reads an enriched `master.mps` that already contains accumulated cuts from a prior run, enabling convergence in far fewer iterations.
- **New Cucumber end-to-end tests** validate both modes: resume verifies continued convergence across stop/restart, and hot start verifies that a fully-converged master reconverges in exactly 1 iteration.

## Key changes

| Area | What changed |
|---|---|
| **Core type** | New `ResumeMode` enum in `ResumeMode.h` with string/int parsing (`resumeModeFromString`) |
| **Options** | `SimulationOptions` and `BendersBaseOptions` changed from `bool RESUME` to `ResumeMode RESUME` with a template specialization for deserialization |
| **C++ logic** | `BendersBase`, `StartUp`, `WriterFactories`, `BendersMPI`, `BendersSequential` — branching on enum values instead of bool; HOT_START shares master-read path with RESUME but does **not** load previous output state |
| **Python** | `resume_study.py` now writes `"resume"` (string) instead of `true` (bool) to the options JSON |
| **Test data** | 4 JSON option files updated from `"RESUME": true` to `"RESUME": "resume"` |
| **E2E tests** | New `benders_resume_modes.feature` with Resume and Hot Start scenarios + supporting step definitions |
| **Unit tests** | All C++ tests updated to use `ResumeMode::COLD_START` / `ResumeMode::RESUME` |
