### PR TITLE
Replace int CACHE_PROBLEMS with CacheProblems enum class

### DIFF
--- a/data_test/ieee96_base/options.json
+++ b/data_test/ieee96_base/options.json
@@ -22,7 +22,7 @@
     "SOLVER_NAME": "COIN",
     "LOG_LEVEL": 2,
     "MAX_ITERATIONS": -1,
-    "CACHE_PROBLEMS": 0,
+    "CACHE_PROBLEMS": "NO_CACHE",
     "AGGREGATION": 0,
     "CSV_NAME": "benders_output_trace",
     "OUTPUTROOT": "."

--- a/data_test/ieee96_micro_it/options.json
+++ b/data_test/ieee96_micro_it/options.json
@@ -22,7 +22,7 @@
     "SOLVER_NAME": "COIN",
     "LOG_LEVEL": 2,
     "MAX_ITERATIONS": -1,
-    "CACHE_PROBLEMS": 0,
+    "CACHE_PROBLEMS": "NO_CACHE",
     "AGGREGATION": 0,
     "CSV_NAME": "benders_output_trace",
     "OUTPUTROOT": "."

--- a/data_test/ieee96_micro_it_skeleton_study/options.json
+++ b/data_test/ieee96_micro_it_skeleton_study/options.json
@@ -22,7 +22,7 @@
     "SOLVER_NAME": "COIN",
     "LOG_LEVEL": 2,
     "MAX_ITERATIONS": -1,
-    "CACHE_PROBLEMS": 2,
+    "CACHE_PROBLEMS": "COMPACT",
     "AGGREGATION": 0,
     "CSV_NAME": "benders_output_trace",
     "OUTPUTROOT": "."

--- a/data_test/ieee96_skeleton/options.json
+++ b/data_test/ieee96_skeleton/options.json
@@ -22,7 +22,7 @@
     "SOLVER_NAME": "COIN",
     "LOG_LEVEL": 2,
     "MAX_ITERATIONS": -1,
-    "CACHE_PROBLEMS": 2,
+    "CACHE_PROBLEMS": "COMPACT",
     "AGGREGATION": 0,
     "CSV_NAME": "benders_output_trace",
     "OUTPUTROOT": "."

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -225,7 +225,7 @@ step for rows where it doesn't apply.
   steps operate on that copy
 - `the batch size is <n>` — sets `BATCH_SIZE` in `options.json`
 - `the cache problems level is <n>` — sets `CACHE_PROBLEMS` in `options.json`
-  (0 = resident subproblems, 1 = reload-from-disk with basis caching, 2 =
+  (`NO_CACHE` = resident subproblems, `PER_SUB` = reload-from-disk with basis caching, `COMPACT` =
   compact skeleton representation — the last requires the study's `sub/`
   layout to actually be in the compact CSV format, not per-subproblem MPS)
 

--- a/docs/reference/benders/in-memory-compact-subproblems.md
+++ b/docs/reference/benders/in-memory-compact-subproblems.md
@@ -3,16 +3,16 @@
 ## Motivation
 
 
-#### CACHE_PROBLEMS = 0
+#### CACHE_PROBLEMS = NO_CACHE
 In the Benders decomposition framework, the resolution starts by loading the
 MPS/SVF files of all the subproblems, so that each of them is held in memory as
 a fully instantiated optimization problem for the whole duration of the run. 
 
 
-#### CACHE_PROBLEMS = 1
+#### CACHE_PROBLEMS = PER_SUB
 A first RAM usage optimization has been implemented by loading the optimization problem from disk just before solving it.
 
-#### CACHE_PROBLEMS = 2
+#### CACHE_PROBLEMS = COMPACT
 However, the disk footprint of the input data remains drastically high and can become problematic as the number and size of subproblems increase, potentially becoming the bottleneck before computation even starts.
 
 Yet this cost is largely redundant: the subproblems share a huge part of their columns and rows — the

--- a/docs/reference/benders/options.md
+++ b/docs/reference/benders/options.md
@@ -47,7 +47,7 @@ The following attributes are defined in the `options.json` file:
 |OUTPUTROOT | `.` |  Path to the folder where output files should be printed  | `boolean` |
 |OUTER_LOOP_OPTION_FILE | `adequacy_criterion.yml` |  Outer Loop Options file  |`string`|
 |AREA_FILE | `area.txt` |  Area file used to get areas on which external criteria (LOLD, UnsuppliedEnergy) are computed |`string` |
-|CACHE_PROBLEMS | `0` |  Subproblem caching mode: `0` = all problems loaded in memory (classic mode), `1` = subproblems stored in disk cache rather than loaded in memory (reduces RAM usage at the expense of a slight CPU time performance reduction), `2` = disk-optimized mode using a shared skeleton problem with per-subproblem CSV data  | `0`, `1` or `2` |
+|CACHE_PROBLEMS | `NO_CACHE` |  Subproblem caching mode: `NO_CACHE` = all problems loaded in memory (classic mode), `PER_SUB` = subproblems stored in disk cache rather than loaded in memory (reduces RAM usage at the expense of a slight CPU time performance reduction), `COMPACT` = disk-optimized mode using a shared skeleton problem with per-subproblem CSV data  | `NO_CACHE`, `PER_SUB` or `COMPACT` |
 |PROBLEMS_FORMAT | `MPS_FILE` |  Format of the problems |`MPS_FILE` or `OPTIMIZED` |
 |MASTER_SOLUTION_TOLERANCE | `1e-4` |  Tolerance for rounding the solution variables of the master problem (to avoid subproblems infeasibilities) | `double` > 0|
 |CUT_COEFFICIENT_TOLERANCE | `5e-3` |  Cofficient under which cuts coefficients and right-hand sides are considered to be zero | `double` > 0|

--- a/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
+++ b/src/cpp/benders/benders_by_batch/BendersByBatch.cpp
@@ -54,8 +54,8 @@ void BendersByBatch::BuildBatches()
     {
         switch (_options.CACHE_PROBLEMS)
         {
-        case 1:
-        case 2:
+        case CacheProblems::PER_SUB:
+        case CacheProblems::COMPACT:
         {
             for (auto it = batch.sub_problem_names.begin(); it != batch.sub_problem_names.end();)
             {
@@ -74,7 +74,7 @@ void BendersByBatch::BuildBatches()
             batch.sub_problem_names.shrink_to_fit();
             break;
         }
-        case 0:
+        case CacheProblems::NO_CACHE:
         default:
         {
             for (int problem_pos = 0; problem_pos < batch.sub_problem_names.size(); problem_pos++)
@@ -539,13 +539,13 @@ void BendersByBatch::GetSubproblemCut(SubProblemDataMap& subproblem_data_map,
 {
     switch (Options().CACHE_PROBLEMS)
     {
-    case 2:
+    case CacheProblems::COMPACT:
         GetCompactInMemCuts(subproblem_data_map, batch_sub_problems);
         break;
-    case 1:
+    case CacheProblems::PER_SUB:
         GetSubproblemCutCache(subproblem_data_map, batch_sub_problems);
         break;
-    case 0:
+    case CacheProblems::NO_CACHE:
     default:
         GetSubproblemCutFast(subproblem_data_map, batch_sub_problems);
         break;

--- a/src/cpp/benders/benders_core/BendersBase.cpp
+++ b/src/cpp/benders/benders_core/BendersBase.cpp
@@ -482,14 +482,13 @@ void BendersBase::GetSubproblemCut(SubProblemDataMap& subproblem_data_map)
 {
     switch (Options().CACHE_PROBLEMS)
     {
-    case 0:
-
+    case CacheProblems::NO_CACHE:
         GetSubproblemCutFast(subproblem_data_map);
         break;
-    case 1:
+    case CacheProblems::PER_SUB:
         GetSubproblemCutCache(subproblem_data_map);
         break;
-    case 2:
+    case CacheProblems::COMPACT:
         GetCompactInMemCuts(subproblem_data_map);
         break;
     default:

--- a/src/cpp/benders/benders_core/SimulationOptions.cpp
+++ b/src/cpp/benders/benders_core/SimulationOptions.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <json/json.h>
 
+#include "antares-xpansion/core/CacheProblems.h"
 #include "antares-xpansion/core/ProblemFormatStream.h"
 #include "antares-xpansion/xpansion_interfaces/LogUtils.h"
 
@@ -26,6 +27,12 @@ template<>
 inline ProblemsFormat Json::Value::as<ProblemsFormat>() const
 {
     return problemsFormatFromString(asString());
+}
+
+template<>
+inline CacheProblems Json::Value::as<CacheProblems>() const
+{
+    return cacheProblemsFromString(asString());
 }
 
 /*!

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
@@ -90,7 +90,10 @@ BENDERS_OPTIONS_MACRO(OUTER_LOOP_OPTION_FILE, std::string, "adequacy_criterion.y
 BENDERS_OPTIONS_MACRO(AREA_FILE, std::string, "area.txt", asString())
 
 // cache problems
-BENDERS_OPTIONS_MACRO(CACHE_PROBLEMS, int, 0, asInt())
+BENDERS_OPTIONS_MACRO(CACHE_PROBLEMS,
+                      CacheProblems,
+                      CacheProblems::NO_CACHE,
+                      as<CacheProblems>())
 
 // Master solution tolerance
 BENDERS_OPTIONS_MACRO(MASTER_SOLUTION_TOLERANCE, double, 1e-4, asDouble())

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/SimulationOptions.hxx
@@ -90,10 +90,7 @@ BENDERS_OPTIONS_MACRO(OUTER_LOOP_OPTION_FILE, std::string, "adequacy_criterion.y
 BENDERS_OPTIONS_MACRO(AREA_FILE, std::string, "area.txt", asString())
 
 // cache problems
-BENDERS_OPTIONS_MACRO(CACHE_PROBLEMS,
-                      CacheProblems,
-                      CacheProblems::NO_CACHE,
-                      as<CacheProblems>())
+BENDERS_OPTIONS_MACRO(CACHE_PROBLEMS, CacheProblems, CacheProblems::NO_CACHE, as<CacheProblems>())
 
 // Master solution tolerance
 BENDERS_OPTIONS_MACRO(MASTER_SOLUTION_TOLERANCE, double, 1e-4, asDouble())

--- a/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
+++ b/src/cpp/benders/benders_core/include/antares-xpansion/benders/benders_core/common.h
@@ -22,6 +22,7 @@
 #include <tuple>
 #include <vector>
 
+#include "antares-xpansion/core/CacheProblems.h"
 #include "antares-xpansion/core/ProblemFormat.h"
 
 enum class MasterFormulation
@@ -225,7 +226,7 @@ struct BendersBaseOptions: public SolverBaseOptions
     int NB_CUTS_PER_ITER = 0;
     bool TRACE = false;
     bool BOUND_ALPHA = false;
-    int CACHE_PROBLEMS = 0;
+    CacheProblems CACHE_PROBLEMS = CacheProblems::NO_CACHE;
 
     MasterFormulation MASTER_FORMULATION;
 

--- a/src/cpp/benders/benders_mpi/BendersMPI.cpp
+++ b/src/cpp/benders/benders_mpi/BendersMPI.cpp
@@ -37,7 +37,7 @@ void BendersMpi::InitializeProblems()
 {
     MatchProblemToId();
     SubProblemNamesInCut subs_per_proc;
-    if (_options.CACHE_PROBLEMS > 0)
+    if (_options.CACHE_PROBLEMS != CacheProblems::NO_CACHE)
     {
         int current_problem_id = 0;
         for (auto it = coupling_map_.begin(); it != coupling_map_.end();)
@@ -577,7 +577,7 @@ void BendersMpi::launch()
     _world.barrier();
 
     std::shared_ptr<SolverAbstract> subProblemFactorSolver;
-    if (_options.CACHE_PROBLEMS == 2)
+    if (_options.CACHE_PROBLEMS == CacheProblems::COMPACT)
     {
         subProblemFactorSolver = build_sub_problem_skeleton();
     }

--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -230,12 +230,12 @@ void Benders_MICRO_ITERS::OnBendersStart(const SubproblemsMapPtr& subproblem_map
 
     switch (options.CACHE_PROBLEMS)
     {
-    // as in case 1 we have nothing to build initially , we load the constraint file in
+    // as in case PER_SUB we have nothing to build initially, we load the constraint file in
     // BendersSubResolutionstart
-    case 0:
+    case CacheProblems::NO_CACHE:
         build_subproblem_constraints_manager_map(subproblem_map, options, solver_log_manager);
         break;
-    case 2:
+    case CacheProblems::COMPACT:
         build_skeleton_constraint_set_loader(options);
         break;
     default:
@@ -284,15 +284,15 @@ void Benders_MICRO_ITERS::OnBendersIterationStart()
 void Benders_MICRO_ITERS::OnBendersIterationEnd()
 {
     OnBendersIterationEnd_();
-    if (options_.CACHE_PROBLEMS < 2)
+    if (options_.CACHE_PROBLEMS != CacheProblems::COMPACT)
     {
         if (!warm_start_)
         {
-            if (options_.CACHE_PROBLEMS == 0)
+            if (options_.CACHE_PROBLEMS == CacheProblems::NO_CACHE)
             {
-                // Only CACHE_PROBLEMS==0 keeps the same manager alive across iterations, so
+                // Only NO_CACHE keeps the same manager alive across iterations, so
                 // it is the only mode where added rows must be physically removed here.
-                // CACHE_PROBLEMS==1 rebuilds a fresh manager from disk on the next
+                // PER_SUB rebuilds a fresh manager from disk on the next
                 // OnBendersSubResolutionStart, making this step moot for that mode.
                 for (auto& [sub_name, constraint_mgr_name]: subproblem_constraint_map_)
                 {
@@ -347,7 +347,7 @@ void Benders_MICRO_ITERS::build_variables_to_follow_indices_vector()
 
 SubproblemConstraintsManagerPtr Benders_MICRO_ITERS::GetActiveManager(const std::string& sub_name)
 {
-    if (options_.CACHE_PROBLEMS < 2)
+    if (options_.CACHE_PROBLEMS != CacheProblems::COMPACT)
     {
         std::string constraints_manager_name = subproblem_constraint_map_[sub_name];
         return constraints_map_[constraints_manager_name];
@@ -358,9 +358,9 @@ SubproblemConstraintsManagerPtr Benders_MICRO_ITERS::GetActiveManager(const std:
 void Benders_MICRO_ITERS::TrackAddedConstraint(const std::string& sub_name,
                                                const std::string& constraint)
 {
-    // CACHE_PROBLEMS==0 keeps the same manager alive for the whole run, so its added rows
+    // NO_CACHE keeps the same manager alive for the whole run, so its added rows
     // already persist on their own; nothing needs tracking for replay there.
-    if (options_.CACHE_PROBLEMS == 0 || !warm_start_)
+    if (options_.CACHE_PROBLEMS == CacheProblems::NO_CACHE || !warm_start_)
     {
         return;
     }
@@ -373,7 +373,7 @@ void Benders_MICRO_ITERS::ReplayPersistedConstraints(const std::string& sub_name
     {
         return;
     }
-    if (options_.CACHE_PROBLEMS == 1)
+    if (options_.CACHE_PROBLEMS == CacheProblems::PER_SUB)
     {
         std::string constraints_manager_name = subproblem_constraint_map_[sub_name];
         for (auto& constraint_name: added_constraints_per_sub_[sub_name])
@@ -381,7 +381,7 @@ void Benders_MICRO_ITERS::ReplayPersistedConstraints(const std::string& sub_name
             constraints_map_[constraints_manager_name]->AddRows(constraint_name);
         }
     }
-    else if (options_.CACHE_PROBLEMS >= 2)
+    else if (options_.CACHE_PROBLEMS == CacheProblems::COMPACT)
     {
         auto ContraintsSolver = constraint_set_loader_->GetSolver();
         for (auto& constraint_name: added_constraints_per_sub_[sub_name])
@@ -460,7 +460,7 @@ void Benders_MICRO_ITERS::OnBendersSubResolutionStart(
   const std::shared_ptr<SubproblemWorker>& sub_worker,
   std::string sub_name)
 {
-    if (options_.CACHE_PROBLEMS == 2)
+    if (options_.CACHE_PROBLEMS == CacheProblems::COMPACT)
     {
         auto constraints_file_name = subproblem_constraint_map_[sub_name];
         auto skeleton_solver = constraint_set_loader_->LoadConstraintSet(constraints_file_name);
@@ -489,7 +489,7 @@ void Benders_MICRO_ITERS::OnBendersSubResolutionStart(
         // and rows temporarily stripped by sharing this skeleton solver come back.
         ReplayPersistedConstraints(sub_name);
     }
-    else if (options_.CACHE_PROBLEMS == 1)
+    else if (options_.CACHE_PROBLEMS == CacheProblems::PER_SUB)
     {
         // In this case we are supposed to have One mps loaded on RAM
         constraints_map_.clear();

--- a/src/cpp/core/include/antares-xpansion/core/CacheProblems.h
+++ b/src/cpp/core/include/antares-xpansion/core/CacheProblems.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <algorithm>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+
+#include "antares-xpansion/xpansion_interfaces/StringManip.h"
+
+enum class CacheProblems
+{
+    NO_CACHE,
+    PER_SUB,
+    COMPACT
+};
+
+inline CacheProblems cacheProblemsFromString(const std::string& str)
+{
+    auto lower_str = StringManip::StringUtils::ToLowercase(str);
+    if (lower_str == "no_cache" || lower_str == "0")
+    {
+        return CacheProblems::NO_CACHE;
+    }
+    if (lower_str == "per_sub" || lower_str == "1")
+    {
+        return CacheProblems::PER_SUB;
+    }
+    if (lower_str == "compact" || lower_str == "2")
+    {
+        return CacheProblems::COMPACT;
+    }
+    throw std::runtime_error("Unknown CacheProblems: " + str);
+}
+
+inline std::ostream& operator<<(std::ostream& stream, const CacheProblems& rhs)
+{
+    switch (rhs)
+    {
+    case CacheProblems::NO_CACHE:
+        stream << "NO_CACHE";
+        break;
+    case CacheProblems::PER_SUB:
+        stream << "PER_SUB";
+        break;
+    case CacheProblems::COMPACT:
+        stream << "COMPACT";
+        break;
+    default:
+        stream << "Unknown";
+    }
+    return stream;
+}

--- a/src/python/antares_xpansion/input_parser.py
+++ b/src/python/antares_xpansion/input_parser.py
@@ -92,9 +92,9 @@ class InputParser:
                                  help="Runs presolve step before Benders methods (Xpress only)")
         self.parser.add_argument("--cache_problems",
                                  dest=LauncherOptionsKeys.cache_problems_key(),
-                                 default=False,
-                                 action='store_true',
-                                 help="Cache problems on disque during benders")
+                                 default="NO_CACHE",
+                                 choices=["NO_CACHE", "PER_SUB", "COMPACT"],
+                                 help="Cache problems mode during benders (NO_CACHE, PER_SUB, COMPACT)")
         self.parser.add_argument("--problem-format",
                                  dest=LauncherOptionsKeys.problem_format_key(),
                                  choices=["mps", "OPTIMIZED"],

--- a/src/python/antares_xpansion/trajectory/args_parser_trajectory.py
+++ b/src/python/antares_xpansion/trajectory/args_parser_trajectory.py
@@ -127,9 +127,9 @@ class TrajectoryArgsParser:
         self.parser.add_argument(
             "--cache_problems",
             dest=TrajectoryLauncherOptionsKeys.cache_problems_key(),
-            default=False,
-            action="store_true",
-            help="Cache problems on disk during benders",
+            default="NO_CACHE",
+            choices=["NO_CACHE", "PER_SUB", "COMPACT"],
+            help="Cache problems mode during benders (NO_CACHE, PER_SUB, COMPACT)",
         )
 
         # Args for the resolution

--- a/src/python/antares_xpansion/trajectory/trajectory_config.py
+++ b/src/python/antares_xpansion/trajectory/trajectory_config.py
@@ -16,7 +16,7 @@ class TrajectoryInputParameters:
     # Solver and problems format
     problems_format: str
     solver: str
-    cache_problems: bool
+    cache_problems: str
     # Relevant for resolution only
     method: str
     n_mpi: int

--- a/src/python/antares_xpansion/xpansionConfig.py
+++ b/src/python/antares_xpansion/xpansionConfig.py
@@ -47,7 +47,7 @@ class InputParameters:
     allow_run_as_root: bool
     memory: bool
     run_presolve: bool
-    cache_problems: bool
+    cache_problems: str
     problem_format: str
 
 
@@ -194,7 +194,7 @@ class XpansionConfigConstants:
         return 0
 
     def cache_problems_default_value(self):
-        return False
+        return "NO_CACHE"
 
     def master_solution_tolerance_default_value(self):
         return 1e-4

--- a/tests/end_to_end/cucumber/features/benders_aggreg_cuts.feature
+++ b/tests/end_to_end/cucumber/features/benders_aggreg_cuts.feature
@@ -28,11 +28,11 @@ Scenario Outline: Benders converges to the same solution across batch and cache 
 
     Examples:
       | cache_level | batch_size | procs |
-      | 0           | 0          | 1     |
-      | 0           | 0          | 5     |
-      | 0           | 5          | 1     |
-      | 0           | 5          | 3     |
-      | 1           | 0          | 1     |
-      | 1           | 0          | 5     |
-      | 1           | 5          | 1     |
-      | 1           | 5          | 3     |
+      | NO_CACHE    | 0          | 1     |
+      | NO_CACHE    | 0          | 5     |
+      | NO_CACHE    | 5          | 1     |
+      | NO_CACHE    | 5          | 3     |
+      | PER_SUB     | 0          | 1     |
+      | PER_SUB     | 0          | 5     |
+      | PER_SUB     | 5          | 1     |
+      | PER_SUB     | 5          | 3     |

--- a/tests/end_to_end/cucumber/features/benders_memory_and_micro_iterations.feature
+++ b/tests/end_to_end/cucumber/features/benders_memory_and_micro_iterations.feature
@@ -21,12 +21,12 @@ Scenario Outline: Benders solves the ieee96 study to the same solution
 
     Examples:
       | study_path                                | cache_level | batch_size | procs |
-      | data_test/ieee96_base                      | 0           | 0          | 1     |
-      | data_test/ieee96_base                      | 0           | 1          | 3     |
-      | data_test/ieee96_base                      | 1           | 0          | 1     |
-      | data_test/ieee96_base                      | 1           | 1          | 3     |
-      | data_test/ieee96_skeleton                   | 2           | 0          | 1     |
-      | data_test/ieee96_skeleton                   | 2           | 1          | 3     |
+      | data_test/ieee96_base                      | NO_CACHE    | 0          | 1     |
+      | data_test/ieee96_base                      | NO_CACHE    | 1          | 3     |
+      | data_test/ieee96_base                      | PER_SUB     | 0          | 1     |
+      | data_test/ieee96_base                      | PER_SUB     | 1          | 3     |
+      | data_test/ieee96_skeleton                   | COMPACT     | 0          | 1     |
+      | data_test/ieee96_skeleton                   | COMPACT     | 1          | 3     |
 
 @fast @short @low_memory
 Scenario Outline: Benders solves the ieee96 study to the same solution with micro-iterations, regardless of warm start
@@ -50,31 +50,31 @@ Scenario Outline: Benders solves the ieee96 study to the same solution with micr
 
     Examples:
       | study_path                                | cache_level | batch_size | procs | warm_start |
-      | data_test/ieee96_micro_it                  | 0           | 0          | 1     | 0          |
-      | data_test/ieee96_micro_it                  | 0           | 0          | 1     | 1          |
-      | data_test/ieee96_micro_it                  | 0           | 1          | 3     | 0          |
-      | data_test/ieee96_micro_it                  | 0           | 1          | 3     | 1          |
-      | data_test/ieee96_micro_it                  | 1           | 0          | 1     | 0          |
-      | data_test/ieee96_micro_it                  | 1           | 0          | 1     | 1          |
-      | data_test/ieee96_micro_it                  | 1           | 1          | 3     | 0          |
-      | data_test/ieee96_micro_it                  | 1           | 1          | 3     | 1          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 0          | 1     | 0          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 0          | 1     | 1          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 1          | 3     | 0          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 1          | 3     | 1          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 0          | 1     | 0          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 0          | 1     | 1          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 1          | 3     | 0          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 1          | 3     | 1          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 0          | 1     | 0          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 0          | 1     | 1          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 1          | 3     | 0          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 1          | 3     | 1          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 0          | 1     | 0          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 0          | 1     | 1          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 1          | 3     | 0          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 1          | 3     | 1          |
 
     # These rows decouple Benders by batch and multiple procs: batch_size=1/procs=1 exercises BendersByBatch on a
     # single process, and batch_size=0/procs=3 exercises plain BendersMpi across 3
     # processes
-      | data_test/ieee96_micro_it                  | 0           | 1          | 1     | 0          |
-      | data_test/ieee96_micro_it                  | 0           | 1          | 1     | 1          |
-      | data_test/ieee96_micro_it                  | 0           | 0          | 3     | 0          |
-      | data_test/ieee96_micro_it                  | 0           | 0          | 3     | 1          |
-      | data_test/ieee96_micro_it                  | 1           | 1          | 1     | 0          |
-      | data_test/ieee96_micro_it                  | 1           | 1          | 1     | 1          |
-      | data_test/ieee96_micro_it                  | 1           | 0          | 3     | 0          |
-      | data_test/ieee96_micro_it                  | 1           | 0          | 3     | 1          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 1          | 1     | 0          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 1          | 1     | 1          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 0          | 3     | 0          |
-      | data_test/ieee96_micro_it_skeleton_study   | 2           | 0          | 3     | 1          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 1          | 1     | 0          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 1          | 1     | 1          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 0          | 3     | 0          |
+      | data_test/ieee96_micro_it                  | NO_CACHE    | 0          | 3     | 1          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 1          | 1     | 0          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 1          | 1     | 1          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 0          | 3     | 0          |
+      | data_test/ieee96_micro_it                  | PER_SUB     | 0          | 3     | 1          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 1          | 1     | 0          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 1          | 1     | 1          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 0          | 3     | 0          |
+      | data_test/ieee96_micro_it_skeleton_study   | COMPACT     | 0          | 3     | 1          |

--- a/tests/end_to_end/cucumber/features/steps/given.py
+++ b/tests/end_to_end/cucumber/features/steps/given.py
@@ -46,7 +46,7 @@ def set_batch_size(context, batch_size):
 def set_cache_problems_level(context, level):
     with open(str(context.tmp_study / "options.json"), "r") as file:
         options_content = json.load(file)
-    options_content["CACHE_PROBLEMS"] = int(level)
+    options_content["CACHE_PROBLEMS"] = level
     with open(str(context.tmp_study / "options.json"), "w") as file:
         json.dump(options_content, file, indent=4)
 


### PR DESCRIPTION
## Summary

This PR replaces the raw `int` type used for the `CACHE_PROBLEMS` option with a proper `enum class CacheProblems { NO_CACHE, PER_SUB, COMPACT }`. The primary motivation is to enhance code readability and maintainability: scattered integer literals (`0`, `1`, `2`) and comparisons like `> 0` or `< 2` throughout the benders codebase made it difficult to understand the intent of each branch at a glance. With named enum values, every switch case and conditional now clearly expresses which caching strategy it targets, making the code self-documenting and reducing the risk of errors when extending or reviewing the logic.

## Changes

- Add `CacheProblems.h` defining the enum class with a case-insensitive `cacheProblemsFromString()` converter (supports both named values and legacy integer strings for backward compatibility) and `operator<<` for stream output
- Wire the new type into the `BENDERS_OPTIONS_MACRO` system (`SimulationOptions.hxx`) and add `Json::Value::as<CacheProblems>()` template specialization (`SimulationOptions.cpp`)
- Update `BendersBaseOptions::CACHE_PROBLEMS` field in `common.h` from `int` to `CacheProblems`
- Replace all integer literals and comparisons in `BendersBase.cpp`, `BendersByBatch.cpp`, `BendersMPI.cpp`, and `Benders_MICRO_ITERS.cpp`

## Test plan

- [x] Verify the project compiles successfully
- [x] Run existing end-to-end tests with `CACHE_PROBLEMS` set to `0`, `1`, and `2` (integer values in options.json) to confirm backward compatibility
- [x] Run existing end-to-end tests with `CACHE_PROBLEMS` set to `"NO_CACHE"`, `"PER_SUB"`, `"COMPACT"` (string values) to confirm new format works

🤖 Generated with [Claude Code](https://claude.com/claude-code)