### PR TITLE
Replacing micro_iterations_config.txt by micro_iterations_config.json

### DIFF
--- a/data_test/ieee96_common/micro_iterations/micro_iterations_config.txt
+++ b/data_test/ieee96_common/micro_iterations/micro_iterations_config.txt
@@ -1,2 +1,0 @@
-plugin_lib_path=plugin_inputs/dummy_micro_iterations_plugin.so
-warm_start=0

--- a/data_test/ieee96_micro_it/micro_iterations_config.json
+++ b/data_test/ieee96_micro_it/micro_iterations_config.json
@@ -1,0 +1,4 @@
+{
+    "plugin_lib_path":"plugin_inputs/dummy_micro_iterations_plugin.so" , 
+    "warm_start":0
+}

--- a/data_test/ieee96_micro_it/micro_iterations_config.txt
+++ b/data_test/ieee96_micro_it/micro_iterations_config.txt
@@ -1,1 +1,0 @@
-../ieee96_common/micro_iterations/micro_iterations_config.txt

--- a/data_test/ieee96_micro_it_skeleton_study/micro_iterations_config.json
+++ b/data_test/ieee96_micro_it_skeleton_study/micro_iterations_config.json
@@ -1,0 +1,4 @@
+{
+    "plugin_lib_path":"plugin_inputs/dummy_micro_iterations_plugin.so" , 
+    "warm_start":0
+}

--- a/data_test/ieee96_micro_it_skeleton_study/micro_iterations_config.txt
+++ b/data_test/ieee96_micro_it_skeleton_study/micro_iterations_config.txt
@@ -1,1 +1,0 @@
-../ieee96_common/micro_iterations/micro_iterations_config.txt

--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -13,6 +13,7 @@
 #include <string_view>
 
 #include <boost/tokenizer.hpp>
+#include <json/reader.h>
 
 #include "iostream"
 
@@ -141,37 +142,32 @@ void Benders_MICRO_ITERS::read_micro_iteration_config_file()
 {
     // Reading the micro iterations configuration file
     std::filesystem::path mirco_iterations_options_path = std::filesystem::path(options_.INPUTROOT)
-                                                          / "micro_iterations_config.txt";
+                                                          / "micro_iterations_config.json";
     std::ifstream micro_iterations_options_stream(mirco_iterations_options_path.string());
 
     if (micro_iterations_options_stream.is_open())
     {
-        std::string line;
-        while (std::getline(micro_iterations_options_stream, line))
+        Json::Value config;
+        Json::CharReaderBuilder reader_builder;
+        std::string errors;
+        if (!Json::parseFromStream(reader_builder, micro_iterations_options_stream, &config, &errors))
         {
-            std::istringstream iss(line);
-            std::string key, value;
+            std::cerr << "Failed to parse JSON config: " << errors << std::endl;
+            exit(EXIT_FAILURE);
+        }
 
-            if (std::getline(iss, key, '=') && std::getline(iss, value))
+        for (const auto& key : config.getMemberNames())
+        {
+            if (key == "warm_start")
             {
-                if (key == "warm_start")
+                if (config[key].asString() == "0")
                 {
-                    if (value == "0")
-                    {
-                        warm_start_ = false;
-                    }
-                }
-                else
-                {
-                    micro_iterations_config_[key] = value;
+                    warm_start_ = false;
                 }
             }
-        }
-        for (auto [key, value]: micro_iterations_config_)
-        {
-            if (key == "plugin_lib_path")
+            else
             {
-                std::string cpp_output_lib_path = micro_iterations_config_["plugin_lib_path"];
+                micro_iterations_config_[key] = config[key].asString();
             }
         }
     }

--- a/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
+++ b/src/cpp/benders/plugins/Benders_MICRO_ITERS.cpp
@@ -8,12 +8,12 @@
 #include <chrono>
 #include <exception>
 #include <fstream>
+#include <json/reader.h>
 #include <sstream>
 #include <stdexcept>
 #include <string_view>
 
 #include <boost/tokenizer.hpp>
-#include <json/reader.h>
 
 #include "iostream"
 
@@ -150,13 +150,16 @@ void Benders_MICRO_ITERS::read_micro_iteration_config_file()
         Json::Value config;
         Json::CharReaderBuilder reader_builder;
         std::string errors;
-        if (!Json::parseFromStream(reader_builder, micro_iterations_options_stream, &config, &errors))
+        if (!Json::parseFromStream(reader_builder,
+                                   micro_iterations_options_stream,
+                                   &config,
+                                   &errors))
         {
             std::cerr << "Failed to parse JSON config: " << errors << std::endl;
             exit(EXIT_FAILURE);
         }
 
-        for (const auto& key : config.getMemberNames())
+        for (const auto& key: config.getMemberNames())
         {
             if (key == "warm_start")
             {

--- a/src/cpp/benders/plugins/CMakeLists.txt
+++ b/src/cpp/benders/plugins/CMakeLists.txt
@@ -9,9 +9,10 @@ target_sources(plugins PRIVATE
 )
 
 target_link_libraries(plugins
-            PUBLIC 
+            PUBLIC
             antaresXpansion::benders_core
             antaresXpansion::logger_lib
+            ${JSONCPP_LIB}
 )
 
 target_include_directories(plugins

--- a/tests/end_to_end/cucumber/features/steps/given.py
+++ b/tests/end_to_end/cucumber/features/steps/given.py
@@ -53,14 +53,11 @@ def set_cache_problems_level(context, level):
 
 @given("the warm start is {value}")
 def set_warm_start(context, value):
-    config_path = context.tmp_study / "micro_iterations_config.txt"
-    match = False
-    with fileinput.FileInput(str(config_path), inplace=True) as file:
-        for line in file:
-            match = match or re.search(r"warm_start\s*=.*", line)
-            print(re.sub(r"warm_start\s*=.*", f"warm_start={value}", line), end="")
-    if not match:
-        with open(config_path, "a") as file:
-            file.write(f"\nwarm_start={value}")
+    config_path = context.tmp_study / "micro_iterations_config.json"
+    with open(str(config_path), "r") as file:
+        config = json.load(file)
+    config["warm_start"] = int(value)
+    with open(str(config_path), "w") as file:
+        json.dump(config, file, indent=4)
 
 


### PR DESCRIPTION
So far, the parameters of the micro iterations mode were handeled by reading a txt file.
However such format is harder to read and to get right so we changed it with a json file 